### PR TITLE
OPHOTRKEH-36: renamed DTOs and their fields

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/api/clerk/ClerkInterpreterController.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/clerk/ClerkInterpreterController.java
@@ -5,8 +5,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import fi.oph.otr.api.dto.clerk.ClerkInterpreterDTO;
 import fi.oph.otr.api.dto.clerk.modify.ClerkInterpreterCreateDTO;
 import fi.oph.otr.api.dto.clerk.modify.ClerkInterpreterUpdateDTO;
-import fi.oph.otr.api.dto.clerk.modify.ClerkLegalInterpreterCreateDTO;
-import fi.oph.otr.api.dto.clerk.modify.ClerkLegalInterpreterUpdateDTO;
+import fi.oph.otr.api.dto.clerk.modify.ClerkQualificationCreateDTO;
+import fi.oph.otr.api.dto.clerk.modify.ClerkQualificationUpdateDTO;
 import fi.oph.otr.service.ClerkInterpreterService;
 import fi.oph.otr.service.LanguageService;
 import fi.oph.otr.service.RegionService;
@@ -93,14 +93,14 @@ public class ClerkInterpreterController {
   @ResponseStatus(HttpStatus.CREATED)
   public ClerkInterpreterDTO createQualification(
     @PathVariable final long interpreterId,
-    @RequestBody @Valid final ClerkLegalInterpreterCreateDTO dto
+    @RequestBody @Valid final ClerkQualificationCreateDTO dto
   ) {
     return clerkInterpreterService.createQualification(interpreterId, dto);
   }
 
   @Operation(tags = TAG_QUALIFICATION, summary = "Update qualification")
   @PutMapping(path = "/qualification", consumes = APPLICATION_JSON_VALUE)
-  public ClerkInterpreterDTO updateQualification(@RequestBody @Valid final ClerkLegalInterpreterUpdateDTO dto) {
+  public ClerkInterpreterDTO updateQualification(@RequestBody @Valid final ClerkQualificationUpdateDTO dto) {
     return clerkInterpreterService.updateQualification(dto);
   }
 

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/InterpreterDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/InterpreterDTO.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.Builder;
 import lombok.NonNull;
 
+@Builder
 public record InterpreterDTO(
   @NonNull String firstName,
   @NonNull String lastName,
@@ -12,9 +13,4 @@ public record InterpreterDTO(
   String otherContactInfo,
   @NonNull List<String> regions,
   @NonNull List<LanguagePairDTO> languages
-) {
-  // Workaround for bug in IntelliJ lombok plugin
-  // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
-  @Builder
-  public InterpreterDTO {}
-}
+) {}

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/InterpreterDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/InterpreterDTO.java
@@ -10,7 +10,7 @@ public record InterpreterDTO(
   String email,
   String phoneNumber,
   String otherContactInfo,
-  @NonNull List<String> areas,
+  @NonNull List<String> regions,
   @NonNull List<LanguagePairDTO> languages
 ) {
   // Workaround for bug in IntelliJ lombok plugin

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/LanguagePairDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/LanguagePairDTO.java
@@ -3,9 +3,5 @@ package fi.oph.otr.api.dto;
 import lombok.Builder;
 import lombok.NonNull;
 
-public record LanguagePairDTO(@NonNull String from, @NonNull String to) {
-  // Workaround for bug in IntelliJ lombok plugin
-  // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
-  @Builder
-  public LanguagePairDTO {}
-}
+@Builder
+public record LanguagePairDTO(@NonNull String from, @NonNull String to) {}

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
@@ -25,8 +25,8 @@ public record ClerkInterpreterDTO(
   String postalCode,
   String town,
   String extraInformation,
-  @NonNull List<String> areas,
-  @NonNull @NotEmpty List<ClerkLegalInterpreterDTO> legalInterpreters
+  @NonNull List<String> regions,
+  @NonNull @NotEmpty List<ClerkQualificationDTO> qualifications
 )
   implements ClerkInterpreterDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
+@Builder
 public record ClerkInterpreterDTO(
   @NonNull @NotNull Long id,
   @NonNull @NotNull Integer version,
@@ -28,9 +29,4 @@ public record ClerkInterpreterDTO(
   @NonNull List<String> regions,
   @NonNull @NotEmpty List<ClerkQualificationDTO> qualifications
 )
-  implements ClerkInterpreterDTOCommonFields {
-  // Workaround for bug in IntelliJ lombok plugin
-  // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
-  @Builder
-  public ClerkInterpreterDTO {}
-}
+  implements ClerkInterpreterDTOCommonFields {}

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTOCommonFields.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTOCommonFields.java
@@ -31,5 +31,5 @@ public interface ClerkInterpreterDTOCommonFields {
 
   String extraInformation();
 
-  List<String> areas();
+  List<String> regions();
 }

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkLanguagePairDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkLanguagePairDTO.java
@@ -6,14 +6,10 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
+@Builder
 public record ClerkLanguagePairDTO(
   @NonNull @NotBlank String from,
   @NonNull @NotBlank String to,
   @NonNull @NotNull LocalDate beginDate,
   @NonNull @NotNull LocalDate endDate
-) {
-  // Workaround for bug in IntelliJ lombok plugin
-  // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
-  @Builder
-  public ClerkLanguagePairDTO {}
-}
+) {}

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkQualificationDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkQualificationDTO.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
+@Builder
 public record ClerkQualificationDTO(
   @NonNull @NotNull Long id,
   @NonNull @NotNull Integer version,
@@ -15,9 +16,4 @@ public record ClerkQualificationDTO(
   @NonNull @NotNull Boolean permissionToPublish,
   @NonNull @NotEmpty List<ClerkLanguagePairDTO> languages
 )
-  implements ClerkQualificationDTOCommonFields {
-  // Workaround for bug in IntelliJ lombok plugin
-  // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
-  @Builder
-  public ClerkQualificationDTO {}
-}
+  implements ClerkQualificationDTOCommonFields {}

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkQualificationDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkQualificationDTO.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
-public record ClerkLegalInterpreterDTO(
+public record ClerkQualificationDTO(
   @NonNull @NotNull Long id,
   @NonNull @NotNull Integer version,
   @NonNull @NotNull Boolean deleted,
@@ -15,9 +15,9 @@ public record ClerkLegalInterpreterDTO(
   @NonNull @NotNull Boolean permissionToPublish,
   @NonNull @NotEmpty List<ClerkLanguagePairDTO> languages
 )
-  implements ClerkLegalInterpreterDTOCommonFields {
+  implements ClerkQualificationDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin
   // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
   @Builder
-  public ClerkLegalInterpreterDTO {}
+  public ClerkQualificationDTO {}
 }

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkQualificationDTOCommonFields.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkQualificationDTOCommonFields.java
@@ -3,7 +3,7 @@ package fi.oph.otr.api.dto.clerk;
 import fi.oph.otr.model.QualificationExaminationType;
 import java.util.List;
 
-public interface ClerkLegalInterpreterDTOCommonFields {
+public interface ClerkQualificationDTOCommonFields {
   QualificationExaminationType examinationType();
 
   Boolean permissionToPublish();

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterCreateDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterCreateDTO.java
@@ -24,8 +24,8 @@ public record ClerkInterpreterCreateDTO(
   String postalCode,
   String town,
   String extraInformation,
-  @NonNull List<String> areas,
-  @NonNull @NotEmpty @Valid List<ClerkLegalInterpreterCreateDTO> legalInterpreters
+  @NonNull List<String> regions,
+  @NonNull @NotEmpty @Valid List<ClerkQualificationCreateDTO> qualifications
 )
   implements ClerkInterpreterDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterCreateDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterCreateDTO.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
+@Builder
 public record ClerkInterpreterCreateDTO(
   @NonNull @NotBlank String identityNumber,
   @NonNull @NotBlank String firstName,
@@ -27,9 +28,4 @@ public record ClerkInterpreterCreateDTO(
   @NonNull List<String> regions,
   @NonNull @NotEmpty @Valid List<ClerkQualificationCreateDTO> qualifications
 )
-  implements ClerkInterpreterDTOCommonFields {
-  // Workaround for bug in IntelliJ lombok plugin
-  // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
-  @Builder
-  public ClerkInterpreterCreateDTO {}
-}
+  implements ClerkInterpreterDTOCommonFields {}

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterUpdateDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterUpdateDTO.java
@@ -24,7 +24,7 @@ public record ClerkInterpreterUpdateDTO(
   String postalCode,
   String town,
   String extraInformation,
-  @NonNull List<String> areas
+  @NonNull List<String> regions
 )
   implements ClerkInterpreterDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterUpdateDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterUpdateDTO.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
+@Builder
 public record ClerkInterpreterUpdateDTO(
   @NonNull @NotNull Long id,
   @NonNull @NotNull Integer version,
@@ -26,9 +27,4 @@ public record ClerkInterpreterUpdateDTO(
   String extraInformation,
   @NonNull List<String> regions
 )
-  implements ClerkInterpreterDTOCommonFields {
-  // Workaround for bug in IntelliJ lombok plugin
-  // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
-  @Builder
-  public ClerkInterpreterUpdateDTO {}
-}
+  implements ClerkInterpreterDTOCommonFields {}

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkQualificationCreateDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkQualificationCreateDTO.java
@@ -10,14 +10,10 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
+@Builder
 public record ClerkQualificationCreateDTO(
   @NonNull @NotNull QualificationExaminationType examinationType,
   @NonNull @NotNull Boolean permissionToPublish,
   @NonNull @NotEmpty @Valid List<ClerkLanguagePairDTO> languages
 )
-  implements ClerkQualificationDTOCommonFields {
-  // Workaround for bug in IntelliJ lombok plugin
-  // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
-  @Builder
-  public ClerkQualificationCreateDTO {}
-}
+  implements ClerkQualificationDTOCommonFields {}

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkQualificationCreateDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkQualificationCreateDTO.java
@@ -1,7 +1,7 @@
 package fi.oph.otr.api.dto.clerk.modify;
 
 import fi.oph.otr.api.dto.clerk.ClerkLanguagePairDTO;
-import fi.oph.otr.api.dto.clerk.ClerkLegalInterpreterDTOCommonFields;
+import fi.oph.otr.api.dto.clerk.ClerkQualificationDTOCommonFields;
 import fi.oph.otr.model.QualificationExaminationType;
 import java.util.List;
 import javax.validation.Valid;
@@ -10,14 +10,14 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
-public record ClerkLegalInterpreterCreateDTO(
+public record ClerkQualificationCreateDTO(
   @NonNull @NotNull QualificationExaminationType examinationType,
   @NonNull @NotNull Boolean permissionToPublish,
   @NonNull @NotEmpty @Valid List<ClerkLanguagePairDTO> languages
 )
-  implements ClerkLegalInterpreterDTOCommonFields {
+  implements ClerkQualificationDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin
   // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
   @Builder
-  public ClerkLegalInterpreterCreateDTO {}
+  public ClerkQualificationCreateDTO {}
 }

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkQualificationUpdateDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkQualificationUpdateDTO.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
+@Builder
 public record ClerkQualificationUpdateDTO(
   @NonNull @NotNull Long id,
   @NonNull @NotNull Integer version,
@@ -17,9 +18,4 @@ public record ClerkQualificationUpdateDTO(
   @NonNull @NotNull Boolean permissionToPublish,
   @NonNull @NotEmpty @Valid List<ClerkLanguagePairDTO> languages
 )
-  implements ClerkQualificationDTOCommonFields {
-  // Workaround for bug in IntelliJ lombok plugin
-  // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
-  @Builder
-  public ClerkQualificationUpdateDTO {}
-}
+  implements ClerkQualificationDTOCommonFields {}

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkQualificationUpdateDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkQualificationUpdateDTO.java
@@ -1,7 +1,7 @@
 package fi.oph.otr.api.dto.clerk.modify;
 
 import fi.oph.otr.api.dto.clerk.ClerkLanguagePairDTO;
-import fi.oph.otr.api.dto.clerk.ClerkLegalInterpreterDTOCommonFields;
+import fi.oph.otr.api.dto.clerk.ClerkQualificationDTOCommonFields;
 import fi.oph.otr.model.QualificationExaminationType;
 import java.util.List;
 import javax.validation.Valid;
@@ -10,16 +10,16 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
-public record ClerkLegalInterpreterUpdateDTO(
+public record ClerkQualificationUpdateDTO(
   @NonNull @NotNull Long id,
   @NonNull @NotNull Integer version,
   @NonNull @NotNull QualificationExaminationType examinationType,
   @NonNull @NotNull Boolean permissionToPublish,
   @NonNull @NotEmpty @Valid List<ClerkLanguagePairDTO> languages
 )
-  implements ClerkLegalInterpreterDTOCommonFields {
+  implements ClerkQualificationDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin
   // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
   @Builder
-  public ClerkLegalInterpreterUpdateDTO {}
+  public ClerkQualificationUpdateDTO {}
 }

--- a/backend/otr/src/main/java/fi/oph/otr/service/PublicInterpreterService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/PublicInterpreterService.java
@@ -82,7 +82,7 @@ public class PublicInterpreterService {
       .otherContactInfo(
         interpreter.isPermissionToPublishOtherContactInfo() ? interpreter.getOtherContactInformation() : null
       )
-      .areas(regions)
+      .regions(regions)
       .languages(languagePairs)
       .build();
   }

--- a/backend/otr/src/main/java/fi/oph/otr/util/localisation/Localisation.java
+++ b/backend/otr/src/main/java/fi/oph/otr/util/localisation/Localisation.java
@@ -3,9 +3,5 @@ package fi.oph.otr.util.localisation;
 import java.util.Optional;
 import lombok.Builder;
 
-public record Localisation(Optional<String> fi, Optional<String> sv, Optional<String> en) {
-  // Workaround for bug in IntelliJ lombok plugin
-  // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764
-  @Builder
-  public Localisation {}
-}
+@Builder
+public record Localisation(Optional<String> fi, Optional<String> sv, Optional<String> en) {}

--- a/backend/otr/src/test/java/fi/oph/otr/service/ClerkInterpreterServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/service/ClerkInterpreterServiceTest.java
@@ -9,11 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import fi.oph.otr.Factory;
 import fi.oph.otr.api.dto.clerk.ClerkInterpreterDTO;
 import fi.oph.otr.api.dto.clerk.ClerkLanguagePairDTO;
-import fi.oph.otr.api.dto.clerk.ClerkLegalInterpreterDTO;
+import fi.oph.otr.api.dto.clerk.ClerkQualificationDTO;
 import fi.oph.otr.api.dto.clerk.modify.ClerkInterpreterCreateDTO;
 import fi.oph.otr.api.dto.clerk.modify.ClerkInterpreterUpdateDTO;
-import fi.oph.otr.api.dto.clerk.modify.ClerkLegalInterpreterCreateDTO;
-import fi.oph.otr.api.dto.clerk.modify.ClerkLegalInterpreterUpdateDTO;
+import fi.oph.otr.api.dto.clerk.modify.ClerkQualificationCreateDTO;
+import fi.oph.otr.api.dto.clerk.modify.ClerkQualificationUpdateDTO;
 import fi.oph.otr.model.Interpreter;
 import fi.oph.otr.model.LanguagePair;
 import fi.oph.otr.model.Qualification;
@@ -160,10 +160,10 @@ class ClerkInterpreterServiceTest {
       .postalCode("00100")
       .town("Helsinki")
       .extraInformation("extra")
-      .areas(List.of("01", "02"))
-      .legalInterpreters(
+      .regions(List.of("01", "02"))
+      .qualifications(
         List.of(
-          ClerkLegalInterpreterCreateDTO
+          ClerkQualificationCreateDTO
             .builder()
             .examinationType(QualificationExaminationType.LEGAL_INTERPRETER_EXAM)
             .permissionToPublish(true)
@@ -188,10 +188,10 @@ class ClerkInterpreterServiceTest {
     assertEquals(createDTO.otherContactInfo(), interpreterDTO.otherContactInfo());
     assertFalse(interpreterDTO.permissionToPublishOtherContactInfo());
     assertEquals(createDTO.extraInformation(), interpreterDTO.extraInformation());
-    assertEquals(Set.of("01", "02"), Set.copyOf(interpreterDTO.areas()));
-    assertEquals(1, interpreterDTO.legalInterpreters().size());
+    assertEquals(Set.of("01", "02"), Set.copyOf(interpreterDTO.regions()));
+    assertEquals(1, interpreterDTO.qualifications().size());
 
-    final ClerkLegalInterpreterDTO qualificationDTO = interpreterDTO.legalInterpreters().get(0);
+    final ClerkQualificationDTO qualificationDTO = interpreterDTO.qualifications().get(0);
     assertEquals(0, qualificationDTO.version());
     assertFalse(qualificationDTO.deleted());
     assertEquals(QualificationExaminationType.LEGAL_INTERPRETER_EXAM, qualificationDTO.examinationType());
@@ -205,7 +205,7 @@ class ClerkInterpreterServiceTest {
   }
 
   private <T> Set<T> collectFromLanguages(
-    final ClerkLegalInterpreterDTO dto,
+    final ClerkQualificationDTO dto,
     final Function<ClerkLanguagePairDTO, T> getter
   ) {
     return dto.languages().stream().map(getter).collect(Collectors.toSet());
@@ -233,10 +233,10 @@ class ClerkInterpreterServiceTest {
       .postalCode("00100")
       .town("Helsinki")
       .extraInformation("extra")
-      .areas(List.of("01", "This region does not exist"))
-      .legalInterpreters(
+      .regions(List.of("01", "This region does not exist"))
+      .qualifications(
         List.of(
-          ClerkLegalInterpreterCreateDTO
+          ClerkQualificationCreateDTO
             .builder()
             .examinationType(QualificationExaminationType.LEGAL_INTERPRETER_EXAM)
             .permissionToPublish(true)
@@ -266,7 +266,7 @@ class ClerkInterpreterServiceTest {
 
     final ClerkInterpreterDTO interpreterDTO = clerkInterpreterService.getInterpreter(id);
     assertEquals(id, interpreterDTO.id());
-    assertEquals(Set.of("01", "02"), Set.copyOf(interpreterDTO.areas()));
+    assertEquals(Set.of("01", "02"), Set.copyOf(interpreterDTO.regions()));
   }
 
   @Test
@@ -289,7 +289,7 @@ class ClerkInterpreterServiceTest {
       .otherContactInfo("interpreter@test.invalid")
       .permissionToPublishOtherContactInfo(true)
       .extraInformation("extra")
-      .areas(List.of("01"))
+      .regions(List.of("01"))
       .build();
 
     final ClerkInterpreterDTO updated = clerkInterpreterService.updateInterpreter(updateDto);
@@ -302,7 +302,7 @@ class ClerkInterpreterServiceTest {
     assertEquals(updateDto.otherContactInfo(), updated.otherContactInfo());
     assertTrue(updated.permissionToPublishOtherContactInfo());
     assertEquals(updateDto.extraInformation(), updated.extraInformation());
-    assertEquals(List.of("01"), updated.areas());
+    assertEquals(List.of("01"), updated.regions());
   }
 
   @Test
@@ -325,7 +325,7 @@ class ClerkInterpreterServiceTest {
       .otherContactInfo("interpreter@test.invalid")
       .permissionToPublishOtherContactInfo(true)
       .extraInformation("extra")
-      .areas(List.of("This region code does not exist"))
+      .regions(List.of("This region code does not exist"))
       .build();
 
     final APIException ex = assertThrows(
@@ -381,7 +381,7 @@ class ClerkInterpreterServiceTest {
 
     final long interpreterId = interpreter2.getId();
 
-    final ClerkLegalInterpreterCreateDTO createDTO = ClerkLegalInterpreterCreateDTO
+    final ClerkQualificationCreateDTO createDTO = ClerkQualificationCreateDTO
       .builder()
       .examinationType(QualificationExaminationType.OTHER)
       .permissionToPublish(false)
@@ -394,10 +394,10 @@ class ClerkInterpreterServiceTest {
       .build();
 
     final ClerkInterpreterDTO interpreterDTO = clerkInterpreterService.createQualification(interpreterId, createDTO);
-    assertEquals(2, interpreterDTO.legalInterpreters().size());
+    assertEquals(2, interpreterDTO.qualifications().size());
 
-    final ClerkLegalInterpreterDTO qualificationDTO = interpreterDTO
-      .legalInterpreters()
+    final ClerkQualificationDTO qualificationDTO = interpreterDTO
+      .qualifications()
       .stream()
       .filter(dto -> dto.examinationType() == QualificationExaminationType.OTHER && !dto.permissionToPublish())
       .toList()
@@ -437,7 +437,7 @@ class ClerkInterpreterServiceTest {
 
     final long interpreterId = interpreter2.getId();
 
-    final ClerkLegalInterpreterCreateDTO dto = ClerkLegalInterpreterCreateDTO
+    final ClerkQualificationCreateDTO dto = ClerkQualificationCreateDTO
       .builder()
       .examinationType(QualificationExaminationType.LEGAL_INTERPRETER_EXAM)
       .permissionToPublish(true)
@@ -476,7 +476,7 @@ class ClerkInterpreterServiceTest {
     entityManager.persist(qualification);
     entityManager.persist(languagePair);
 
-    final ClerkLegalInterpreterUpdateDTO updateDTO = ClerkLegalInterpreterUpdateDTO
+    final ClerkQualificationUpdateDTO updateDTO = ClerkQualificationUpdateDTO
       .builder()
       .id(qualification.getId())
       .version(qualification.getVersion())
@@ -492,8 +492,8 @@ class ClerkInterpreterServiceTest {
 
     final ClerkInterpreterDTO dto = clerkInterpreterService.updateQualification(updateDTO);
 
-    assertEquals(1, dto.legalInterpreters().size());
-    final ClerkLegalInterpreterDTO qualificationDTO = dto.legalInterpreters().get(0);
+    assertEquals(1, dto.qualifications().size());
+    final ClerkQualificationDTO qualificationDTO = dto.qualifications().get(0);
 
     assertEquals(updateDTO.version() + 1, qualificationDTO.version());
     assertFalse(qualificationDTO.deleted());
@@ -521,7 +521,7 @@ class ClerkInterpreterServiceTest {
     entityManager.persist(qualification);
     entityManager.persist(languagePair);
 
-    final ClerkLegalInterpreterUpdateDTO updateDTO = ClerkLegalInterpreterUpdateDTO
+    final ClerkQualificationUpdateDTO updateDTO = ClerkQualificationUpdateDTO
       .builder()
       .id(qualification.getId())
       .version(qualification.getVersion())
@@ -562,12 +562,12 @@ class ClerkInterpreterServiceTest {
 
     qualificationRepository.findAll().forEach(q -> assertEquals(Objects.equals(idToDelete, q.getId()), q.isDeleted()));
 
-    dto.legalInterpreters().forEach(q -> assertEquals(Objects.equals(idToDelete, q.id()), q.deleted()));
+    dto.qualifications().forEach(q -> assertEquals(Objects.equals(idToDelete, q.id()), q.deleted()));
 
     clerkInterpreterService
       .list()
       .stream()
-      .flatMap(i -> i.legalInterpreters().stream())
+      .flatMap(i -> i.qualifications().stream())
       .forEach(q -> assertEquals(Objects.equals(idToDelete, q.id()), q.deleted()));
   }
 }

--- a/backend/otr/src/test/java/fi/oph/otr/service/PublicInterpreterServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/service/PublicInterpreterServiceTest.java
@@ -101,7 +101,7 @@ class PublicInterpreterServiceTest {
     assertNull(publishedInterpreter1.email());
     assertNotNull(publishedInterpreter1.phoneNumber());
     assertEquals(interpreter1.getOtherContactInformation(), publishedInterpreter1.otherContactInfo());
-    assertEquals(Set.of(), Set.copyOf(publishedInterpreter1.areas()));
+    assertEquals(Set.of(), Set.copyOf(publishedInterpreter1.regions()));
 
     assertEquals(2, publishedInterpreter1.languages().size());
     assertLanguagePair(languagePair11, publishedInterpreter1.languages().get(0));
@@ -111,7 +111,7 @@ class PublicInterpreterServiceTest {
     assertNotNull(publishedInterpreter2.email());
     assertNull(publishedInterpreter2.phoneNumber());
     assertNull(publishedInterpreter2.otherContactInfo());
-    assertEquals(Set.of("01", "02"), Set.copyOf(publishedInterpreter2.areas()));
+    assertEquals(Set.of("01", "02"), Set.copyOf(publishedInterpreter2.regions()));
 
     assertEquals(1, publishedInterpreter2.languages().size());
     assertLanguagePair(languagePair21, publishedInterpreter2.languages().get(0));

--- a/frontend/packages/otr/package.json
+++ b/frontend/packages/otr/package.json
@@ -21,6 +21,6 @@
     "otr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.4"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.8"
   }
 }

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -75,7 +75,8 @@
         }
       },
       "publicInterpreterListing": {
-        "rowsPerPageLabel": "Riviä per sivu"
+        "rowsPerPageLabel": "Riviä per sivu",
+        "wholeFinland": "Koko Suomi"
       },
       "table": {
         "pagination": {

--- a/frontend/packages/otr/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
+++ b/frontend/packages/otr/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
@@ -50,7 +50,7 @@ import { NotifierUtils } from 'utils/notifier';
 
 const langsFrom = ['FI', 'SV'];
 
-const areas = [
+const regions = [
   'Ahvenanmaa',
   'Etelä-Karjala',
   'Etelä-Pohjanmaa',
@@ -90,7 +90,7 @@ export const PublicTranslatorFilters = ({
     fromLang: '',
     toLang: '',
     name: '',
-    area: '',
+    region: '',
     errors: [],
   };
   const [filters, setFilters] = useState(defaultFiltersState);
@@ -99,7 +99,7 @@ export const PublicTranslatorFilters = ({
     fromLang: null,
     toLang: null,
     name: '',
-    area: null,
+    region: null,
   };
   const debounce = useDebounce(300);
 
@@ -328,14 +328,14 @@ export const PublicTranslatorFilters = ({
           />
         </div>
         <div className="public-translator-filters__filter">
-          <H3> {t('town.title')}</H3>
+          <H3>{t('town.title')}</H3>
           <ComboBox
             data-testid="public-translator-filters__town-combobox"
-            {...getComboBoxAttributes(SearchFilter.Area)}
+            {...getComboBoxAttributes(SearchFilter.Region)}
             placeholder={t('town.placeholder')}
             label={t('town.placeholder')}
             id="filters-town"
-            values={areas.map(valueAsOption)}
+            values={regions.map(valueAsOption)}
             onKeyUp={handleKeyUp}
           />
         </div>

--- a/frontend/packages/otr/src/components/publicTranslator/listing/PublicTranslatorListingRow.tsx
+++ b/frontend/packages/otr/src/components/publicTranslator/listing/PublicTranslatorListingRow.tsx
@@ -39,7 +39,7 @@ export const PublicTranslatorListingRow = ({
   const selected = filteredSelectedIds.includes(translator.id);
 
   const { fromLang, toLang } = filters;
-  const { firstName, lastName, languages, areas } = translator;
+  const { firstName, lastName, languages, regions } = translator;
 
   const { isPhone } = useWindowProperties();
   const translateLanguage = useKoodistoLanguagesTranslation();
@@ -74,12 +74,12 @@ export const PublicTranslatorListingRow = ({
     }
   };
 
-  const getAreasDescription = (areas: Array<string>) => {
-    if (areas.length > 0) {
-      return areas.join(', ');
+  const getRegionsDescription = (regions: Array<string>) => {
+    if (regions.length > 0) {
+      return regions.join(', ');
     }
 
-    return '-';
+    return t('component.publicInterpreterListing.wholeFinland');
   };
 
   const renderPhoneTableCells = () => (
@@ -100,7 +100,7 @@ export const PublicTranslatorListingRow = ({
             </div>
             <div>
               <H3>{t('pages.translator.town')}</H3>
-              <Text>{getAreasDescription(areas)}</Text>
+              <Text>{getRegionsDescription(regions)}</Text>
             </div>
           </div>
           <Checkbox
@@ -131,7 +131,7 @@ export const PublicTranslatorListingRow = ({
         ))}
       </TableCell>
       <TableCell>
-        <Text>{getAreasDescription(areas)}</Text>
+        <Text>{getRegionsDescription(regions)}</Text>
       </TableCell>
     </>
   );

--- a/frontend/packages/otr/src/enums/app.ts
+++ b/frontend/packages/otr/src/enums/app.ts
@@ -12,7 +12,7 @@ export enum SearchFilter {
   FromLang = 'fromLang',
   ToLang = 'toLang',
   Name = 'name',
-  Area = 'area',
+  Region = 'region',
 }
 
 export enum PublicUIViews {

--- a/frontend/packages/otr/src/interfaces/publicTranslator.ts
+++ b/frontend/packages/otr/src/interfaces/publicTranslator.ts
@@ -12,7 +12,7 @@ export interface PublicTranslator extends WithId {
   email?: string;
   phoneNumber?: string;
   otherContactInfo?: string;
-  areas: Array<string>;
+  regions: Array<string>;
   languages: Array<LanguagePair>;
 }
 
@@ -20,7 +20,7 @@ export interface PublicTranslatorFilter {
   fromLang: string;
   toLang: string;
   name: string;
-  area: string;
+  region: string;
   errors: Array<SearchFilter>;
 }
 
@@ -28,7 +28,7 @@ export interface PublicTranslatorFilterValues {
   fromLang: AutocompleteValue;
   toLang: AutocompleteValue;
   name: string;
-  area: AutocompleteValue;
+  region: AutocompleteValue;
 }
 
 export interface PublicTranslatorResponse {

--- a/frontend/packages/otr/src/redux/reducers/publicTranslator.ts
+++ b/frontend/packages/otr/src/redux/reducers/publicTranslator.ts
@@ -29,7 +29,7 @@ const defaultState = {
     fromLang: '',
     toLang: '',
     name: '',
-    area: '',
+    region: '',
   },
 };
 

--- a/frontend/packages/otr/src/redux/selectors/publicTranslator.ts
+++ b/frontend/packages/otr/src/redux/selectors/publicTranslator.ts
@@ -58,8 +58,8 @@ export const filterPublicTranslators = (
   if (isNotBlank(filters.name)) {
     filteredData = filteredData.filter((t) => filterByName(t, filters));
   }
-  if (isNotBlank(filters.area)) {
-    filteredData = filteredData.filter((t) => filterByArea(t, filters));
+  if (isNotBlank(filters.region)) {
+    filteredData = filteredData.filter((t) => filterByRegion(t, filters));
   }
 
   return filteredData;
@@ -91,11 +91,11 @@ const filterByName = (
   return isNameIncluded;
 };
 
-const filterByArea = (
+const filterByRegion = (
   publicTranslator: PublicTranslator,
   filters: PublicTranslatorFilter
 ) => {
-  return publicTranslator.areas
-    .map((area) => area.toLowerCase())
-    .includes(filters.area.toLowerCase());
+  return publicTranslator.regions
+    .map((r) => r.toLowerCase())
+    .includes(filters.region.toLowerCase());
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2290,7 +2290,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.otr@workspace:packages/otr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.4"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.8"
   languageName: unknown
   linkType: soft
 
@@ -10503,13 +10503,6 @@ __metadata:
   dependencies:
     kind-of: ^6.0.2
   checksum: 39b3dd9630a774aba288a680e7d2901f5c0eae7b8387fc5c8ea559918b29b3da144b7bdb990d7ccd9e11be05508ac9e459ce51d01fd65e583282f6ffafcba2e7
-  languageName: node
-  linkType: hard
-
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.4":
-  version: 1.0.4
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.0.4::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.0.4%2F24a1541c4e758293020d0b8e3ab702f4d8ca5b64cc6d4a033729d53c20ac8e7c"
-  checksum: 0bd262cf32aef16dd67e24672cb969573ac925c707f58bfb1dd23eb17499a7e7f3bc9cc7541cf420c6179ffe16d5caa34db2580887b96d6c064b3e47d29ee55a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
DTO:t ja kentät uudelleennimetty sekä backendin päässä oheisen dokkarin mukaisesti: https://wiki.eduuni.fi/pages/viewpage.action?pageId=278341853

Frontendiin koskin sen verran, että "areas" uudelleennimetty olemaan "regions". UI:n pitäisi myös näyttää teksti "Koko Suomi" tulkille toiminta-alueena, jos alueiden/maakuntien lista on tyhjä.