### PR TITLE
Shared(Frontend): new I18nNamespace enums

### DIFF
--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.0.13] - 2022-05-17
+
+## Added
+
+- KoodistoRegions and Privacy I18n namespaces
+
 ## [1.0.12] - 2022-05-16
 
 ## Changed

--- a/frontend/packages/shared/src/enums/common.ts
+++ b/frontend/packages/shared/src/enums/common.ts
@@ -63,10 +63,12 @@ export enum HTTPStatusCode {
 }
 
 export enum I18nNamespace {
-  Common = 'common',
-  Translation = 'translation',
-  KoodistoLanguages = 'koodistoLanguages',
   Accessibility = 'accessibility',
+  Common = 'common',
+  KoodistoLanguages = 'koodistoLanguages',
+  KoodistoRegions = 'koodistoRegions',
+  Privacy = 'privacy',
+  Translation = 'translation',
 }
 
 export enum KeyboardKey {

--- a/frontend/packages/shared/src/hooks/useWindowProperties/useWindowProperties.ts
+++ b/frontend/packages/shared/src/hooks/useWindowProperties/useWindowProperties.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Screenwidth } from 'shared/enums';
+
+import { Screenwidth } from '../../enums/common';
 
 const getProperties = () => {
   const { innerWidth: width, innerHeight: height } = window;


### PR DESCRIPTION
Privacy tarkoitus ottaa käyttöön OPHAKTKEH-347:ssä tietosuojaan liittyvien käännösten lataamiseen. Lisätty myös jo tässä vaiheessa OTR:n tarvitsema erillinen avain koodiston maakuntia varten. Jos myöhemmin halutaan, voisi koodiston kielet ja maakunnat olla OTR:ssä samassa jsonissakin, mutta skriptit noiden hakemiseksi eivät tuota ainakaan toistaiseksi tue.