### PR TITLE
AKT(Backend): OPHAKTKEH-357 päivitetyt sähköpostipohjat

### DIFF
--- a/backend/akt/src/main/java/fi/oph/akt/config/AppConfig.java
+++ b/backend/akt/src/main/java/fi/oph/akt/config/AppConfig.java
@@ -31,7 +31,11 @@ public class AppConfig {
   public EmailSender emailSender(@Value("${akt.email.ryhmasahkoposti-service-url}") String emailServiceUrl) {
     LOG.info("emailServiceUrl:{}", emailServiceUrl);
     final WebClient webClient = webClientBuilderWithCallerId().baseUrl(emailServiceUrl).build();
-    return new EmailSenderViestintapalvelu(webClient);
+    return new EmailSenderViestintapalvelu(
+      webClient,
+      ConfigEnums.SERVICENAME.value(),
+      ConfigEnums.EMAIL_SENDER_NAME.value()
+    );
   }
 
   @Bean
@@ -46,6 +50,6 @@ public class AppConfig {
   }
 
   private static WebClient.Builder webClientBuilderWithCallerId() {
-    return WebClient.builder().defaultHeader("Caller-Id", "1.2.246.562.10.00000000001.akt");
+    return WebClient.builder().defaultHeader("Caller-Id", ConfigEnums.CALLER_ID.value());
   }
 }

--- a/backend/akt/src/main/java/fi/oph/akt/config/AuditConfiguration.java
+++ b/backend/akt/src/main/java/fi/oph/akt/config/AuditConfiguration.java
@@ -11,6 +11,6 @@ public class AuditConfiguration {
 
   @Bean
   public Audit audit() {
-    return new Audit(new LoggerImpl(), "akt", ApplicationType.VIRKAILIJA);
+    return new Audit(new LoggerImpl(), ConfigEnums.SERVICENAME.value(), ApplicationType.VIRKAILIJA);
   }
 }

--- a/backend/akt/src/main/java/fi/oph/akt/config/ConfigEnums.java
+++ b/backend/akt/src/main/java/fi/oph/akt/config/ConfigEnums.java
@@ -2,6 +2,7 @@ package fi.oph.akt.config;
 
 public enum ConfigEnums {
   CALLER_ID("1.2.246.562.10.00000000001.akt"),
+  EMAIL_SENDER_NAME("AKR"),
   SERVICENAME("akt");
 
   private final String value;

--- a/backend/akt/src/main/java/fi/oph/akt/service/ContactRequestService.java
+++ b/backend/akt/src/main/java/fi/oph/akt/service/ContactRequestService.java
@@ -135,7 +135,8 @@ public class ContactRequestService {
       getMessageLines(contactRequestDTO)
     );
 
-    final String subject = "Yhteydenotto kääntäjärekisteristä";
+    final String subject =
+      "Yhteydenotto auktorisoitujen kääntäjien rekisteristä | Kontaktförfrågan från registret över auktoriserade translatorer";
     final String body = templateRenderer.renderContactRequestTranslatorEmailBody(templateParams);
 
     translators.forEach(translator -> {
@@ -169,7 +170,7 @@ public class ContactRequestService {
       getMessageLines(contactRequestDTO)
     );
 
-    final String subject = "Lähettämäsi yhteydenottopyyntö";
+    final String subject = "Lähettämäsi yhteydenottopyyntö | Din kontaktförfrågan | Request for contact";
     final String body = templateRenderer.renderContactRequestRequesterEmailBody(templateParams);
 
     createEmail(requesterName, requesterEmail, subject, body, EmailType.CONTACT_REQUEST_REQUESTER);
@@ -196,9 +197,9 @@ public class ContactRequestService {
       environment.getRequiredProperty("host-virkailija")
     );
 
-    final String recipientName = "Auktoris - OPH";
+    final String recipientName = "Auktorisoitujen kääntäjien tutkintolautakunta";
     final String recipientAddress = "auktoris.lautakunta@oph.fi";
-    final String subject = "Yhteydenotto kääntäjään jonka postiosoite ei tiedossa";
+    final String subject = "Yhteydenotto kääntäjään jonka sähköposti ei tiedossa";
     final String body = templateRenderer.renderContactRequestClerkEmailBody(templateParams);
 
     createEmail(recipientName, recipientAddress, subject, body, EmailType.CONTACT_REQUEST_CLERK);

--- a/backend/akt/src/main/java/fi/oph/akt/service/email/sender/EmailSenderViestintapalvelu.java
+++ b/backend/akt/src/main/java/fi/oph/akt/service/email/sender/EmailSenderViestintapalvelu.java
@@ -22,6 +22,10 @@ public class EmailSenderViestintapalvelu implements EmailSender {
 
   private final WebClient webClient;
 
+  private final String callingProcess;
+
+  private final String sender;
+
   @Override
   public String sendEmail(final EmailData emailData) throws JsonProcessingException {
     final Map<String, Object> postData = createPostData(emailData);
@@ -46,9 +50,9 @@ public class EmailSenderViestintapalvelu implements EmailSender {
       "charset",
       "UTF-8",
       "callingProcess",
-      "akt",
+      callingProcess,
       "sender",
-      "AKT",
+      sender,
       "subject",
       emailData.subject(),
       "body",

--- a/backend/akt/src/main/resources/email-templates/authorisation-expiry.html
+++ b/backend/akt/src/main/resources/email-templates/authorisation-expiry.html
@@ -7,33 +7,26 @@
         <br/>
 
         <p>
-            Oikeutesi toimia auktorisoituna kääntäjänä kieliparissa [[${langPair}]] on päättymässä [[${expiryDate}]].
-        </p>
-        <br/>
-
-        <p>
-            Sinun tulee hakea auktorisoidun kääntäjän oikeuden uusimista, jotta voit edelleen toimia auktorisoituna kääntäjänä. Oikeuden myöntää Auktorisoitujen kääntäjien tutkintolautakunta, jonka seuraava kokous on [[${nextMeetingDate}]].
+            Oikeutesi toimia auktorisoituna kääntäjänä kieliparissa [[${langPairFI}]] on päättymässä [[${expiryDate}]].
         </p>
         <p>
-            Auktorisoidun kääntäjän oikeuden uusiminen tapahtuu sille tarkoitetulla hakemuksella.
+            Sinun tulee hakea auktorisoidun kääntäjän oikeuden uusimista, jotta voit edelleen toimia auktorisoituna kääntäjänä. Oikeuden myöntää Auktorisoitujen kääntäjien tutkintolautakunta, jonka seuraavat kokoukset ovat [[${meetingDate1}]] ja [[${meetingDate2}]].
         </p>
         <p>
-            Hakemusmenettelyn tiedot löytyvät täältä: <a href="https://www.oph.fi/fi/koulutus-ja-tutkinnot/auktorisoinnin-uusiminen">https://www.oph.fi/fi/koulutus-ja-tutkinnot/auktorisoinnin-uusiminen</a>. Sivun lopussa on tulostettava hakemuslomake.
+            Jos et uusi oikeuttasi, et voi toimia auktorisoituna kääntäjänä. Tietosi poistuvat julkisesta auktorisoitujen kääntäjien rekisteristä oikeutesi päättymisen jälkeen.
         </p>
         <p>
-            Täytetty ja allekirjoitettu hakemuslomake lähetetään osoitteeseen:
+            Auktorisoidun kääntäjän oikeuden uusiminen tapahtuu sille tarkoitetulla hakemuksella. Hakemusmenettelyn tiedot löytyvät täältä: <a href="https://www.oph.fi/fi/koulutus-ja-tutkinnot/auktorisoinnin-uusiminen">https://www.oph.fi/fi/koulutus-ja-tutkinnot/auktorisoinnin-uusiminen</a>. Sivun lopussa on tulostettava hakemuslomake.
         </p>
         <p>
-            Kirjaamo Opetushallitus, PL 380, 00531 Helsinki.
+            Täytetty ja allekirjoitettu hakemuslomake lähetetään postitse tai skannattuna osoitteeseen: Kirjaamo Opetushallitus, PL 380, 00531 Helsinki tai <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a>
         </p>
         <p>
-            Ote väestötietojärjestelmästä lähetetään sähköpostitse: <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a>. Hakemuksen tulee olla perillä viikkoa ennen tutkintolautakunnan kokousta.
+            Hakemuksen liitteeksi vaadittu ote väestötietojärjestelmästä (asuinpaikkatodistus) lähetetään sähköpostitse <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a>. Hakemus liitteineen tulee olla perillä viikkoa ennen tutkintolautakunnan kokousta.
         </p>
         <p>
             Lisää tietoa auktorisoidun kääntäjän tutkintojärjestelmästä löydät täältä: <a href="https://www.oph.fi/fi/koulutus-ja-tutkinnot/usein-kysyttya-auktorisoidun-kaantajan-tutkinnosta">https://www.oph.fi/fi/koulutus-ja-tutkinnot/usein-kysyttya-auktorisoidun-kaantajan-tutkinnosta</a>
         </p>
-        <br/>
-
         <p>
             Kysymykset: <a href="mailto:auktoris.lautakunta@oph.fi">auktoris.lautakunta@oph.fi</a>
         </p>
@@ -42,18 +35,50 @@
         <p>
             Älä vastaa tähän viestiin - viesti on lähetetty automaattisesti.
         </p>
-        <br/>
-
-        <p>
-            Ystävällisin terveisin
-        </p>
-        <br/>
-
-        <p>
-            Auktorisoitujen kääntäjien tutkintolautakunta
-        </p>
-        <p>
+        <p style="border-bottom: 1px solid black; padding-bottom: 15px;">
+            Ystävällisin terveisin<br/>
+            Auktorisoitujen kääntäjien tutkintolautakunta<br/>
             Opetushallitus
+        </p>
+
+        <p>
+            Bästa [[${translatorName}]],
+        </p>
+        <br/>
+
+        <p>
+            Din rätt att verka som auktoriserad translator i språkparet [[${langPairSV}]] slutar [[${expiryDate}]].
+        </p>
+        <p>
+            Du ska ansöka om förlängning av Examensnämnden för auktoriserade translatorer. Nästa möten då ansökningarna behandlas är [[${meetingDate1}]] och [[${meetingDate2}]].
+        </p>
+        <p>
+            Om du inte förnyar din rätt, kan du inte verka som auktoriserad translator och ditt namn tas bort från offentliga registret över auktoriserade translatorer.
+        </p>
+        <p>
+            Ansökningsblanketten samt rådgivning för ansökningsprocessen för att förnya rätten att verka som auktoriserad translator finns här: <a href="https://www.oph.fi/sv/utbildning-och-examina/ansokan-om-att-fornya-ratten-att-verka-som-auktoriserad-translator">https://www.oph.fi/sv/utbildning-och-examina/ansokan-om-att-fornya-ratten-att-verka-som-auktoriserad-translator</a>
+        </p>
+        <p>
+            En ifylld och underskriven ansökningsblankett samt bilagan (utdrag ur befolkningsdatasystemet) skickas per post eller skannad till adressen: Registratur, Utbildningsstyrelsen, PB 380, 00531 Helsingfors eller <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a>
+        </p>
+        <p>
+            Utdraget ur befolkningsdatasystemet (hemvistintyg) är elektroniskt och beställs här: <a href="https://dvv.fi/sv/intyg-fran-befolkningsdatasystemet">https://dvv.fi/sv/intyg-fran-befolkningsdatasystemet</a>. Utdraget skickas till <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a>. Ansökan ska vara framme en vecka innan Examensnämndens nästa möte.
+        </p>
+        <p>
+            Läs mera om auktoriserad översättning: <a href="https://www.oph.fi/sv/utbildning-och-examina/vanliga-fragor-om-examen-auktoriserad-translator">https://www.oph.fi/sv/utbildning-och-examina/vanliga-fragor-om-examen-auktoriserad-translator</a>
+        </p>
+        <p>
+            Frågor: <a href="mailto:auktoris.lautakunta@oph.fi">auktoris.lautakunta@oph.fi</a>
+        </p>
+        <br/>
+
+        <p>
+            Svara inte till detta meddelande, det har skickats automatiskt.
+        </p>
+        <p>
+            Med vänlig hälsning<br/>
+            Examensnämnden för auktoriserade translatorer<br/>
+            Utbildningsstyrelsen
         </p>
     </body>
 </html>

--- a/backend/akt/src/main/resources/email-templates/contact-request-clerk.html
+++ b/backend/akt/src/main/resources/email-templates/contact-request-clerk.html
@@ -10,6 +10,9 @@
         <ul th:each="translator : ${translators}">
             <li><a th:href="@{https://{aktHost}/akt/virkailija/kaantaja/{id}(aktHost=${aktHost},id=${translator.id})}">[[${translator.name}]]</a></li>
         </ul>
+        <p>
+            Huomaa, että kääntäjien tietojen tarkastelu vaatii ensin Opintopolkuun kirjautumisen.
+        </p>
         <br/>
 
         <p>

--- a/backend/akt/src/main/resources/email-templates/contact-request-requester.html
+++ b/backend/akt/src/main/resources/email-templates/contact-request-requester.html
@@ -6,7 +6,7 @@
         </p>
         <div th:unless="${contactedTranslators.isEmpty()}">
             <p>
-                Olet ottanut yhteyttä seuraaviin kääntäjiin auktorisoitua käännöstyötä varten:
+                Olet ottanut yhteyttä seuraaviin auktorisoituihin kääntäjiin käännöstoimeksiantoa varten:
             </p>
             <ul>
                 <li th:each="name : ${contactedTranslators}">[[${name}]]</li>
@@ -21,18 +21,20 @@
             <ul>
                 <li th:each="name : ${otherTranslators}">[[${name}]]</li>
             </ul>
-            <p>Opetushallituksen virkailija pyrkii selvittämään yo. kääntäjien yhteystiedot ja ottaa teihin asian tiimoilta myöhemmin yhteyttä.</p>
+            <p>
+                Opetushallituksen virkailija pyrkii selvittämään yo. kääntäjien yhteystiedot ja ottaa teihin asian tiimoilta myöhemmin yhteyttä.
+            </p>
             <br/>
         </div>
 
-        <p>Ohessa jättämäsi viesti sekä yhteystietosi:</p>
+        <p>Tässä jättämäsi viesti sekä yhteystietosi:</p>
 
         <p>
             <span th:each="line : ${messageLines}">[[${line}]]<br/></span>
         </p>
 
         <p>
-            <strong>Lähettäjän tiedot</strong><br/>
+            <strong>Yhteystietosi</strong><br/>
             <span th:text="${requesterName}"></span><br/>
             <span th:text="${requesterEmail}"></span><br/>
             <span th:unless="${requesterPhone.isEmpty()}">[[${requesterPhone}]]<br/></span>
@@ -42,9 +44,79 @@
         <p>
             Älä vastaa tähän viestiin - viesti on lähetetty automaattisesti.
         </p>
-        <p>
+        <p style="border-bottom: 1px solid black; padding-bottom: 15px;">
             Ystävällisin terveisin<br/>
             Opetushallitus
+        </p>
+
+        <p>
+            Hej,
+        </p>
+        <div th:unless="${contactedTranslators.isEmpty()}">
+            <p>
+                Du har kontaktat följande auktoriserade translatorer gällande ett översättningsuppdrag:
+            </p>
+            <ul>
+                <li th:each="name : ${contactedTranslators}">[[${name}]]</li>
+            </ul>
+            <br/>
+        </div>
+
+        <p>Här ditt meddelande och dina kontaktuppgifter:</p>
+
+        <p>
+            <span th:each="line : ${messageLines}">[[${line}]]<br/></span>
+        </p>
+
+        <p>
+            <strong>Dina kontaktuppgifter</strong><br/>
+            <span th:text="${requesterName}"></span><br/>
+            <span th:text="${requesterEmail}"></span><br/>
+            <span th:unless="${requesterPhone.isEmpty()}">[[${requesterPhone}]]<br/></span>
+        </p>
+        <br/>
+
+        <p>
+            Svara inte till detta meddelande, det har skickats automatiskt.
+        </p>
+        <p style="border-bottom: 1px solid black; padding-bottom: 15px;">
+            Med vänlig hälsning<br/>
+            Utbildningsstyrelsen
+        </p>
+
+        <p>
+            Hello,
+        </p>
+        <div th:unless="${contactedTranslators.isEmpty()}">
+            <p>
+                You have contacted following authorised translators for translation assignment:
+            </p>
+            <ul>
+                <li th:each="name : ${contactedTranslators}">[[${name}]]</li>
+            </ul>
+            <br/>
+        </div>
+
+        <p>Here is your message and contacts:</p>
+
+        <p>
+            <span th:each="line : ${messageLines}">[[${line}]]<br/></span>
+        </p>
+
+        <p>
+            <strong>Your contacts</strong><br/>
+            <span th:text="${requesterName}"></span><br/>
+            <span th:text="${requesterEmail}"></span><br/>
+            <span th:unless="${requesterPhone.isEmpty()}">[[${requesterPhone}]]<br/></span>
+        </p>
+        <br/>
+
+        <p>
+            Please, don't reply this message - it is generated automatically.
+        </p>
+        <p>
+            Kind regards<br/>
+            Finnish National Agency for Education
         </p>
     </body>
 </html>

--- a/backend/akt/src/main/resources/email-templates/contact-request-translator.html
+++ b/backend/akt/src/main/resources/email-templates/contact-request-translator.html
@@ -5,7 +5,7 @@
             Hei,
         </p>
         <p>
-            Sinuun on otettu yhteyttä auktorisoitua käännöstyötä varten. Ohessa sinulle jätetty viesti sekä tiedot sen lähettäjästä.
+            Sinuun on otettu yhteyttä käännöstoimeksiantoa varten. Ohessa sinulle jätetty viesti ja tiedot sen lähettäjästä.
         </p>
         <br/>
 
@@ -24,9 +24,37 @@
         <p>
             Älä vastaa tähän viestiin - viesti on lähetetty automaattisesti.
         </p>
-        <p>
+        <p style="border-bottom: 1px solid black; padding-bottom: 15px;">
             Ystävällisin terveisin<br/>
             Opetushallitus
+        </p>
+
+        <p>
+            Hej,
+        </p>
+        <p>
+            Du har blivit kontaktad gällande ett översättningsuppdrag. Nere meddelandet, som har lämnats till dig.
+        </p>
+        <br/>
+
+        <p>
+            <span th:each="line : ${messageLines}">[[${line}]]<br/></span>
+        </p>
+
+        <p>
+            <strong>Avsändarens uppgifter</strong><br/>
+            <span th:text="${requesterName}"></span><br/>
+            <span th:text="${requesterEmail}"></span><br/>
+            <span th:unless="${requesterPhone.isEmpty()}">[[${requesterPhone}]]<br/></span>
+        </p>
+        <br/>
+
+        <p>
+            Svara inte till detta meddelande, det har skickats automatiskt.
+        </p>
+        <p>
+            Med vänlig hälsning<br/>
+            Utbildningsstyrelsen
         </p>
     </body>
 </html>

--- a/backend/akt/src/test/java/fi/oph/akt/service/ContactRequestServiceTest.java
+++ b/backend/akt/src/test/java/fi/oph/akt/service/ContactRequestServiceTest.java
@@ -152,7 +152,13 @@ class ContactRequestServiceTest {
           .stream()
           .filter(e -> e.recipientName().equals(t.getFullName()))
           .filter(e -> e.recipientAddress().equals(t.getEmail()))
-          .filter(e -> e.subject().equals("Yhteydenotto kääntäjärekisteristä"))
+          .filter(e ->
+            e
+              .subject()
+              .equals(
+                "Yhteydenotto auktorisoitujen kääntäjien rekisteristä | Kontaktförfrågan från registret över auktoriserade translatorer"
+              )
+          )
           .filter(e -> e.body().equals("<html>translator</html>"))
           .count()
       )
@@ -164,7 +170,7 @@ class ContactRequestServiceTest {
         .stream()
         .filter(e -> e.recipientName().equals("Sean Sender"))
         .filter(e -> e.recipientAddress().equals("sean.sender@invalid"))
-        .filter(e -> e.subject().equals("Lähettämäsi yhteydenottopyyntö"))
+        .filter(e -> e.subject().equals("Lähettämäsi yhteydenottopyyntö | Din kontaktförfrågan | Request for contact"))
         .filter(e -> e.body().equals("<html>requester</html>"))
         .count()
     );
@@ -200,7 +206,7 @@ class ContactRequestServiceTest {
         .stream()
         .filter(e -> e.recipientName().equals("Sean Sender"))
         .filter(e -> e.recipientAddress().equals("sean.sender@invalid"))
-        .filter(e -> e.subject().equals("Lähettämäsi yhteydenottopyyntö"))
+        .filter(e -> e.subject().equals("Lähettämäsi yhteydenottopyyntö | Din kontaktförfrågan | Request for contact"))
         .filter(e -> e.body().equals("<html>requester</html>"))
         .count()
     );
@@ -209,9 +215,9 @@ class ContactRequestServiceTest {
       1,
       emailDatas
         .stream()
-        .filter(e -> e.recipientName().equals("Auktoris - OPH"))
+        .filter(e -> e.recipientName().equals("Auktorisoitujen kääntäjien tutkintolautakunta"))
         .filter(e -> e.recipientAddress().equals("auktoris.lautakunta@oph.fi"))
-        .filter(e -> e.subject().equals("Yhteydenotto kääntäjään jonka postiosoite ei tiedossa"))
+        .filter(e -> e.subject().equals("Yhteydenotto kääntäjään jonka sähköposti ei tiedossa"))
         .filter(e -> e.body().equals("<html>clerk</html>"))
         .count()
     );

--- a/backend/akt/src/test/java/fi/oph/akt/service/email/ClerkEmailServiceTest.java
+++ b/backend/akt/src/test/java/fi/oph/akt/service/email/ClerkEmailServiceTest.java
@@ -71,6 +71,7 @@ public class ClerkEmailServiceTest {
   @BeforeEach
   public void setup() {
     final LanguageService languageService = new LanguageService();
+    languageService.init();
 
     clerkEmailService =
       new ClerkEmailService(
@@ -197,8 +198,8 @@ public class ClerkEmailServiceTest {
   @Test
   public void testCreateAuthorisationExpiryEmail() {
     final MeetingDate meetingDate1 = Factory.meetingDate(LocalDate.of(2020, 1, 10));
-    final MeetingDate meetingDate2 = Factory.meetingDate(LocalDate.of(2050, 1, 10));
-    final MeetingDate meetingDate3 = Factory.meetingDate(LocalDate.of(2060, 1, 10));
+    final MeetingDate meetingDate2 = Factory.meetingDate(LocalDate.of(2050, 2, 11));
+    final MeetingDate meetingDate3 = Factory.meetingDate(LocalDate.of(2060, 3, 12));
     final Translator translator = Factory.translator();
     final Authorisation authorisation = Factory.kktAuthorisation(translator, meetingDate1);
 
@@ -219,12 +220,16 @@ public class ClerkEmailServiceTest {
     final Map<String, Object> expectedTemplateParams = Map.of(
       "translatorName",
       "Etu Suku",
-      "langPair",
+      "langPairFI",
       "ruotsi - englanti",
+      "langPairSV",
+      "svenska - engelska",
       "expiryDate",
       "01.12.2049",
-      "nextMeetingDate",
-      "10.01.2050"
+      "meetingDate1",
+      "11.02.2050",
+      "meetingDate2",
+      "12.03.2060"
     );
 
     when(templateRenderer.renderAuthorisationExpiryEmailBody(expectedTemplateParams))
@@ -238,7 +243,7 @@ public class ClerkEmailServiceTest {
 
     assertEquals("Etu Suku", emailData.recipientName());
     assertEquals("etu.suku@invalid", emailData.recipientAddress());
-    assertEquals("Auktorisointisi on päättymässä", emailData.subject());
+    assertEquals("Auktorisointisi on päättymässä | Din auktorisering går mot sitt slut", emailData.subject());
     assertEquals("Auktorisointisi päättyy 01.12.2049", emailData.body());
 
     verify(authorisationTermReminderRepository).save(any());
@@ -265,12 +270,16 @@ public class ClerkEmailServiceTest {
     final Map<String, Object> expectedTemplateParams = Map.of(
       "translatorName",
       "Etu Suku",
-      "langPair",
+      "langPairFI",
       "ruotsi - englanti",
+      "langPairSV",
+      "svenska - engelska",
       "expiryDate",
       "01.12.2049",
-      "nextMeetingDate",
-      "[ei tiedossa]"
+      "meetingDate1",
+      "-",
+      "meetingDate2",
+      "-"
     );
 
     when(templateRenderer.renderAuthorisationExpiryEmailBody(expectedTemplateParams))

--- a/backend/akt/src/test/java/fi/oph/akt/service/email/sender/EmailSenderViestintapalveluTest.java
+++ b/backend/akt/src/test/java/fi/oph/akt/service/email/sender/EmailSenderViestintapalveluTest.java
@@ -28,7 +28,12 @@ class EmailSenderViestintapalveluTest {
   public void setup() {
     mockWebServer = new MockWebServer();
     final String mockWebServerBaseUrl = mockWebServer.url("/").url().toString();
-    sender = new EmailSenderViestintapalvelu(WebClient.builder().baseUrl(mockWebServerBaseUrl).build());
+    sender =
+      new EmailSenderViestintapalvelu(
+        WebClient.builder().baseUrl(mockWebServerBaseUrl).build(),
+        "prosessi",
+        "Sovellus"
+      );
   }
 
   @Test
@@ -58,8 +63,8 @@ class EmailSenderViestintapalveluTest {
 
     assertThat(body).extractingJsonPathBooleanValue("$.email.html").isEqualTo(true);
     assertThat(body).extractingJsonPathStringValue("$.email.charset").isEqualTo("UTF-8");
-    assertThat(body).extractingJsonPathStringValue("$.email.callingProcess").isEqualTo("akt");
-    assertThat(body).extractingJsonPathStringValue("$.email.sender").isEqualTo("AKT");
+    assertThat(body).extractingJsonPathStringValue("$.email.callingProcess").isEqualTo("prosessi");
+    assertThat(body).extractingJsonPathStringValue("$.email.sender").isEqualTo("Sovellus");
     assertThat(body).extractingJsonPathStringValue("$.email.subject").isEqualTo("testiotsikko");
     assertThat(body).extractingJsonPathStringValue("$.email.body").isEqualTo("testiviesti");
 

--- a/backend/akt/src/test/java/fi/oph/akt/util/TemplateRendererTest.java
+++ b/backend/akt/src/test/java/fi/oph/akt/util/TemplateRendererTest.java
@@ -23,12 +23,16 @@ class TemplateRendererTest {
       Map.of(
         "translatorName",
         "Jack Smith",
-        "langPair",
+        "langPairFI",
         "englanti - ruotsi",
+        "langPairSV",
+        "engelska - svenska",
         "expiryDate",
         "06.02.2022",
-        "nextMeetingDate",
-        "13.12.2021"
+        "meetingDate1",
+        "13.12.2021",
+        "meetingDate2",
+        "14.03.2022"
       )
     );
 
@@ -36,18 +40,9 @@ class TemplateRendererTest {
     assertTrue(renderedContent.contains("<html "));
     assertTrue(renderedContent.contains("Jack Smith"));
     assertTrue(renderedContent.contains("englanti - ruotsi"));
+    assertTrue(renderedContent.contains("engelska - svenska"));
     assertTrue(renderedContent.contains("06.02.2022"));
     assertTrue(renderedContent.contains("13.12.2021"));
-  }
-
-  @Test
-  public void testAuthorisationExpiryTemplateIsRenderedProperlyWhenNextMeetingDateIsNotKnown() {
-    final String renderedContent = templateRenderer.renderAuthorisationExpiryEmailBody(
-      Map.of("nextMeetingDate", "[ei tiedossa]")
-    );
-
-    assertNotNull(renderedContent);
-    assertTrue(renderedContent.contains("[ei tiedossa]"));
   }
 
   @Test


### PR DESCRIPTION
Sähköpostipohjat päivitetty OneDrivessa olevan Word-dokumentin mukaisesti. Esimerkit uusista näiden pohjien perusteella generoiduista sähköpostiviesteistä löytyy alta.

Pohja 1: https://virkailija.untuvaopintopolku.fi/viestintapalvelu-ui/#/reportMessages/view/2470991 
Pohja 2: https://virkailija.untuvaopintopolku.fi/viestintapalvelu-ui/#/reportMessages/view/2470985 
Pohja 3: https://virkailija.untuvaopintopolku.fi/viestintapalvelu-ui/#/reportMessages/view/2470988 
Pohja 4: https://virkailija.untuvaopintopolku.fi/viestintapalvelu-ui/#/reportMessages/view/2470976

Tämän branchin yhteydessä toteutettu myös pienenä muutoksena ConfigEnums käyttöönotto ja korjattu ongelma ClerkEmailService testien ajamisessa (languageService.init() ei pakotettu ja sitä myöten sen initialisointi ei välttämättä ehtinyt tapahtua ennen kuin sitä tarvittiin kielikoodien käännöksiin).