### PR TITLE
OTR(Backend): OPHOTRKEH-59 henkilötietojen listaus ONR:stä

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
@@ -15,7 +15,7 @@ public record ClerkInterpreterDTO(
   @NonNull @NotBlank String identityNumber,
   @NonNull @NotBlank String lastName,
   @NonNull @NotBlank String firstName,
-  String nickName,
+  @NonNull @NotBlank String nickName,
   @NonNull @NotBlank String email,
   @NonNull @NotNull Boolean permissionToPublishEmail,
   String phoneNumber,

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterCreateDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterCreateDTO.java
@@ -14,7 +14,7 @@ public record ClerkInterpreterCreateDTO(
   @NonNull @NotBlank String identityNumber,
   @NonNull @NotBlank String lastName,
   @NonNull @NotBlank String firstName,
-  String nickName,
+  @NonNull @NotBlank String nickName,
   @NonNull @NotBlank String email,
   @NonNull @NotNull Boolean permissionToPublishEmail,
   String phoneNumber,

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterUpdateDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/modify/ClerkInterpreterUpdateDTO.java
@@ -14,7 +14,7 @@ public record ClerkInterpreterUpdateDTO(
   @NonNull @NotBlank String identityNumber,
   @NonNull @NotBlank String lastName,
   @NonNull @NotBlank String firstName,
-  String nickName,
+  @NonNull @NotBlank String nickName,
   @NonNull @NotBlank String email,
   @NonNull @NotNull Boolean permissionToPublishEmail,
   String phoneNumber,

--- a/backend/otr/src/main/java/fi/oph/otr/config/AppConfig.java
+++ b/backend/otr/src/main/java/fi/oph/otr/config/AppConfig.java
@@ -6,6 +6,9 @@ import fi.oph.otr.onr.mock.OnrOperationApiMock;
 import fi.oph.otr.service.email.sender.EmailSender;
 import fi.oph.otr.service.email.sender.EmailSenderNoOp;
 import fi.oph.otr.service.email.sender.EmailSenderViestintapalvelu;
+import fi.vm.sade.javautils.nio.cas.CasClient;
+import fi.vm.sade.javautils.nio.cas.CasClientBuilder;
+import fi.vm.sade.javautils.nio.cas.CasConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -46,9 +49,23 @@ public class AppConfig {
 
   @Bean
   @ConditionalOnProperty(name = "otr.onr.enabled", havingValue = "true")
-  public OnrOperationApi onrOperationApiImpl() {
-    LOG.info("OnrOperationApiImpl in use");
-    return new OnrOperationApiImpl();
+  public OnrOperationApi onrOperationApiImpl(
+    @Value("${otr.onr.service-url}") String onrServiceUrl,
+    @Value("${otr.onr.cas.url}") String casUrl,
+    @Value("${otr.onr.cas.username}") String casUsername,
+    @Value("${otr.onr.cas.password}") String casPassword
+  ) {
+    LOG.info("onrServiceUrl:{}", onrServiceUrl);
+    final CasConfig casConfig = CasConfig.SpringSessionCasConfig(
+      casUsername,
+      casPassword,
+      casUrl,
+      onrServiceUrl,
+      Constants.CALLER_ID,
+      Constants.CALLER_ID
+    );
+    final CasClient casClient = CasClientBuilder.build(casConfig);
+    return new OnrOperationApiImpl(casClient, onrServiceUrl);
   }
 
   @Bean

--- a/backend/otr/src/main/java/fi/oph/otr/onr/ContactDetailsUtil.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/ContactDetailsUtil.java
@@ -1,0 +1,85 @@
+package fi.oph.otr.onr;
+
+import static fi.oph.otr.onr.dto.ContactDetailsGroupType.KOTIMAINEN_POSTIOSOITE;
+import static fi.oph.otr.onr.dto.ContactDetailsGroupType.KOTIOSOITE;
+import static fi.oph.otr.onr.dto.ContactDetailsGroupType.OTR_OSOITE;
+import static fi.oph.otr.onr.dto.ContactDetailsGroupType.SAHKOINEN_OSOITE;
+import static fi.oph.otr.onr.dto.ContactDetailsGroupType.TILAPAINEN_KOTIMAAN_OSOITE;
+import static fi.oph.otr.onr.dto.ContactDetailsGroupType.TILAPAINEN_ULKOMAAN_OSOITE;
+import static fi.oph.otr.onr.dto.ContactDetailsGroupType.ULKOMAINEN_POSTIOSOITE;
+import static fi.oph.otr.onr.dto.ContactDetailsGroupType.VAKINAINEN_KOTIMAAN_OSOITE;
+import static fi.oph.otr.onr.dto.ContactDetailsGroupType.VAKINAINEN_ULKOMAAN_OSOITE;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Comparator.nullsLast;
+
+import fi.oph.otr.onr.dto.ContactDetailsDTO;
+import fi.oph.otr.onr.dto.ContactDetailsGroupDTO;
+import fi.oph.otr.onr.dto.ContactDetailsGroupType;
+import fi.oph.otr.onr.dto.ContactDetailsType;
+import fi.oph.otr.util.CustomOrderComparator;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class ContactDetailsUtil {
+
+  private static final List<ContactDetailsGroupType> CIVIL_REGISTRY_ORDERING = List.of(
+    TILAPAINEN_KOTIMAAN_OSOITE,
+    TILAPAINEN_ULKOMAAN_OSOITE,
+    VAKINAINEN_KOTIMAAN_OSOITE,
+    VAKINAINEN_ULKOMAAN_OSOITE,
+    KOTIMAINEN_POSTIOSOITE,
+    ULKOMAINEN_POSTIOSOITE,
+    SAHKOINEN_OSOITE
+  );
+
+  private static final CustomOrderComparator<ContactDetailsGroupType> OTR_FIRST = new CustomOrderComparator<>(
+    Stream.concat(Stream.of(OTR_OSOITE), CIVIL_REGISTRY_ORDERING.stream()).toList()
+  );
+
+  private static final CustomOrderComparator<ContactDetailsGroupType> OTR_LAST = new CustomOrderComparator<>(
+    Stream.concat(CIVIL_REGISTRY_ORDERING.stream(), Stream.of(OTR_OSOITE)).toList()
+  );
+
+  public static String getPrimaryEmail(final List<ContactDetailsGroupDTO> groups) {
+    return getPrimaryValue(groups, ContactDetailsType.EMAIL, OTR_FIRST);
+  }
+
+  public static String getPrimaryPhoneNumber(final List<ContactDetailsGroupDTO> groups) {
+    return getPrimaryValue(groups, ContactDetailsType.PHONE_NUMBER, OTR_FIRST);
+  }
+
+  public static String getPrimaryStreet(final List<ContactDetailsGroupDTO> groups) {
+    return getPrimaryValue(groups, ContactDetailsType.STREET, OTR_LAST);
+  }
+
+  public static String getPrimaryPostalCode(final List<ContactDetailsGroupDTO> groups) {
+    return getPrimaryValue(groups, ContactDetailsType.POSTAL_CODE, OTR_LAST);
+  }
+
+  public static String getPrimaryTown(final List<ContactDetailsGroupDTO> groups) {
+    return getPrimaryValue(groups, ContactDetailsType.TOWN, OTR_LAST);
+  }
+
+  public static String getPrimaryCountry(final List<ContactDetailsGroupDTO> groups) {
+    return getPrimaryValue(groups, ContactDetailsType.COUNTRY, OTR_LAST);
+  }
+
+  private static String getPrimaryValue(
+    final List<ContactDetailsGroupDTO> contactDetailsGroups,
+    final ContactDetailsType contactDetailsType,
+    final Comparator<ContactDetailsGroupType> comparator
+  ) {
+    return contactDetailsGroups
+      .stream()
+      .sorted(comparing(ContactDetailsGroupDTO::getType, nullsLast(comparator.thenComparing(naturalOrder()))))
+      .filter(group -> !group.getType().equals(KOTIOSOITE))
+      .flatMap(group -> group.getContactDetailsSet().stream())
+      .filter(details -> details.getType().equals(contactDetailsType))
+      .filter(details -> details.getValue() != null && !details.getValue().isBlank())
+      .map(ContactDetailsDTO::getValue)
+      .findFirst()
+      .orElse(null);
+  }
+}

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApi.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApi.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface OnrOperationApi {
-  Map<String, PersonalData> fetchPersonalDatas(List<String> onrIds);
+  Map<String, PersonalData> fetchPersonalDatas(List<String> onrIds) throws Exception;
 
   String insertPersonalData(PersonalData personalData);
 

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
@@ -1,16 +1,86 @@
 package fi.oph.otr.onr;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.oph.otr.config.Constants;
+import fi.oph.otr.onr.dto.ContactDetailsGroupDTO;
+import fi.oph.otr.onr.dto.PersonalDataDTO;
 import fi.oph.otr.onr.model.PersonalData;
+import fi.vm.sade.javautils.nio.cas.CasClient;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import net.minidev.json.JSONArray;
 import org.apache.commons.lang.NotImplementedException;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.RequestBuilder;
+import org.asynchttpclient.Response;
+import org.asynchttpclient.util.HttpConstants.Methods;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
+@RequiredArgsConstructor
 public class OnrOperationApiImpl implements OnrOperationApi {
 
-  // TODO: implement
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final CasClient onrClient;
+
+  private final String onrServiceUrl;
+
   @Override
-  public Map<String, PersonalData> fetchPersonalDatas(final List<String> onrIds) {
-    throw new NotImplementedException();
+  public Map<String, PersonalData> fetchPersonalDatas(final List<String> onrIds) throws Exception {
+    final Request request = new RequestBuilder()
+      .setUrl(onrServiceUrl + "/henkilo/henkilotByHenkiloOidList")
+      .setMethod(Methods.POST)
+      .setBody(JSONArray.toJSONString(onrIds))
+      .addHeader("Accept", MediaType.APPLICATION_JSON_VALUE)
+      .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+      .addHeader("Caller-Id", Constants.CALLER_ID)
+      .setRequestTimeout((int) TimeUnit.MINUTES.toMillis(2))
+      .build();
+
+    final Response response = onrClient.executeBlocking(request);
+
+    if (response.getStatusCode() == HttpStatus.OK.value()) {
+      final List<PersonalDataDTO> personalDataDTOS = OBJECT_MAPPER.readValue(
+        response.getResponseBody(),
+        new TypeReference<>() {}
+      );
+
+      final Map<String, PersonalData> personalDatas = new HashMap<>();
+      personalDataDTOS.forEach(dto -> personalDatas.put(dto.getOnrId(), createPersonalData(dto)));
+      return personalDatas;
+    } else {
+      throw new RuntimeException("ONR service returned unexpected status code: " + response.getStatusCode());
+    }
+  }
+
+  /**
+   * Creates PersonalData based on `personalDataDTO`.
+   * If `personalDataDTO` has null identityNumber, or its `contactDetailsGroups` contains no suitable group with
+   * email contact details, building PersonalData will fail to @NonNull constraint. This shouldn't take place in
+   * production but may occur with improper ONR test data.
+   */
+  private PersonalData createPersonalData(final PersonalDataDTO personalDataDTO) {
+    final List<ContactDetailsGroupDTO> groups = personalDataDTO.getContactDetailsGroups();
+
+    return PersonalData
+      .builder()
+      .lastName(personalDataDTO.getLastName())
+      .firstName(personalDataDTO.getFirstName())
+      .nickName(personalDataDTO.getNickName())
+      .identityNumber(personalDataDTO.getIdentityNumber())
+      .email(ContactDetailsUtil.getPrimaryEmail(groups))
+      .phoneNumber(ContactDetailsUtil.getPrimaryPhoneNumber(groups))
+      .street(ContactDetailsUtil.getPrimaryStreet(groups))
+      .postalCode(ContactDetailsUtil.getPrimaryPostalCode(groups))
+      .town(ContactDetailsUtil.getPrimaryTown(groups))
+      .country(ContactDetailsUtil.getPrimaryCountry(groups))
+      .isIndividualised(personalDataDTO.getIsIndividualised())
+      .build();
   }
 
   // TODO: insert personal data in ONR

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrService.java
@@ -7,11 +7,15 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Resource;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class OnrService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OnrService.class);
 
   private Map<String, PersonalData> personalDataCache = new HashMap<>();
 
@@ -19,7 +23,11 @@ public class OnrService {
   private final OnrOperationApi api;
 
   public void updateCache(final List<String> onrIds) {
-    personalDataCache = api.fetchPersonalDatas(onrIds);
+    try {
+      personalDataCache = api.fetchPersonalDatas(onrIds);
+    } catch (final Exception e) {
+      LOG.error("Updating personal data cache failed", e);
+    }
   }
 
   public Map<String, PersonalData> getCachedPersonalDatas() {

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsDTO.java
@@ -1,0 +1,14 @@
+package fi.oph.otr.onr.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class ContactDetailsDTO {
+
+  @JsonProperty("yhteystietoTyyppi")
+  private ContactDetailsType type;
+
+  @JsonProperty("yhteystietoArvo")
+  private String value;
+}

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupDTO.java
@@ -1,0 +1,20 @@
+package fi.oph.otr.onr.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Set;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ContactDetailsGroupDTO {
+
+  @JsonProperty("ryhmaKuvaus")
+  private ContactDetailsGroupType type;
+
+  @JsonProperty("ryhmaAlkuperaTieto")
+  private ContactDetailsGroupSource source;
+
+  @JsonProperty("yhteystieto")
+  public Set<ContactDetailsDTO> contactDetailsSet;
+}

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupSource.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupSource.java
@@ -1,0 +1,26 @@
+package fi.oph.otr.onr.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ContactDetailsGroupSource {
+  @JsonProperty("alkupera1")
+  VTJ,
+
+  @JsonProperty("alkupera2")
+  VIRKAILIJAN_UI,
+
+  @JsonProperty("alkupera3")
+  OMAT_TIEDOT_UI,
+
+  @JsonProperty("alkupera4")
+  HAKU_LOMAKE,
+
+  @JsonProperty("alkupera5")
+  TIEDON_SIIRROT,
+
+  @JsonProperty("alkupera6")
+  MUU_ALKUPERA,
+
+  @JsonProperty("alkupera7")
+  OTR,
+}

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupType.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupType.java
@@ -1,0 +1,32 @@
+package fi.oph.otr.onr.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ContactDetailsGroupType {
+  @JsonProperty("yhteystietotyyppi1")
+  KOTIOSOITE,
+
+  @JsonProperty("yhteystietotyyppi4")
+  VAKINAINEN_KOTIMAAN_OSOITE,
+
+  @JsonProperty("yhteystietotyyppi5")
+  VAKINAINEN_ULKOMAAN_OSOITE,
+
+  @JsonProperty("yhteystietotyyppi8")
+  SAHKOINEN_OSOITE,
+
+  @JsonProperty("yhteystietotyyppi9")
+  TILAPAINEN_KOTIMAAN_OSOITE,
+
+  @JsonProperty("yhteystietotyyppi10")
+  TILAPAINEN_ULKOMAAN_OSOITE,
+
+  @JsonProperty("yhteystietotyyppi11")
+  KOTIMAINEN_POSTIOSOITE,
+
+  @JsonProperty("yhteystietotyyppi12")
+  ULKOMAINEN_POSTIOSOITE,
+
+  @JsonProperty("yhteystietotyyppi13")
+  OTR_OSOITE,
+}

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsType.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsType.java
@@ -1,0 +1,31 @@
+package fi.oph.otr.onr.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ContactDetailsType {
+  @JsonProperty("YHTEYSTIETO_SAHKOPOSTI")
+  EMAIL,
+
+  @JsonProperty("YHTEYSTIETO_PUHELINNUMERO")
+  PHONE_NUMBER,
+
+  // Currently unused, exists for json mapping
+  @JsonProperty("YHTEYSTIETO_MATKAPUHELINNUMERO")
+  MOBILE_PHONE_NUMBER,
+
+  @JsonProperty("YHTEYSTIETO_KATUOSOITE")
+  STREET,
+
+  @JsonProperty("YHTEYSTIETO_POSTINUMERO")
+  POSTAL_CODE,
+
+  @JsonProperty("YHTEYSTIETO_KAUPUNKI")
+  TOWN,
+
+  // Currently unused, exists for json mapping
+  @JsonProperty("YHTEYSTIETO_KUNTA")
+  MUNICIPALITY,
+
+  @JsonProperty("YHTEYSTIETO_MAA")
+  COUNTRY,
+}

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/PersonalDataDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/PersonalDataDTO.java
@@ -1,0 +1,32 @@
+package fi.oph.otr.onr.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PersonalDataDTO {
+
+  @JsonProperty("oidHenkilo")
+  private String onrId;
+
+  @JsonProperty("sukunimi")
+  private String lastName;
+
+  @JsonProperty("etunimet")
+  private String firstName;
+
+  @JsonProperty("kutsumanimi")
+  private String nickName;
+
+  @JsonProperty("hetu")
+  private String identityNumber;
+
+  @JsonProperty("yksiloityVTJ")
+  private Boolean isIndividualised;
+
+  @JsonProperty("yhteystiedotRyhma")
+  private List<ContactDetailsGroupDTO> contactDetailsGroups;
+}

--- a/backend/otr/src/main/java/fi/oph/otr/onr/mock/PersonalDataFactory.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/mock/PersonalDataFactory.java
@@ -22,7 +22,7 @@ public class PersonalDataFactory {
       .builder()
       .lastName(lastName)
       .firstName(nickName + " " + secondName)
-      .nickName(counterValue % 9 != 0 ? nickName : null)
+      .nickName(nickName)
       .identityNumber(identityNumbers.next())
       .email(nickName.toLowerCase() + "." + lastName.toLowerCase() + "@example.invalid")
       .phoneNumber(counterValue % 10 != 0 ? "+35840" + (1000000 + counterValue) : null)

--- a/backend/otr/src/main/java/fi/oph/otr/onr/model/PersonalData.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/model/PersonalData.java
@@ -1,26 +1,19 @@
 package fi.oph.otr.onr.model;
 
-import java.util.Optional;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 
 @Builder
 public record PersonalData(
-  @NonNull @NotBlank String lastName,
-  @NonNull @NotBlank String firstName,
-  String nickName,
-  @NonNull @NotBlank String identityNumber,
-  @NonNull @NotBlank String email,
+  @NonNull String lastName,
+  @NonNull String firstName,
+  @NonNull String nickName,
+  @NonNull String identityNumber,
+  @NonNull String email,
   String phoneNumber,
   String street,
   String postalCode,
   String town,
   String country,
-  @NotNull Boolean isIndividualised
-) {
-  public String nickNameOrFirstName() {
-    return Optional.ofNullable(nickName).filter(nickName -> !nickName.isBlank()).orElse(firstName);
-  }
-}
+  Boolean isIndividualised // always returned from ONR
+) {}

--- a/backend/otr/src/main/java/fi/oph/otr/service/PublicInterpreterService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/PublicInterpreterService.java
@@ -83,7 +83,7 @@ public class PublicInterpreterService {
     return InterpreterDTO
       .builder()
       .id(interpreter.getId())
-      .firstName(personalData.nickNameOrFirstName())
+      .firstName(personalData.nickName())
       .lastName(personalData.lastName())
       .email(interpreter.isPermissionToPublishEmail() ? personalData.email() : null)
       .phoneNumber(interpreter.isPermissionToPublishPhone() ? personalData.phoneNumber() : null)

--- a/backend/otr/src/main/java/fi/oph/otr/service/email/ClerkEmailService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/email/ClerkEmailService.java
@@ -62,7 +62,7 @@ public class ClerkEmailService {
     final PersonalData personalData = onrService.getCachedPersonalDatas().get(interpreter.getOnrId());
 
     if (personalData != null) {
-      final String recipientName = personalData.nickNameOrFirstName() + " " + personalData.lastName();
+      final String recipientName = personalData.nickName() + " " + personalData.lastName();
       final String recipientAddress = personalData.email();
       final String emailSubject = "Merkintäsi oikeustulkkirekisteriin on päättymässä";
 
@@ -81,7 +81,7 @@ public class ClerkEmailService {
         EmailType.QUALIFICATION_EXPIRY
       );
 
-      final Email email = emailRepository.getById(emailId);
+      final Email email = emailRepository.getReferenceById(emailId);
 
       createQualificationReminder(qualification, email);
     } else {

--- a/backend/otr/src/main/resources/application.yaml
+++ b/backend/otr/src/main/resources/application.yaml
@@ -60,3 +60,8 @@ otr:
     ryhmasahkoposti-service-url: ${ryhmasahkoposti-service-url:null}
   onr:
     enabled: ${onr.enabled:false}
+    service-url: ${onr.service-url:https://virkailija.untuvaopintopolku.fi/oppijanumerorekisteri-service}
+    cas:
+      url: ${virkailija.cas.url:https://virkailija.untuvaopintopolku.fi/cas}
+      username: ${oppijanumerorekisteri-service.rekisteri.username:username}
+      password: ${oppijanumerorekisteri-service.rekisteri.password:password}

--- a/backend/otr/src/main/resources/oph-configuration/otr.properties.template
+++ b/backend/otr/src/main/resources/oph-configuration/otr.properties.template
@@ -15,3 +15,6 @@ email.sending-enabled=true
 ryhmasahkoposti-service-url=${url-alb}/ryhmasahkoposti-service/email/firewall
 
 onr.enabled=false
+onr.service-url=${url-alb}/oppijanumerorekisteri-service
+oppijanumerorekisteri-service.rekisteri.username=
+oppijanumerorekisteri-service.rekisteri.password=

--- a/backend/otr/src/test/java/fi/oph/otr/onr/OnrServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/onr/OnrServiceTest.java
@@ -22,7 +22,8 @@ public class OnrServiceTest {
   private final PersonalData personalData = PersonalData
     .builder()
     .lastName("Rajala")
-    .firstName("Iiro")
+    .firstName("Iiro Aapeli")
+    .nickName("Iiro")
     .identityNumber("1")
     .email("iiro.rajala@example.invalid")
     .build();
@@ -30,7 +31,8 @@ public class OnrServiceTest {
   private final PersonalData updatedPersonalData = PersonalData
     .builder()
     .lastName("Karjalainen")
-    .firstName("Eero")
+    .firstName("Eero Aapeli")
+    .nickName("Eero")
     .identityNumber("2")
     .email("eero.karjalainen@example.invalid")
     .build();
@@ -44,13 +46,22 @@ public class OnrServiceTest {
   }
 
   @Test
-  public void testUpdateCache() {
+  public void testUpdateCacheOnSuccess() throws Exception {
     when(onrOperationApi.fetchPersonalDatas(List.of("1"))).thenReturn(Map.of("1", personalData));
     onrService.updateCache(List.of("1"));
 
     final Map<String, PersonalData> cachedPersonalDatas = onrService.getCachedPersonalDatas();
     assertEquals(1, cachedPersonalDatas.size());
     assertEquals(personalData, cachedPersonalDatas.get("1"));
+  }
+
+  @Test
+  public void testUpdateCacheOnFailure() throws Exception {
+    doThrow(new RuntimeException()).when(onrOperationApi).fetchPersonalDatas(List.of("1"));
+    onrService.updateCache(List.of("1"));
+
+    final Map<String, PersonalData> cachedPersonalDatas = onrService.getCachedPersonalDatas();
+    assertEquals(0, cachedPersonalDatas.size());
   }
 
   @Test

--- a/backend/otr/src/test/java/fi/oph/otr/service/PublicInterpreterServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/service/PublicInterpreterServiceTest.java
@@ -107,17 +107,16 @@ class PublicInterpreterServiceTest {
             .identityNumber("1")
             .email("iiro.rajala@example.invalid")
             .phoneNumber("+3581234567")
-            .isIndividualised(true)
             .build(),
           interpreter2.getOnrId(),
           PersonalData
             .builder()
             .lastName("Heinänen")
-            .firstName("Ella Marja") // nickname unknown
+            .firstName("Ella Marja")
+            .nickName("Ella")
             .identityNumber("2")
             .email("ella.heinanen@example.invalid")
             .phoneNumber("+3582345678")
-            .isIndividualised(true)
             .build()
         )
       );
@@ -140,7 +139,7 @@ class PublicInterpreterServiceTest {
 
     final InterpreterDTO publishedInterpreter2 = interpreters.get(1);
     assertEquals(interpreter2.getId(), publishedInterpreter2.id());
-    assertEquals("Ella Marja", publishedInterpreter2.firstName());
+    assertEquals("Ella", publishedInterpreter2.firstName());
     assertEquals("Heinänen", publishedInterpreter2.lastName());
     assertEquals("ella.heinanen@example.invalid", publishedInterpreter2.email());
     assertNull(publishedInterpreter2.phoneNumber());

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -148,6 +148,11 @@
     </dependency>
     <dependency>
       <groupId>fi.vm.sade.java-utils</groupId>
+      <artifactId>java-cas</artifactId>
+      <version>1.0.7-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>fi.vm.sade.java-utils</groupId>
       <artifactId>opintopolku-user-details-service</artifactId>
       <version>0.3.0-SNAPSHOT</version>
     </dependency>


### PR DESCRIPTION
Henkilötietojen listaus ONR:stä toteutettu ja testattu lokaalisti untuvaa vasten. Untuvalla on testihenkilö (https://virkailija.untuvaopintopolku.fi/henkilo-ui/oppija/1.2.246.562.24.23230998710), jonka onr_id:tä vastaavan tulkin voi lokaaliin tietokantaan lisätä poistaen samalla muut tulkit, jos esim. julkista listausta haluaa lokaalisti kokeilla. Lokaaliin testaukseen tulee myös `application.yaml`:ssa korvata `username` ja `password` sopivilla arvoilla, jotka voi etsiä cloud-basen alta: `./aws/config.py untuva get-secrets | grep oikeustulkkirekisteri`.

Tämän pull requestin yhteydessä myös muutettu tulkkien HETU sekä email ei-pakollisiksi sekä vastaavasti kutsumanimi pakolliseksi. Nämä muutokset pohjautuvat oppijanumerorekisterin tietokantataulujen määrittelyyn sekä tapaan luoda ja muokata oppijoita ONR:ssä https://virkailija.untuvaopintopolku.fi/henkilo-ui/oppija/luonti
Taulujen sisällöt kuvattu myös alla.