### PR TITLE
OTR(Backend): OPHOTRKEH-63 skripti testioppijoiden luontiin

### DIFF
--- a/backend/otr/db/4_init.sql
+++ b/backend/otr/db/4_init.sql
@@ -6,13 +6,13 @@ TRUNCATE email CASCADE;
 INSERT INTO interpreter(onr_id, permission_to_publish_email, permission_to_publish_phone, other_contact_information,
                         permission_to_publish_other_contact_information, extra_information)
 SELECT
-  '1.2.246.test-' || i::text,
-  i % 4 <> 0,
+  '1.2.246.562.24.312345000' || lpad(i::text, 2, '0'),
+  i % 9 <> 0,
+  i % 8 <> 0,
+  CASE mod(i, 7) WHEN 0 THEN 'Tulkintie ' || i::text || ', Kokkola' ELSE NULL END,
   i % 3 <> 0,
-  CASE mod(i, 5) WHEN 0 THEN 'Tulkintie ' || i::text || ', Kokkola' ELSE NULL END,
-  i % 2 <> 0,
-  CASE mod(i, 7) WHEN 0 THEN 'Extra ' || i::text ELSE NULL END
-FROM generate_series(1, 200) i;
+  CASE mod(i, 11) WHEN 0 THEN 'Extra ' || i::text ELSE NULL END
+FROM generate_series(1, 53) i;
 
 -- Qualifications
 
@@ -20,7 +20,7 @@ INSERT INTO qualification(interpreter_id, permission_to_publish, examination_typ
                           end_date, diary_number)
 SELECT
   interpreter_id,
-  interpreter_id % 38 <> 0,
+  interpreter_id % 26 <> 0,
   CASE mod(interpreter_id, 3) WHEN 0 THEN 'OTHER' ELSE 'LEGAL_INTERPRETER_EXAM' END,
   'FI',
   langs[mod(interpreter_id, array_length(langs, 1)) + 1],
@@ -28,7 +28,7 @@ SELECT
   '2025-01-01',
   '1234' || interpreter_id::text
 FROM interpreter,
-     (SELECT ('{CS, DA, DE, EL, EN, ES, ET, FR, IS, KO, KTU, LT, MY, NL, NN, PL, PTU, SE, SK, SO, SV, TR, UK, UZ, VKS, ZH}')::text[] AS langs) AS langs;
+     (SELECT ('{CS, DE, EL, ES, ET, FR, IT, KO, KTU, LA, PL, PTU, SE, VKS, ZH}')::text[] AS langs) AS langs;
 
 -- Insert some specific qualifications
 
@@ -39,11 +39,11 @@ SELECT
   TRUE,
   examination_type,
   'FI',
-  'IT',
+  'SV',
   '2018-10-03',
   '2023-10-03'
 FROM qualification
-WHERE interpreter_id % 10 = 0;
+WHERE interpreter_id % 4 = 0;
 
 INSERT INTO qualification(interpreter_id, permission_to_publish, examination_type, from_lang, to_lang, begin_date,
                           end_date)
@@ -52,11 +52,11 @@ SELECT
   TRUE,
   examination_type,
   'FI',
-  'LA',
+  'EN',
   '2019-07-14',
   '2024-06-19'
 FROM qualification
-WHERE interpreter_id % 25 = 0;
+WHERE interpreter_id % 5 = 0;
 
 INSERT INTO qualification(interpreter_id, permission_to_publish, examination_type, from_lang, to_lang, begin_date,
                           end_date)
@@ -69,7 +69,7 @@ SELECT
   '2021-05-08',
   '2026-03-10'
 FROM qualification
-WHERE interpreter_id % 75 = 0;
+WHERE interpreter_id % 40 = 0;
 
 INSERT INTO qualification(interpreter_id, permission_to_publish, examination_type, from_lang, to_lang, begin_date,
                           end_date)
@@ -82,7 +82,7 @@ SELECT
   '2022-04-30',
   '2026-12-31'
 FROM qualification
-WHERE interpreter_id % 198 = 0;
+WHERE interpreter_id % 51 = 0;
 
 INSERT INTO qualification(interpreter_id, permission_to_publish, examination_type, from_lang, to_lang, begin_date,
                           end_date)
@@ -95,7 +95,7 @@ SELECT
   '2019-08-08',
   '2024-09-09'
 FROM qualification
-WHERE interpreter_id % 199 = 0;
+WHERE interpreter_id % 52 = 0;
 
 INSERT INTO qualification(interpreter_id, permission_to_publish, examination_type, from_lang, to_lang, begin_date,
                           end_date)
@@ -108,7 +108,7 @@ SELECT
   '2015-09-17',
   '2020-09-17'
 FROM qualification
-WHERE interpreter_id % 200 = 0;
+WHERE interpreter_id % 53 = 0;
 
 -- Regions
 

--- a/backend/otr/db/onr/0_onr_create_learners.sql
+++ b/backend/otr/db/onr/0_onr_create_learners.sql
@@ -1,0 +1,64 @@
+-- Preliminary script to be run on untuva or pallero `opppijanumerorekisteri` database
+-- This script creates learners defined in backend/otr/db/4_init.sql and should only be run once
+
+-- ONR ids reserved for OTR: 1.2.246.562.24.31234500001 - 1.2.246.562.24.31234500053
+
+-- Create male learners
+
+INSERT INTO henkilo(id, version, etunimet, kutsumanimi, sukunimi, hetu, oidhenkilo)
+SELECT
+    (SELECT MAX(id) FROM henkilo) + i,
+    0,
+    first_names[mod(i, array_length(first_names, 1)) + 1] || ' ' || second_names[mod(i, array_length(second_names, 1)) + 1],
+    first_names[mod(i, array_length(first_names, 1)) + 1],
+    last_names[mod(i, array_length(last_names, 1)) + 1],
+    identity_numbers[mod(i, array_length(identity_numbers, 1)) + 1],
+    '1.2.246.562.24.312345000' || lpad(i::text, 2, '0')
+FROM generate_series(1, 27) AS i,
+    (SELECT ('{Antti, Eero, Ilkka, Jari, Juha, Matti, Pekka, Timo, Iiro, Jukka, Hugo, ' ||
+             'Jaakko, Lasse, Kyösti, Markku, Kristian, Mikael, Nooa, Otto, Olli, ' ||
+             'Aapo}')::text[] AS first_names) AS first_name_table,
+    (SELECT ('{Kalle, Kari, Marko, Mikko, Tapani, Ville, Jesse, Joose, Sakari, Tero, ' ||
+             'Samu, Roope, Panu, Matias, Seppo, Rauno, ' ||
+             'Aapeli}')::text[] AS second_names) AS second_name_table,
+    (SELECT ('{Aaltonen, Alanen, Eskola, Hakala, Heikkinen, Heinonen, Hiltunen, Hirvonen, ' ||
+             'Hämäläinen, Kallio, Karjalainen, Kinnunen, Korhonen, Koskinen, Laakso, ' ||
+             'Lahtinen, Laine, Lehtonen, Leinonen, Leppänen, Manninen, Mattila, Mäkinen, ' ||
+             'Nieminen, Noronen, Ojala, Paavola, Pitkänen, Räsänen, Saarinen, Salo, ' ||
+             'Salonen, Toivonen, Tuominen, Turunen, Valtonen, Virtanen, ' ||
+             'Väisänen}')::text[] AS last_names) AS last_name_table,
+    (SELECT ('{290473-991R, 220468-941A, 261159-9052, 291153-951X, 280770-9137, 070511-947X, ' ||
+             '101018-9615, 090108-921C, 020353-929B, 300333-933C, 181101-955J, 300356-9850, ' ||
+             '050595-9392, 260673-9835, 291054-933T, 120436-947T, 290813-971U, 190307-9792, ' ||
+             '290758-9831, 140387-9418, 290678-9090, 220911-937H, 290196-903D, 220657-993S, ' ||
+             '291116-903U, 080912-955A, 240206-905U}')::text[] AS identity_numbers) AS identity_number_table;
+
+-- Create female learners
+
+INSERT INTO henkilo(id, version, etunimet, kutsumanimi, sukunimi, hetu, oidhenkilo)
+SELECT
+        (SELECT MAX(id) FROM henkilo) + i - 27,
+        0,
+        first_names[mod(i, array_length(first_names, 1)) + 1] || ' ' || second_names[mod(i, array_length(second_names, 1)) + 1],
+        first_names[mod(i, array_length(first_names, 1)) + 1],
+        last_names[mod(i, array_length(last_names, 1)) + 1],
+        identity_numbers[mod(i, array_length(identity_numbers, 1)) + 1],
+        '1.2.246.562.24.312345000' || lpad(i::text, 2, '0')
+FROM generate_series(28, 53) AS i,
+     (SELECT ('{Anneli, Ella, Hanna, Iiris, Liisa, Maria, Ninni, Viivi, Sointu, ' ||
+              'Ulla, Varpu, Raili, Neea, Noora, Mirka, Oona, Jonna, Jaana, Katja, ' ||
+              'Jenni, Reija}')::text[] AS first_names) AS first_name_table,
+     (SELECT ('{Anna, Iida, Kerttu, Kristiina, Marjatta, Ronja, Sara, Helena, ' ||
+              'Aino, Erika, Emmi, Aada, Eveliina, Nanna, Olga, Inkeri, ' ||
+              'Petra}')::text[] AS second_names) AS second_name_table,
+     (SELECT ('{Aaltonen, Alanen, Eskola, Hakala, Heikkinen, Heinonen, Hiltunen, Hirvonen, ' ||
+              'Hämäläinen, Kallio, Karjalainen, Kinnunen, Korhonen, Koskinen, Laakso, ' ||
+              'Lahtinen, Laine, Lehtonen, Leinonen, Leppänen, Manninen, Mattila, Mäkinen, ' ||
+              'Nieminen, Noronen, Ojala, Paavola, Pitkänen, Räsänen, Saarinen, Salo, ' ||
+              'Salonen, Toivonen, Tuominen, Turunen, Valtonen, Virtanen, ' ||
+              'Väisänen}')::text[] AS last_names) AS last_name_table,
+     (SELECT ('{020794-9240, 100822-996P, 170461-930X, 030804-976W, 050905-956L, 051103-962W, ' ||
+              '110169-952D, 091181-910X, 171112-948H, 160689-9968, 300572-976E, 240733-960L, ' ||
+              '291005-942E, 280973-976M, 240267-938M, 290795-9384, 110622-994N, 100572-948M, ' ||
+              '291170-984C, 171017-9546, 200284-970F, 301091-9640, 210701-9481, 290757-954U, ' ||
+              '070635-998K, 080219-990L}')::text[] AS identity_numbers) AS identity_number_table;

--- a/backend/otr/db/onr/1_onr_init_contact_details.sql
+++ b/backend/otr/db/onr/1_onr_init_contact_details.sql
@@ -1,0 +1,96 @@
+-- Init script to be run on untuva or pallero `opppijanumerorekisteri` database
+-- This script initialises ONR with contact details for to the learners created in 0_onr_create_learners.sql
+
+-- ONR ids reserved for OTR: 1.2.246.562.24.31234500001 - 1.2.246.562.24.31234500053
+
+-- Delete OTR contact details data
+
+DELETE FROM yhteystiedot WHERE yhteystiedotryhma_id IN (
+    SELECT id
+    FROM yhteystiedotryhma
+    WHERE ryhmakuvaus = 'yhteystietotyyppi13' AND ryhma_alkuperatieto = 'alkupera7'
+);
+
+DELETE FROM yhteystiedotryhma
+WHERE ryhmakuvaus = 'yhteystietotyyppi13' AND ryhma_alkuperatieto = 'alkupera7';
+
+
+-- Insert OTR contact details group for each learner
+
+INSERT INTO yhteystiedotryhma(id, version, ryhmakuvaus, ryhma_alkuperatieto, henkilo_id)
+SELECT
+    (SELECT MAX(id) FROM yhteystiedotryhma) + i,
+    0,
+    'yhteystietotyyppi13',
+    'alkupera7',
+    (SELECT id FROM henkilo WHERE oidhenkilo = '1.2.246.562.24.312345000' || lpad(i::text, 2, '0'))
+FROM generate_series(1, 53) AS i;
+
+-- Insert contact details for created OTR contact details groups
+
+INSERT INTO yhteystiedot(id, version, yhteystieto_tyyppi, yhteystieto_arvo, yhteystiedotryhma_id)
+SELECT
+    (SELECT MAX(id) FROM yhteystiedot) + i,
+    0,
+    'YHTEYSTIETO_SAHKOPOSTI',
+    (SELECT LOWER(kutsumanimi) || '.' || LOWER(sukunimi) || '@oikeustulkki.invalid' FROM henkilo WHERE oidhenkilo = '1.2.246.562.24.312345000' || lpad(i::text, 2, '0')),
+    (SELECT yr.id FROM yhteystiedotryhma yr, henkilo h WHERE yr.henkilo_id = h.id AND h.oidhenkilo = '1.2.246.562.24.312345000' || lpad(i::text, 2, '0'))
+FROM generate_series(1, 53) AS i;
+
+INSERT INTO yhteystiedot(id, version, yhteystieto_tyyppi, yhteystieto_arvo, yhteystiedotryhma_id)
+SELECT
+    (SELECT MAX(id) FROM yhteystiedot) + i,
+    0,
+    'YHTEYSTIETO_PUHELINNUMERO',
+    '+35840' || (1000000 + i)::text,
+    (SELECT yr.id FROM yhteystiedotryhma yr, henkilo h WHERE yr.henkilo_id = h.id AND h.oidhenkilo = '1.2.246.562.24.312345000' || lpad(i::text, 2, '0'))
+FROM generate_series(1, 53) AS i
+WHERE mod(i, 5) <> 0;
+
+INSERT INTO yhteystiedot(id, version, yhteystieto_tyyppi, yhteystieto_arvo, yhteystiedotryhma_id)
+SELECT
+    (SELECT MAX(id) FROM yhteystiedot) + i,
+    0,
+    'YHTEYSTIETO_KATUOSOITE',
+    street[mod(i, array_length(street, 1)) + 1],
+    (SELECT yr.id FROM yhteystiedotryhma yr, henkilo h WHERE yr.henkilo_id = h.id AND h.oidhenkilo = '1.2.246.562.24.312345000' || lpad(i::text, 2, '0'))
+FROM generate_series(1, 53) AS i,
+     (SELECT ('{Malminkatu 1, Runebergintie 2, Sibeliuksenkuja 3, Veturitie 4, ' ||
+              'Pirkkolantie 123}')::text[] AS street) AS street_table
+WHERE mod(i, 6) = 0;
+
+INSERT INTO yhteystiedot(id, version, yhteystieto_tyyppi, yhteystieto_arvo, yhteystiedotryhma_id)
+SELECT
+    (SELECT MAX(id) FROM yhteystiedot) + i,
+    0,
+    'YHTEYSTIETO_POSTINUMERO',
+    postal_code[mod(i, array_length(postal_code, 1)) + 1],
+    (SELECT yr.id FROM yhteystiedotryhma yr, henkilo h WHERE yr.henkilo_id = h.id AND h.oidhenkilo = '1.2.246.562.24.312345000' || lpad(i::text, 2, '0'))
+FROM generate_series(1, 53) AS i,
+     (SELECT ('{00100, 01200, 06100, 13500, 31600, 48600, ' ||
+              '54460}')::text[] AS postal_code) AS postal_code_table
+WHERE mod(i, 3) = 0;
+
+INSERT INTO yhteystiedot(id, version, yhteystieto_tyyppi, yhteystieto_arvo, yhteystiedotryhma_id)
+SELECT
+    (SELECT MAX(id) FROM yhteystiedot) + i,
+    0,
+    'YHTEYSTIETO_KAUPUNKI',
+    town[mod(i, array_length(town, 1)) + 1],
+    (SELECT yr.id FROM yhteystiedotryhma yr, henkilo h WHERE yr.henkilo_id = h.id AND h.oidhenkilo = '1.2.246.562.24.312345000' || lpad(i::text, 2, '0'))
+FROM generate_series(1, 53) AS i,
+     (SELECT ('{Helsinki, Turku, Hämeenlinna, Kuopio, Lahti, Porvoo, Vantaa, Järvenpää, ' ||
+              'Kouvola, Tampere, Oulu, Rovaniemi, Kajaani, Joensuu, Uusikaupunki, Kuopio, ' ||
+              'Kotka}')::text[] AS town) AS town_table
+WHERE mod(i, 2) = 0;
+
+INSERT INTO yhteystiedot(id, version, yhteystieto_tyyppi, yhteystieto_arvo, yhteystiedotryhma_id)
+SELECT
+    (SELECT MAX(id) FROM yhteystiedot) + i,
+    0,
+    'YHTEYSTIETO_MAA',
+    country[mod(i, array_length(country, 1)) + 1],
+    (SELECT yr.id FROM yhteystiedotryhma yr, henkilo h WHERE yr.henkilo_id = h.id AND h.oidhenkilo = '1.2.246.562.24.312345000' || lpad(i::text, 2, '0'))
+FROM generate_series(1, 53) AS i,
+     (SELECT ('{Suomi, suomi, SUOMI, Finland, FINLAND}')::text[] AS country) AS country_table
+WHERE mod(i, 4) = 0;

--- a/backend/otr/db/onr/2_onr_delete_learners.sql
+++ b/backend/otr/db/onr/2_onr_delete_learners.sql
@@ -1,0 +1,19 @@
+-- Sql script for deleting learners created in 0_onr_create_learners.sql if needed
+-- Running this script requires deletion of OTR contact details data first as done in 1_onr_init_contact_details.sql
+
+-- Code commented out so that it's not run by accident
+
+-- DELETE FROM yksilointivirhe WHERE henkilo_id IN (
+--    SELECT id
+--    FROM henkilo
+--    WHERE oidhenkilo IN (
+--        SELECT '1.2.246.562.24.312345000' || lpad(i::text, 2, '0')
+--        FROM generate_series(1, 53) AS i
+--    )
+--);
+
+--DELETE FROM henkilo
+--WHERE oidhenkilo IN (
+--    SELECT '1.2.246.562.24.312345000' || lpad(i::text, 2, '0')
+--    FROM generate_series(1, 53) AS i
+--);

--- a/docs/otr.md
+++ b/docs/otr.md
@@ -59,6 +59,25 @@ Set `OTR_UNSECURE=true` environment variable as shown [here](../README.md#develo
 
 &nbsp;
 
+#### Initialising cloud databases
+
+Under `backend/otr/db` directory there's `4_init.sql` script for initialising interpreters
+in cloud test environment (untuva / pallero). Under `backend/otr/db/onr` there are separate
+scripts for initialsing respective learners and their contact details in `ONR`
+(oppijanumerorekisteri).
+
+Script `0_onr_create_learners.sql` should be run only once just to create learners corresponding
+to onr ids of interpreters initialised to OTR database. Script `1_onr_init_contact_details.sql`
+deletes and initialises OTR contact details for learners. It can be run on cloud test environment
+database whenever needed.
+
+If there is a case where the learners need to be deleted and re-initialised for some reason,
+`2_onr_delete_learners.sql` contains a commented out solution for that. If the learners have
+been updated via some means after their creation outside from the APIs we use, there's a
+chance deletion of learners fails due to some foreign key constraint.
+
+&nbsp;
+
 ## Frontend
 
 ### Build and Run


### PR DESCRIPTION
Lisätty skriptit
1.  testioppijoiden luontiin ONR:ään
2. niiden yhteystietojen alustamiseen
3. testioppijoiden poistoon jos tarve on

Päivitetty 4_init.sql siten, että täällä luotujen tulkkien onr id:t vastaavat oppijanumerorekisteriin populoitavien henkilöiden id:eitä. Testioppijoiden luonnissa määritellyt tilapäiset hetut miehiä ja naisia varten haettu enemmän ja vähemmän brute forcella testaten, onko tämä hetu vapaana tai onko tämä. Kaikki oheiset hetut käyttämättömiä (ainakin toistaiseksi) niin untuvalla kuin pallerollakin. Untuvaan tosin nuo henkilöt yhteystietoineen näiden skriptien pohjilta jo alustinkin.
