### PR TITLE
SHARED(Frontend): Fix autocomplete label rendering

### DIFF
--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.0.14] - 2022-05-19
+
+## Fixed
+
+- Autocomplete label rendering
+
 ## [1.0.13] - 2022-05-17
 
 ## Added

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/components/ComboBox/ComboBox.tsx
+++ b/frontend/packages/shared/src/components/ComboBox/ComboBox.tsx
@@ -32,10 +32,6 @@ export const sortOptionsByLabels = (options: Array<ComboBoxOption>) => {
   return options.sort(compareOptionLabels);
 };
 
-const autocompleteValueToString = (option: AutocompleteValue): string => {
-  return option?.label || '';
-};
-
 const isOptionEqualToValue = (
   option: AutocompleteValue,
   value: AutocompleteValue
@@ -62,12 +58,18 @@ export const ComboBox = ({
   showError,
   ...rest
 }: ComboBoxProps & AutoCompleteComboBox) => {
+  const getOptionLabel = (option: AutocompleteValue): string => {
+    const [activeOption] = values.filter((v) => v.value === option?.value);
+
+    return activeOption ? activeOption.label : '';
+  };
+
   return (
     <FormControl fullWidth error={showError}>
       <Autocomplete
         disablePortal
         {...rest}
-        getOptionLabel={autocompleteValueToString}
+        getOptionLabel={getOptionLabel}
         isOptionEqualToValue={isOptionEqualToValue}
         options={values}
         renderInput={(params) => (


### PR DESCRIPTION
Autocomplete-komponentin valitun optionin labeli ei vaihtunut kieltä vaihtaessa. Tämä korjaa sen.
 