### PR TITLE
AKT(Backend): OPHATKEH-377 mailipohjien päivitys

### DIFF
--- a/backend/akt/src/main/java/fi/oph/akt/service/ContactRequestService.java
+++ b/backend/akt/src/main/java/fi/oph/akt/service/ContactRequestService.java
@@ -116,7 +116,7 @@ public class ContactRequestService {
     final List<Translator> translatorsWithoutEmail = translatorsByExistingEmail.get(false);
 
     sendTranslatorEmails(translatorsWithEmail, contactRequestDTO);
-    sendRequesterEmail(translatorsWithEmail, translatorsWithoutEmail, contactRequestDTO);
+    sendRequesterEmail(translators, contactRequestDTO);
 
     if (!translatorsWithoutEmail.isEmpty()) {
       sendClerkEmail(translatorsWithoutEmail, contactRequestDTO);
@@ -147,19 +147,13 @@ public class ContactRequestService {
     });
   }
 
-  private void sendRequesterEmail(
-    final List<Translator> contactedTranslators,
-    final List<Translator> otherTranslators,
-    final ContactRequestDTO contactRequestDTO
-  ) {
+  private void sendRequesterEmail(final List<Translator> translators, final ContactRequestDTO contactRequestDTO) {
     final String requesterName = getRequesterName(contactRequestDTO);
     final String requesterEmail = getRequesterEmail(contactRequestDTO);
 
     final Map<String, Object> templateParams = Map.of(
-      "contactedTranslators",
-      contactedTranslators.stream().map(Translator::getFullName).sorted().toList(),
-      "otherTranslators",
-      otherTranslators.stream().map(Translator::getFullName).sorted().toList(),
+      "translators",
+      translators.stream().map(Translator::getFullName).sorted().toList(),
       "requesterName",
       getRequesterName(contactRequestDTO),
       "requesterEmail",

--- a/backend/akt/src/main/resources/email-templates/authorisation-expiry.html
+++ b/backend/akt/src/main/resources/email-templates/authorisation-expiry.html
@@ -56,7 +56,7 @@
             Om du inte förnyar din rätt, kan du inte verka som auktoriserad translator och ditt namn tas bort från offentliga registret över auktoriserade translatorer.
         </p>
         <p>
-            Ansökningsblanketten samt rådgivning för ansökningsprocessen för att förnya rätten att verka som auktoriserad translator finns här: <a href="https://www.oph.fi/sv/utbildning-och-examina/ansokan-om-att-fornya-ratten-att-verka-som-auktoriserad-translator">https://www.oph.fi/sv/utbildning-och-examina/ansokan-om-att-fornya-ratten-att-verka-som-auktoriserad-translator</a>
+            Ansökningsblanketten samt rådgivning för ansökningsprocessen för att förnya rätten att verka som auktoriserad translator finns här: <a href="https://www.oph.fi/sv/utbildning-och-examina/ansokan-om-att-fornya-ratten-att-verka-som-auktoriserad-translator">https://www.oph.fi/sv/utbildning-och-examina/ansokan-om-att-fornya-ratten-att-verka-som-auktoriserad-translator</a>. Ansökningsblanketten kan printas ut i slutet på sidan.
         </p>
         <p>
             En ifylld och underskriven ansökningsblankett samt bilagan (utdrag ur befolkningsdatasystemet) skickas per post eller skannad till adressen: Registratur, Utbildningsstyrelsen, PB 380, 00531 Helsingfors eller <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a>

--- a/backend/akt/src/main/resources/email-templates/contact-request-requester.html
+++ b/backend/akt/src/main/resources/email-templates/contact-request-requester.html
@@ -4,28 +4,13 @@
         <p>
             Hei,
         </p>
-        <div th:unless="${contactedTranslators.isEmpty()}">
-            <p>
-                Olet ottanut yhteyttä seuraaviin auktorisoituihin kääntäjiin käännöstoimeksiantoa varten:
-            </p>
-            <ul>
-                <li th:each="name : ${contactedTranslators}">[[${name}]]</li>
-            </ul>
-            <br/>
-        </div>
-
-        <div th:unless="${otherTranslators.isEmpty()}">
-            <p>
-                Seuraaviin kääntäjiin ei voitu ottaa yhteyttä, sillä heidän sähköpostiosoitteensa eivät ole Opetushallituksen tiedossa:
-            </p>
-            <ul>
-                <li th:each="name : ${otherTranslators}">[[${name}]]</li>
-            </ul>
-            <p>
-                Opetushallituksen virkailija pyrkii selvittämään yo. kääntäjien yhteystiedot ja ottaa teihin asian tiimoilta myöhemmin yhteyttä.
-            </p>
-            <br/>
-        </div>
+        <p>
+            Olet ottanut yhteyttä seuraaviin auktorisoituihin kääntäjiin käännöstoimeksiantoa varten:
+        </p>
+        <ul>
+            <li th:each="name : ${translators}">[[${name}]]</li>
+        </ul>
+        <br/>
 
         <p>Tässä jättämäsi viesti sekä yhteystietosi:</p>
 
@@ -52,15 +37,13 @@
         <p>
             Hej,
         </p>
-        <div th:unless="${contactedTranslators.isEmpty()}">
-            <p>
-                Du har kontaktat följande auktoriserade translatorer gällande ett översättningsuppdrag:
-            </p>
-            <ul>
-                <li th:each="name : ${contactedTranslators}">[[${name}]]</li>
-            </ul>
-            <br/>
-        </div>
+        <p>
+            Du har kontaktat följande auktoriserade translatorer gällande ett översättningsuppdrag:
+        </p>
+        <ul>
+            <li th:each="name : ${translators}">[[${name}]]</li>
+        </ul>
+        <br/>
 
         <p>Här ditt meddelande och dina kontaktuppgifter:</p>
 
@@ -87,15 +70,13 @@
         <p>
             Hello,
         </p>
-        <div th:unless="${contactedTranslators.isEmpty()}">
-            <p>
-                You have contacted following authorised translators for translation assignment:
-            </p>
-            <ul>
-                <li th:each="name : ${contactedTranslators}">[[${name}]]</li>
-            </ul>
-            <br/>
-        </div>
+        <p>
+            You have contacted following authorised translators for translation assignment:
+        </p>
+        <ul>
+            <li th:each="name : ${translators}">[[${name}]]</li>
+        </ul>
+        <br/>
 
         <p>Here is your message and contacts:</p>
 

--- a/backend/akt/src/test/java/fi/oph/akt/util/TemplateRendererTest.java
+++ b/backend/akt/src/test/java/fi/oph/akt/util/TemplateRendererTest.java
@@ -75,10 +75,8 @@ class TemplateRendererTest {
   public void testContactRequestRequesterTemplateIsRendered() {
     final String renderedContent = templateRenderer.renderContactRequestRequesterEmailBody(
       Map.of(
-        "contactedTranslators",
+        "translators",
         List.of("Jack Smith", "Mark Davis"),
-        "otherTranslators",
-        List.of("James Moore"),
         "requesterName",
         "John Doe",
         "requesterEmail",
@@ -94,7 +92,6 @@ class TemplateRendererTest {
     assertTrue(renderedContent.contains("<html "));
     assertTrue(renderedContent.contains("Jack Smith"));
     assertTrue(renderedContent.contains("Mark Davis"));
-    assertTrue(renderedContent.contains("James Moore"));
     assertTrue(renderedContent.contains("John Doe"));
     assertTrue(renderedContent.contains("john.doe@unknown.invalid"));
     assertTrue(renderedContent.contains("+358 400 888 777"));


### PR DESCRIPTION
Yhteydenottajalle tulevaan vahvistusmailiin ei ilmeisesti muutoksia haluttu, joten yhdenmukaistin eri kielten versiot. Umpeutumismailista taas puuttui tuo yksi virke ruotsin kielellä, joka suomenkielisestä versiosta jo löytyikin. Ennen mergausta voi halutessa vaihtaa committien nimet vastaamaan tiketin numeroa.

Viety untuvalle jossa voi halutessa testailla.