### PR TITLE
AKT(Backend): OPHAKTKEH-372 yhteydenottopyyntöjen tuhoaminen 6kk pyynnön jälkeen

### DIFF
--- a/backend/akt/src/main/java/fi/oph/akt/repository/ContactRequestRepository.java
+++ b/backend/akt/src/main/java/fi/oph/akt/repository/ContactRequestRepository.java
@@ -1,8 +1,14 @@
 package fi.oph.akt.repository;
 
 import fi.oph.akt.model.ContactRequest;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ContactRequestRepository extends JpaRepository<ContactRequest, Long> {}
+public interface ContactRequestRepository extends JpaRepository<ContactRequest, Long> {
+  @Query("SELECT cr FROM ContactRequest cr WHERE cr.createdAt < ?1")
+  List<ContactRequest> findObsoleteContactRequests(LocalDateTime createdBefore);
+}

--- a/backend/akt/src/main/java/fi/oph/akt/repository/EmailRepository.java
+++ b/backend/akt/src/main/java/fi/oph/akt/repository/EmailRepository.java
@@ -1,6 +1,8 @@
 package fi.oph.akt.repository;
 
 import fi.oph.akt.model.Email;
+import fi.oph.akt.model.EmailType;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +13,7 @@ import org.springframework.stereotype.Repository;
 public interface EmailRepository extends JpaRepository<Email, Long> {
   @Query("SELECT e.id FROM Email e WHERE e.sentAt IS NULL ORDER BY e.modifiedAt asc")
   List<Long> findEmailsToSend(PageRequest pageRequest);
+
+  @Query("SELECT e FROM Email e WHERE e.createdAt < ?1 AND e.emailType IN ?2")
+  List<Email> findObsoleteEmails(LocalDateTime createdBefore, List<EmailType> emailTypes);
 }

--- a/backend/akt/src/main/java/fi/oph/akt/scheduled/EmailScheduledSending.java
+++ b/backend/akt/src/main/java/fi/oph/akt/scheduled/EmailScheduledSending.java
@@ -1,6 +1,7 @@
-package fi.oph.akt.service.email;
+package fi.oph.akt.scheduled;
 
 import fi.oph.akt.repository.EmailRepository;
+import fi.oph.akt.service.email.EmailService;
 import fi.oph.akt.util.SchedulingUtil;
 import java.util.List;
 import javax.annotation.Resource;

--- a/backend/akt/src/main/java/fi/oph/akt/scheduled/ObsoleteContactRequestsDestroyer.java
+++ b/backend/akt/src/main/java/fi/oph/akt/scheduled/ObsoleteContactRequestsDestroyer.java
@@ -1,0 +1,40 @@
+package fi.oph.akt.scheduled;
+
+import fi.oph.akt.service.ContactRequestService;
+import fi.oph.akt.util.SchedulingUtil;
+import java.time.LocalDateTime;
+import javax.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ObsoleteContactRequestsDestroyer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ObsoleteContactRequestsDestroyer.class);
+
+  private static final String LOCK_AT_LEAST = "PT0S";
+
+  private static final String LOCK_AT_MOST = "PT1H";
+
+  @Resource
+  private final ContactRequestService contactRequestService;
+
+  @Scheduled(cron = "0 0 4 * * *")
+  @SchedulerLock(name = "destroyObsoleteContactRequests", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
+  public void destroyObsoleteContactRequests() {
+    SchedulingUtil.runWithScheduledUser(() -> {
+      LOG.info("destroyObsoleteContactRequests");
+
+      try {
+        contactRequestService.destroyObsoleteContactRequests(LocalDateTime.now().minusMonths(6));
+      } catch (Exception e) {
+        LOG.error("Destroying obsolete contact requests failed", e);
+      }
+    });
+  }
+}

--- a/backend/akt/src/test/java/fi/oph/akt/Factory.java
+++ b/backend/akt/src/test/java/fi/oph/akt/Factory.java
@@ -3,6 +3,8 @@ package fi.oph.akt;
 import fi.oph.akt.model.Authorisation;
 import fi.oph.akt.model.AuthorisationBasis;
 import fi.oph.akt.model.AuthorisationTermReminder;
+import fi.oph.akt.model.ContactRequest;
+import fi.oph.akt.model.ContactRequestTranslator;
 import fi.oph.akt.model.Email;
 import fi.oph.akt.model.EmailType;
 import fi.oph.akt.model.ExaminationDate;
@@ -116,5 +118,31 @@ public class Factory {
     reminder.setEmail(email);
 
     return reminder;
+  }
+
+  public static ContactRequest contactRequest() {
+    final ContactRequest contactRequest = new ContactRequest();
+    contactRequest.setFirstName("Anne");
+    contactRequest.setLastName("Aardvark");
+    contactRequest.setEmail("anne.aardvark@example.invalid");
+    contactRequest.setMessage("Test message");
+    contactRequest.setFromLang("FI");
+    contactRequest.setToLang("EN");
+
+    return contactRequest;
+  }
+
+  public static ContactRequestTranslator contactRequestTranslator(
+    final Translator translator,
+    final ContactRequest contactRequest
+  ) {
+    final ContactRequestTranslator contactRequestTranslator = new ContactRequestTranslator();
+    translator.getContactRequestTranslators().add(contactRequestTranslator);
+    contactRequest.getContactRequestTranslators().add(contactRequestTranslator);
+
+    contactRequestTranslator.setTranslator(translator);
+    contactRequestTranslator.setContactRequest(contactRequest);
+
+    return contactRequestTranslator;
   }
 }

--- a/backend/akt/src/test/java/fi/oph/akt/scheduled/EmailScheduledSendingTest.java
+++ b/backend/akt/src/test/java/fi/oph/akt/scheduled/EmailScheduledSendingTest.java
@@ -1,4 +1,4 @@
-package fi.oph.akt.service.email;
+package fi.oph.akt.scheduled;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -9,6 +9,7 @@ import fi.oph.akt.Factory;
 import fi.oph.akt.model.Email;
 import fi.oph.akt.model.EmailType;
 import fi.oph.akt.repository.EmailRepository;
+import fi.oph.akt.service.email.EmailService;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;

--- a/backend/akt/src/test/java/fi/oph/akt/scheduled/ExpiringAuthorisationsEmailCreatorTest.java
+++ b/backend/akt/src/test/java/fi/oph/akt/scheduled/ExpiringAuthorisationsEmailCreatorTest.java
@@ -1,4 +1,4 @@
-package fi.oph.akt.service.email;
+package fi.oph.akt.scheduled;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,6 +14,7 @@ import fi.oph.akt.model.EmailType;
 import fi.oph.akt.model.MeetingDate;
 import fi.oph.akt.model.Translator;
 import fi.oph.akt.repository.AuthorisationRepository;
+import fi.oph.akt.service.email.ClerkEmailService;
 import java.time.LocalDate;
 import java.util.List;
 import javax.annotation.Resource;


### PR DESCRIPTION
Tämän koodilogiikan testaaminen on nyt vähän haastavaa. BaseEntity luokan `@PrePersist` pakottaa createdAt-aikaleimat modeleille ja niitä ei pysty tällä hetkellä muuttamaan. Jonkinmoisia testejä pyrin väsäillä ja kolmessa jälkimmäisessä commitissa jokaisessa vähän eri ajatusmalli testien suhteen.

Yhtenä vaihtoehtona stackoverflowssa ehdotetaan kellon tuomista Beaninä, jolloin tuota tulisi hyödyntää myös BaseEntityn alla. Miten sitten toimisi ja onko tällainen järkevää on taas toinen juttu.

Tätä pitäisi vielä manuaalisesti testailla ja miettiä mitä noiden testien osalta tekee ennen kuin harkitsee mergausta.