### PR TITLE
OTR(Backend): OPHOTRKEH-80 personal data fetching from ONR by id number

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/api/clerk/PersonController.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/clerk/PersonController.java
@@ -1,0 +1,29 @@
+package fi.oph.otr.api.clerk;
+
+import fi.oph.otr.api.dto.clerk.PersonDTO;
+import fi.oph.otr.service.PersonService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.Optional;
+import javax.annotation.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/v1/clerk/person", produces = MediaType.APPLICATION_JSON_VALUE)
+public class PersonController {
+
+  private static final String TAG_PERSON = "Person API";
+
+  @Resource
+  private PersonService personService;
+
+  @Operation(tags = TAG_PERSON, summary = "Return person data from ONR with given identity number")
+  @GetMapping
+  public Optional<PersonDTO> findPerson(@RequestParam(value = "identityNumber") final String identityNumber)
+    throws Exception {
+    return personService.findPersonByIdentityNumber(identityNumber);
+  }
+}

--- a/backend/otr/src/main/java/fi/oph/otr/api/clerk/PersonController.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/clerk/PersonController.java
@@ -5,12 +5,15 @@ import fi.oph.otr.service.PersonService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.Optional;
 import javax.annotation.Resource;
+import javax.validation.constraints.NotBlank;
 import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequestMapping(value = "/api/v1/clerk/person", produces = MediaType.APPLICATION_JSON_VALUE)
 public class PersonController {
@@ -22,7 +25,7 @@ public class PersonController {
 
   @Operation(tags = TAG_PERSON, summary = "Return person data from ONR with given identity number")
   @GetMapping
-  public Optional<PersonDTO> findPerson(@RequestParam(value = "identityNumber") final String identityNumber)
+  public Optional<PersonDTO> findPerson(@RequestParam(value = "identityNumber") @NotBlank final String identityNumber)
     throws Exception {
     return personService.findPersonByIdentityNumber(identityNumber);
   }

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/PersonDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/PersonDTO.java
@@ -1,0 +1,19 @@
+package fi.oph.otr.api.dto.clerk;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+public record PersonDTO(
+  @NonNull @NotBlank String identityNumber,
+  @NonNull @NotBlank String lastName,
+  @NonNull @NotBlank String firstName,
+  @NonNull @NotBlank String nickName,
+  String street,
+  String postalCode,
+  String town,
+  String country,
+  @NonNull @NotNull Boolean isIndividualised
+) {}

--- a/backend/otr/src/main/java/fi/oph/otr/config/ControllerExceptionAdvice.java
+++ b/backend/otr/src/main/java/fi/oph/otr/config/ControllerExceptionAdvice.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -42,6 +43,14 @@ public class ControllerExceptionAdvice {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<Object> handleHttpMessageNotReadableException(final HttpMessageNotReadableException ex) {
     LOG.error("HttpMessageNotReadableException: " + ex.getMessage());
+    return badRequest();
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<Object> handleMissingServletRequestParameterException(
+    final HttpMessageNotReadableException ex
+  ) {
+    LOG.error("MissingServletRequestParameterException: " + ex.getMessage());
     return badRequest();
   }
 

--- a/backend/otr/src/main/java/fi/oph/otr/config/ControllerExceptionAdvice.java
+++ b/backend/otr/src/main/java/fi/oph/otr/config/ControllerExceptionAdvice.java
@@ -3,6 +3,7 @@ package fi.oph.otr.config;
 import fi.oph.otr.util.exception.APIException;
 import fi.oph.otr.util.exception.APIExceptionType;
 import fi.oph.otr.util.exception.NotFoundException;
+import javax.validation.ConstraintViolationException;
 import net.minidev.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,12 @@ public class ControllerExceptionAdvice {
     final HttpMessageNotReadableException ex
   ) {
     LOG.error("MissingServletRequestParameterException: " + ex.getMessage());
+    return badRequest();
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<Object> handleConstraintViolationException(final ConstraintViolationException ex) {
+    LOG.error("ConstraintViolationException: " + ex.getMessage());
     return badRequest();
   }
 

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApi.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApi.java
@@ -3,9 +3,12 @@ package fi.oph.otr.onr;
 import fi.oph.otr.onr.model.PersonalData;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface OnrOperationApi {
   Map<String, PersonalData> fetchPersonalDatas(List<String> onrIds) throws Exception;
+
+  Optional<PersonalData> findPersonalDataByIdentityNumber(String identityNumber) throws Exception;
 
   String insertPersonalData(PersonalData personalData);
 

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrService.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -32,6 +33,10 @@ public class OnrService {
 
   public Map<String, PersonalData> getCachedPersonalDatas() {
     return Collections.unmodifiableMap(personalDataCache);
+  }
+
+  public Optional<PersonalData> findPersonalDataByIdentityNumber(final String identityNumber) throws Exception {
+    return api.findPersonalDataByIdentityNumber(identityNumber);
   }
 
   public String insertPersonalData(final PersonalData personalData) {

--- a/backend/otr/src/main/java/fi/oph/otr/onr/mock/OnrOperationApiMock.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/mock/OnrOperationApiMock.java
@@ -5,6 +5,7 @@ import fi.oph.otr.onr.model.PersonalData;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 public class OnrOperationApiMock implements OnrOperationApi {
@@ -16,6 +17,67 @@ public class OnrOperationApiMock implements OnrOperationApi {
 
     onrIds.forEach(onrId -> personalDatas.put(onrId, personalDataFactory.create()));
     return personalDatas;
+  }
+
+  @Override
+  public Optional<PersonalData> findPersonalDataByIdentityNumber(final String identityNumber) {
+    final String individualised1 = "090687-913J";
+    final String individualised2 = "170378-966N";
+    final String manuallyCreated1 = "170688-935N";
+    final String manuallyCreated2 = "121094-917M";
+
+    final PersonalData personalData =
+      switch (identityNumber) {
+        case individualised1 -> PersonalData
+          .builder()
+          .lastName("Lehtinen")
+          .firstName("Matti Tauno")
+          .nickName("Matti")
+          .identityNumber(identityNumber)
+          .email("matti.lehtinen@example.invalid")
+          .street("Kajaanintie 123")
+          .postalCode("93600")
+          .town("Kuusamo")
+          .country("FINLAND")
+          .isIndividualised(true)
+          .build();
+        case individualised2 -> PersonalData
+          .builder()
+          .lastName("Mannonen")
+          .firstName("Anna Maria")
+          .nickName("Anna")
+          .identityNumber(identityNumber)
+          .email("anna.mannonen@example.invalid")
+          .street("Tampereentie 234")
+          .postalCode("20100")
+          .town("Turku")
+          .country("SUOMI")
+          .isIndividualised(true)
+          .build();
+        case manuallyCreated1 -> PersonalData
+          .builder()
+          .lastName("Oppija")
+          .firstName("Oona Inkeri")
+          .nickName("Oona")
+          .identityNumber(identityNumber)
+          .email("oona.oppija@example.invalid")
+          .street("Ristikontie 333")
+          .town("Helsinki")
+          .isIndividualised(false)
+          .build();
+        case manuallyCreated2 -> PersonalData
+          .builder()
+          .lastName("Oppija")
+          .firstName("Olli Pekka")
+          .nickName("Olli")
+          .identityNumber(identityNumber)
+          .email("olli.oppija@example.invalid")
+          .isIndividualised(false)
+          .build();
+        default -> null;
+      };
+
+    return Optional.ofNullable(personalData);
   }
 
   @Override

--- a/backend/otr/src/main/java/fi/oph/otr/service/PersonService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/PersonService.java
@@ -1,0 +1,35 @@
+package fi.oph.otr.service;
+
+import fi.oph.otr.api.dto.clerk.PersonDTO;
+import fi.oph.otr.onr.OnrService;
+import java.util.Optional;
+import javax.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PersonService {
+
+  @Resource
+  private final OnrService onrService;
+
+  public Optional<PersonDTO> findPersonByIdentityNumber(final String identityNumber) throws Exception {
+    return onrService
+      .findPersonalDataByIdentityNumber(identityNumber)
+      .map(personalData ->
+        PersonDTO
+          .builder()
+          .identityNumber(personalData.identityNumber())
+          .lastName(personalData.lastName())
+          .firstName(personalData.firstName())
+          .nickName(personalData.nickName())
+          .street(personalData.street())
+          .postalCode(personalData.postalCode())
+          .town(personalData.town())
+          .country(personalData.country())
+          .isIndividualised(personalData.isIndividualised())
+          .build()
+      );
+  }
+}


### PR DESCRIPTION
Toimivaksi testattu yksittäisen henkilön henkilötietojen hakurajapinta ONR:stä. Testaukseen samat jutut kuin listauksenkin kanssa; application.yamlissa konffeista onr päälle ja `username` sekä `password` asetus.

Untuvalla merkittävästi henkilöitä tilapäisillä hetuilla. Täältä käsin voi myös verifioida palautettua dataa ONR:ssä olevaa dataa vasten: https://virkailija.untuvaopintopolku.fi/henkilo-ui/henkilohaku

Myös uusi exception handler lisätty. Tuo palauttaa 400 kun kutsuu person rajapintaa ilman `identityNumber` query parametria. OnrOperationApiMock alla taas neljän eri palautettavan henkilön tiedot eri hetuilla. Noilla voi tulkin luontia kätevästi lokaalisti testailla kun siihen pisteeseen frontin kanssa päästään.