### PR TITLE
OTR(Backend): OPHOTRKEH-92 personal data update implementation

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/api/clerk/ClerkInterpreterController.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/clerk/ClerkInterpreterController.java
@@ -8,11 +8,8 @@ import fi.oph.otr.api.dto.clerk.modify.ClerkInterpreterUpdateDTO;
 import fi.oph.otr.api.dto.clerk.modify.ClerkQualificationCreateDTO;
 import fi.oph.otr.api.dto.clerk.modify.ClerkQualificationUpdateDTO;
 import fi.oph.otr.service.ClerkInterpreterService;
-import fi.oph.otr.service.LanguageService;
-import fi.oph.otr.service.RegionService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
-import java.util.Set;
 import javax.annotation.Resource;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -35,23 +32,7 @@ public class ClerkInterpreterController {
   private static final String TAG_QUALIFICATION = "Qualification API";
 
   @Resource
-  private LanguageService languageService;
-
-  @Resource
-  private RegionService regionService;
-
-  @Resource
   private ClerkInterpreterService clerkInterpreterService;
-
-  @GetMapping(path = "/lang-codes")
-  public Set<String> listKoodistoLangCodes() {
-    return languageService.listKoodistoCodes();
-  }
-
-  @GetMapping(path = "/region-codes")
-  public Set<String> listKoodistoRegionCodes() {
-    return regionService.listKoodistoCodes();
-  }
 
   // INTERPRETER
 
@@ -64,7 +45,8 @@ public class ClerkInterpreterController {
   @Operation(tags = TAG_INTERPRETER, summary = "Create new interpreter")
   @PostMapping(consumes = APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.CREATED)
-  public ClerkInterpreterDTO createInterpreter(@RequestBody @Valid final ClerkInterpreterCreateDTO dto) {
+  public ClerkInterpreterDTO createInterpreter(@RequestBody @Valid final ClerkInterpreterCreateDTO dto)
+    throws Exception {
     return clerkInterpreterService.createInterpreter(dto);
   }
 
@@ -76,7 +58,8 @@ public class ClerkInterpreterController {
 
   @Operation(tags = TAG_INTERPRETER, summary = "Update interpreter")
   @PutMapping(consumes = APPLICATION_JSON_VALUE)
-  public ClerkInterpreterDTO updateInterpreter(@RequestBody @Valid final ClerkInterpreterUpdateDTO dto) {
+  public ClerkInterpreterDTO updateInterpreter(@RequestBody @Valid final ClerkInterpreterUpdateDTO dto)
+    throws Exception {
     return clerkInterpreterService.updateInterpreter(dto);
   }
 

--- a/backend/otr/src/main/java/fi/oph/otr/onr/ContactDetailsUtil.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/ContactDetailsUtil.java
@@ -15,11 +15,15 @@ import static java.util.Comparator.nullsLast;
 
 import fi.oph.otr.onr.dto.ContactDetailsDTO;
 import fi.oph.otr.onr.dto.ContactDetailsGroupDTO;
+import fi.oph.otr.onr.dto.ContactDetailsGroupSource;
 import fi.oph.otr.onr.dto.ContactDetailsGroupType;
 import fi.oph.otr.onr.dto.ContactDetailsType;
+import fi.oph.otr.onr.model.PersonalData;
 import fi.oph.otr.util.CustomOrderComparator;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ContactDetailsUtil {
@@ -81,5 +85,37 @@ public class ContactDetailsUtil {
       .map(ContactDetailsDTO::getValue)
       .findFirst()
       .orElse(null);
+  }
+
+  public static ContactDetailsGroupDTO createOtrContactDetailsGroup(final PersonalData personalData) {
+    final Set<ContactDetailsType> otrContactDetailsTypes = Set.of(
+      ContactDetailsType.EMAIL,
+      ContactDetailsType.PHONE_NUMBER
+    );
+
+    final Set<ContactDetailsDTO> contactDetailsSet = Stream
+      .of(
+        createContactDetailsDTO(ContactDetailsType.EMAIL, personalData.getEmail()),
+        createContactDetailsDTO(ContactDetailsType.PHONE_NUMBER, personalData.getPhoneNumber()),
+        createContactDetailsDTO(ContactDetailsType.STREET, personalData.getStreet()),
+        createContactDetailsDTO(ContactDetailsType.POSTAL_CODE, personalData.getPostalCode()),
+        createContactDetailsDTO(ContactDetailsType.TOWN, personalData.getTown()),
+        createContactDetailsDTO(ContactDetailsType.COUNTRY, personalData.getCountry())
+      )
+      .filter(dto -> !personalData.getIndividualised() || otrContactDetailsTypes.contains(dto.getType()))
+      .collect(Collectors.toSet());
+
+    final ContactDetailsGroupDTO contactDetailsGroupDTO = new ContactDetailsGroupDTO();
+    contactDetailsGroupDTO.setType(ContactDetailsGroupType.OTR_OSOITE);
+    contactDetailsGroupDTO.setSource(ContactDetailsGroupSource.OTR);
+    contactDetailsGroupDTO.setContactDetailsSet(contactDetailsSet);
+    return contactDetailsGroupDTO;
+  }
+
+  private static ContactDetailsDTO createContactDetailsDTO(final ContactDetailsType type, final String value) {
+    final ContactDetailsDTO contactDetailsDTO = new ContactDetailsDTO();
+    contactDetailsDTO.setType(type);
+    contactDetailsDTO.setValue(value);
+    return contactDetailsDTO;
   }
 }

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApi.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApi.java
@@ -12,5 +12,5 @@ public interface OnrOperationApi {
 
   String insertPersonalData(PersonalData personalData);
 
-  void updatePersonalData(PersonalData personalData);
+  void updatePersonalData(PersonalData personalData) throws Exception;
 }

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
@@ -110,10 +110,31 @@ public class OnrOperationApiImpl implements OnrOperationApi {
     throw new NotImplementedException();
   }
 
-  // TODO: update existing personal data in ONR
   @Override
-  public void updatePersonalData(final PersonalData personalData) {
-    throw new NotImplementedException();
+  public void updatePersonalData(final PersonalData personalData) throws Exception {
+    final List<ContactDetailsGroupDTO> contactDetailsGroups = List.of(
+      ContactDetailsUtil.createOtrContactDetailsGroup(personalData)
+    );
+    final PersonalDataDTO personalDataDTO = new PersonalDataDTO();
+    personalDataDTO.setOnrId(personalData.getOnrId());
+    personalDataDTO.setLastName(personalData.getLastName());
+    personalDataDTO.setFirstName(personalData.getFirstName());
+    personalDataDTO.setNickName(personalData.getNickName());
+    personalDataDTO.setIdentityNumber(personalData.getIdentityNumber());
+    personalDataDTO.setIndividualised(personalData.getIndividualised());
+    personalDataDTO.setContactDetailsGroups(contactDetailsGroups);
+
+    final Request request = defaultRequestBuilder()
+      .setUrl(onrServiceUrl + "/henkilo")
+      .setMethod(Methods.PUT)
+      .setBody(OBJECT_MAPPER.writeValueAsString(personalDataDTO))
+      .build();
+
+    final Response response = onrClient.executeBlocking(request);
+
+    if (response.getStatusCode() != HttpStatus.OK.value()) {
+      throw new RuntimeException("ONR service returned unexpected status code: " + response.getStatusCode());
+    }
   }
 
   private RequestBuilder defaultRequestBuilder() {

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
@@ -112,17 +112,7 @@ public class OnrOperationApiImpl implements OnrOperationApi {
 
   @Override
   public void updatePersonalData(final PersonalData personalData) throws Exception {
-    final List<ContactDetailsGroupDTO> contactDetailsGroups = List.of(
-      ContactDetailsUtil.createOtrContactDetailsGroup(personalData)
-    );
-    final PersonalDataDTO personalDataDTO = new PersonalDataDTO();
-    personalDataDTO.setOnrId(personalData.getOnrId());
-    personalDataDTO.setLastName(personalData.getLastName());
-    personalDataDTO.setFirstName(personalData.getFirstName());
-    personalDataDTO.setNickName(personalData.getNickName());
-    personalDataDTO.setIdentityNumber(personalData.getIdentityNumber());
-    personalDataDTO.setIndividualised(personalData.getIndividualised());
-    personalDataDTO.setContactDetailsGroups(contactDetailsGroups);
+    final PersonalDataDTO personalDataDTO = createPersonalDataDTO(personalData);
 
     final Request request = defaultRequestBuilder()
       .setUrl(onrServiceUrl + "/henkilo")
@@ -135,6 +125,21 @@ public class OnrOperationApiImpl implements OnrOperationApi {
     if (response.getStatusCode() != HttpStatus.OK.value()) {
       throw new RuntimeException("ONR service returned unexpected status code: " + response.getStatusCode());
     }
+  }
+
+  static PersonalDataDTO createPersonalDataDTO(final PersonalData personalData) {
+    final List<ContactDetailsGroupDTO> contactDetailsGroups = List.of(
+      ContactDetailsUtil.createOtrContactDetailsGroup(personalData)
+    );
+    final PersonalDataDTO personalDataDTO = new PersonalDataDTO();
+    personalDataDTO.setOnrId(personalData.getOnrId());
+    personalDataDTO.setLastName(personalData.getLastName());
+    personalDataDTO.setFirstName(personalData.getFirstName());
+    personalDataDTO.setNickName(personalData.getNickName());
+    personalDataDTO.setIdentityNumber(personalData.getIdentityNumber());
+    personalDataDTO.setIndividualised(personalData.getIndividualised());
+    personalDataDTO.setContactDetailsGroups(contactDetailsGroups);
+    return personalDataDTO;
   }
 
   private RequestBuilder defaultRequestBuilder() {

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrService.java
@@ -63,7 +63,7 @@ public class OnrService {
     return onrId;
   }
 
-  public void updatePersonalData(final PersonalData personalData) {
+  public void updatePersonalData(final PersonalData personalData) throws Exception {
     personalData.assertOnrUpdatePossible();
     api.updatePersonalData(personalData);
     personalDataCache.put(personalData.getOnrId(), personalData);

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsDTO.java
@@ -2,8 +2,10 @@ package fi.oph.otr.onr.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class ContactDetailsDTO {
 
   @JsonProperty("yhteystietoTyyppi")

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupDTO.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Set;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ContactDetailsGroupDTO {
 

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/PersonalDataDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/PersonalDataDTO.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PersonalDataDTO {
 

--- a/backend/otr/src/main/java/fi/oph/otr/service/ClerkInterpreterService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/ClerkInterpreterService.java
@@ -141,7 +141,7 @@ public class ClerkInterpreterService {
   }
 
   @Transactional
-  public ClerkInterpreterDTO createInterpreter(final ClerkInterpreterCreateDTO dto) {
+  public ClerkInterpreterDTO createInterpreter(final ClerkInterpreterCreateDTO dto) throws Exception {
     validateRegions(dto);
     dto.qualifications().forEach(this::validateLanguagePair);
 
@@ -263,7 +263,7 @@ public class ClerkInterpreterService {
   }
 
   @Transactional
-  public ClerkInterpreterDTO updateInterpreter(final ClerkInterpreterUpdateDTO dto) {
+  public ClerkInterpreterDTO updateInterpreter(final ClerkInterpreterUpdateDTO dto) throws Exception {
     validateRegions(dto);
 
     final Interpreter interpreter = interpreterRepository.getReferenceById(dto.id());

--- a/backend/otr/src/test/java/fi/oph/otr/onr/OnrOperationApiImplTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/onr/OnrOperationApiImplTest.java
@@ -1,7 +1,9 @@
 package fi.oph.otr.onr;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import fi.oph.otr.onr.dto.ContactDetailsDTO;
 import fi.oph.otr.onr.dto.ContactDetailsGroupDTO;
@@ -22,23 +24,49 @@ class OnrOperationApiImplTest {
     final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
 
     assertDtoMatchesDefaultData(dto);
+    assertTrue(dto.getIndividualised());
+
     final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
     assertEquals(2, contactDetailsSet.size());
-    assertEquals("e@mail", findByType(contactDetailsSet, ContactDetailsType.EMAIL).getValue());
-    assertNull(findByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER).getValue());
+    assertEquals("e@mail", findValueByType(contactDetailsSet, ContactDetailsType.EMAIL));
+    assertNull(findValueByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER));
   }
 
   @Test
-  void testCreatePersonalDataDTO_IndividualisedWithPHone() {
+  void testCreatePersonalDataDTO_IndividualisedWithPhone() {
     final PersonalData personalData = defaultData().email("e@mail").individualised(true).phoneNumber("040404").build();
 
     final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
 
     assertDtoMatchesDefaultData(dto);
+    assertTrue(dto.getIndividualised());
+
     final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
     assertEquals(2, contactDetailsSet.size());
-    assertEquals("e@mail", findByType(contactDetailsSet, ContactDetailsType.EMAIL).getValue());
-    assertEquals("040404", findByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER).getValue());
+    assertEquals("e@mail", findValueByType(contactDetailsSet, ContactDetailsType.EMAIL));
+    assertEquals("040404", findValueByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER));
+  }
+
+  @Test
+  void testCreatePersonalDataDTO_IndividualisedAllOtherDetails() {
+    final PersonalData personalData = defaultData()
+      .email("e@mail")
+      .individualised(true)
+      .phoneNumber("040404")
+      .street("Katu 1")
+      .postalCode("12321")
+      .town("Taajama")
+      .country("Maa")
+      .build();
+    final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
+
+    assertDtoMatchesDefaultData(dto);
+    assertTrue(dto.getIndividualised());
+
+    final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
+    assertEquals(2, contactDetailsSet.size());
+    assertEquals("e@mail", findValueByType(contactDetailsSet, ContactDetailsType.EMAIL));
+    assertEquals("040404", findValueByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER));
   }
 
   @Test
@@ -48,14 +76,16 @@ class OnrOperationApiImplTest {
     final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
 
     assertDtoMatchesDefaultData(dto);
+    assertFalse(dto.getIndividualised());
+
     final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
     assertEquals(6, contactDetailsSet.size());
-    assertEquals("e@mail", findByType(contactDetailsSet, ContactDetailsType.EMAIL).getValue());
-    assertNull(findByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER).getValue());
-    assertNull(findByType(contactDetailsSet, ContactDetailsType.STREET).getValue());
-    assertNull(findByType(contactDetailsSet, ContactDetailsType.POSTAL_CODE).getValue());
-    assertNull(findByType(contactDetailsSet, ContactDetailsType.TOWN).getValue());
-    assertNull(findByType(contactDetailsSet, ContactDetailsType.COUNTRY).getValue());
+    assertEquals("e@mail", findValueByType(contactDetailsSet, ContactDetailsType.EMAIL));
+    assertNull(findValueByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER));
+    assertNull(findValueByType(contactDetailsSet, ContactDetailsType.STREET));
+    assertNull(findValueByType(contactDetailsSet, ContactDetailsType.POSTAL_CODE));
+    assertNull(findValueByType(contactDetailsSet, ContactDetailsType.TOWN));
+    assertNull(findValueByType(contactDetailsSet, ContactDetailsType.COUNTRY));
   }
 
   @Test
@@ -72,14 +102,16 @@ class OnrOperationApiImplTest {
     final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
 
     assertDtoMatchesDefaultData(dto);
+    assertFalse(dto.getIndividualised());
+
     final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
     assertEquals(6, contactDetailsSet.size());
-    assertEquals("e@mail", findByType(contactDetailsSet, ContactDetailsType.EMAIL).getValue());
-    assertEquals("040404", findByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER).getValue());
-    assertEquals("Katu 1", findByType(contactDetailsSet, ContactDetailsType.STREET).getValue());
-    assertEquals("12321", findByType(contactDetailsSet, ContactDetailsType.POSTAL_CODE).getValue());
-    assertEquals("Taajama", findByType(contactDetailsSet, ContactDetailsType.TOWN).getValue());
-    assertEquals("Maa", findByType(contactDetailsSet, ContactDetailsType.COUNTRY).getValue());
+    assertEquals("e@mail", findValueByType(contactDetailsSet, ContactDetailsType.EMAIL));
+    assertEquals("040404", findValueByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER));
+    assertEquals("Katu 1", findValueByType(contactDetailsSet, ContactDetailsType.STREET));
+    assertEquals("12321", findValueByType(contactDetailsSet, ContactDetailsType.POSTAL_CODE));
+    assertEquals("Taajama", findValueByType(contactDetailsSet, ContactDetailsType.TOWN));
+    assertEquals("Maa", findValueByType(contactDetailsSet, ContactDetailsType.COUNTRY));
   }
 
   private Set<ContactDetailsDTO> assertGroupGettingContactDetailsDTOS(final PersonalDataDTO dto) {
@@ -90,10 +122,10 @@ class OnrOperationApiImplTest {
     return contactDetailsGroupDTO.getContactDetailsSet();
   }
 
-  private ContactDetailsDTO findByType(final Set<ContactDetailsDTO> dtos, final ContactDetailsType type) {
+  private String findValueByType(final Set<ContactDetailsDTO> dtos, final ContactDetailsType type) {
     for (final ContactDetailsDTO dto : dtos) {
       if (dto.getType() == type) {
-        return dto;
+        return dto.getValue();
       }
     }
     throw new RuntimeException("DTO not found for type:" + type);

--- a/backend/otr/src/test/java/fi/oph/otr/onr/OnrOperationApiImplTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/onr/OnrOperationApiImplTest.java
@@ -1,0 +1,119 @@
+package fi.oph.otr.onr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import fi.oph.otr.onr.dto.ContactDetailsDTO;
+import fi.oph.otr.onr.dto.ContactDetailsGroupDTO;
+import fi.oph.otr.onr.dto.ContactDetailsGroupSource;
+import fi.oph.otr.onr.dto.ContactDetailsGroupType;
+import fi.oph.otr.onr.dto.ContactDetailsType;
+import fi.oph.otr.onr.dto.PersonalDataDTO;
+import fi.oph.otr.onr.model.PersonalData;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class OnrOperationApiImplTest {
+
+  @Test
+  void testCreatePersonalDataDTO_IndividualisedNoPhone() {
+    final PersonalData personalData = defaultData().email("e@mail").individualised(true).build();
+
+    final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
+
+    assertDtoMatchesDefaultData(dto);
+    final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
+    assertEquals(2, contactDetailsSet.size());
+    assertEquals("e@mail", findByType(contactDetailsSet, ContactDetailsType.EMAIL).getValue());
+    assertNull(findByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER).getValue());
+  }
+
+  @Test
+  void testCreatePersonalDataDTO_IndividualisedWithPHone() {
+    final PersonalData personalData = defaultData().email("e@mail").individualised(true).phoneNumber("040404").build();
+
+    final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
+
+    assertDtoMatchesDefaultData(dto);
+    final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
+    assertEquals(2, contactDetailsSet.size());
+    assertEquals("e@mail", findByType(contactDetailsSet, ContactDetailsType.EMAIL).getValue());
+    assertEquals("040404", findByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER).getValue());
+  }
+
+  @Test
+  void testCreatePersonalDataDTO_NotIndividualisedNoOtherDetails() {
+    final PersonalData personalData = defaultData().email("e@mail").individualised(false).build();
+
+    final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
+
+    assertDtoMatchesDefaultData(dto);
+    final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
+    assertEquals(6, contactDetailsSet.size());
+    assertEquals("e@mail", findByType(contactDetailsSet, ContactDetailsType.EMAIL).getValue());
+    assertNull(findByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER).getValue());
+    assertNull(findByType(contactDetailsSet, ContactDetailsType.STREET).getValue());
+    assertNull(findByType(contactDetailsSet, ContactDetailsType.POSTAL_CODE).getValue());
+    assertNull(findByType(contactDetailsSet, ContactDetailsType.TOWN).getValue());
+    assertNull(findByType(contactDetailsSet, ContactDetailsType.COUNTRY).getValue());
+  }
+
+  @Test
+  void testCreatePersonalDataDTO_NotIndividualisedWithAllOtherDetails() {
+    final PersonalData personalData = defaultData()
+      .email("e@mail")
+      .individualised(false)
+      .phoneNumber("040404")
+      .street("Katu 1")
+      .postalCode("12321")
+      .town("Taajama")
+      .country("Maa")
+      .build();
+    final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
+
+    assertDtoMatchesDefaultData(dto);
+    final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
+    assertEquals(6, contactDetailsSet.size());
+    assertEquals("e@mail", findByType(contactDetailsSet, ContactDetailsType.EMAIL).getValue());
+    assertEquals("040404", findByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER).getValue());
+    assertEquals("Katu 1", findByType(contactDetailsSet, ContactDetailsType.STREET).getValue());
+    assertEquals("12321", findByType(contactDetailsSet, ContactDetailsType.POSTAL_CODE).getValue());
+    assertEquals("Taajama", findByType(contactDetailsSet, ContactDetailsType.TOWN).getValue());
+    assertEquals("Maa", findByType(contactDetailsSet, ContactDetailsType.COUNTRY).getValue());
+  }
+
+  private Set<ContactDetailsDTO> assertGroupGettingContactDetailsDTOS(final PersonalDataDTO dto) {
+    assertEquals(1, dto.getContactDetailsGroups().size());
+    final ContactDetailsGroupDTO contactDetailsGroupDTO = dto.getContactDetailsGroups().get(0);
+    assertEquals(ContactDetailsGroupType.OTR_OSOITE, contactDetailsGroupDTO.getType());
+    assertEquals(ContactDetailsGroupSource.OTR, contactDetailsGroupDTO.getSource());
+    return contactDetailsGroupDTO.getContactDetailsSet();
+  }
+
+  private ContactDetailsDTO findByType(final Set<ContactDetailsDTO> dtos, final ContactDetailsType type) {
+    for (final ContactDetailsDTO dto : dtos) {
+      if (dto.getType() == type) {
+        return dto;
+      }
+    }
+    throw new RuntimeException("DTO not found for type:" + type);
+  }
+
+  private PersonalData.PersonalDataBuilder defaultData() {
+    return PersonalData
+      .builder()
+      .onrId("onrID0101")
+      .lastName("Sukunimi")
+      .firstName("Etunimi")
+      .nickName("Kutsumanimi")
+      .identityNumber("id111222");
+  }
+
+  private void assertDtoMatchesDefaultData(final PersonalDataDTO dto) {
+    assertEquals("onrID0101", dto.getOnrId());
+    assertEquals("Sukunimi", dto.getLastName());
+    assertEquals("Etunimi", dto.getFirstName());
+    assertEquals("Kutsumanimi", dto.getNickName());
+    assertEquals("id111222", dto.getIdentityNumber());
+  }
+}

--- a/backend/otr/src/test/java/fi/oph/otr/onr/OnrServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/onr/OnrServiceTest.java
@@ -99,7 +99,7 @@ public class OnrServiceTest {
   }
 
   @Test
-  public void testUpdatePersonalData() {
+  public void testUpdatePersonalData() throws Exception {
     final String onrId = onrService.insertPersonalData(personalData);
     final PersonalData updatedPersonalData = createUpdatedPersonalData(onrId);
 
@@ -113,7 +113,7 @@ public class OnrServiceTest {
   }
 
   @Test
-  public void testUpdatePersonalDataDoesntUpdateCacheIfExceptionAtApiOccurs() {
+  public void testUpdatePersonalDataDoesntUpdateCacheIfExceptionAtApiOccurs() throws Exception {
     final String onrId = onrService.insertPersonalData(personalData);
     final PersonalData updatedPersonalData = createUpdatedPersonalData(onrId);
 

--- a/backend/otr/src/test/java/fi/oph/otr/service/ClerkInterpreterServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/service/ClerkInterpreterServiceTest.java
@@ -193,7 +193,7 @@ class ClerkInterpreterServiceTest {
   }
 
   @Test
-  public void testCreateInterpreter() {
+  public void testCreateInterpreter() throws Exception {
     final LocalDate today = LocalDate.now();
     final LocalDate tomorrow = LocalDate.now().plusDays(1);
     final LocalDate yesterday = LocalDate.now().minusDays(1);
@@ -310,7 +310,7 @@ class ClerkInterpreterServiceTest {
   }
 
   @Test
-  public void testCreateInterpreterWithExistingStudent() {
+  public void testCreateInterpreterWithExistingStudent() throws Exception {
     final LocalDate today = LocalDate.now();
     final LocalDate tomorrow = LocalDate.now().plusDays(1);
 
@@ -470,7 +470,7 @@ class ClerkInterpreterServiceTest {
   }
 
   @Test
-  public void testUpdateInterpreter() {
+  public void testUpdateInterpreter() throws Exception {
     final long id = createInterpreter("onrId");
     final Interpreter interpreter = interpreterRepository.getReferenceById(id);
     final int initialVersion = interpreter.getVersion();


### PR DESCRIPTION
Oppijan "Eero Alanen" päivittämistä testattu lokaalisti untuvan ONR:ää vasten:
https://virkailija.untuvaopintopolku.fi/henkilo-ui/virkailija/1.2.246.562.24.31234500001

Kaikki vaikuttaisi pellittävän eli tulkin yhteystietojen lisäys onnistuu null-arvoa vasten, poisto onnistuu ONR:stä jos kentän tyhjentää ja tiedon muokkaus toki myös.

Koitin alkuun asettaa PersonalDataDTO:hon ja sen ali-dtoihin (ContactDetailsGroupDTO ja ContactDetailsDTO) lombokin Builderin käyttöön, mutta kun tuo oli luokilla annotaationa, niin jackson ei osannut parsia oppijoiden tietoja, kun ne ONR:stä alkuun haettiin. Sama ongelma toistui myös jos näille asetti parametrillisia konstruktoreita. En alkanut tarkemmin selvitellä saisko tuon Builderin myös toimimaan, Setter näyttää pelaavan.

Halutessa `ContactDetailsUtil.createOtrContactDetailsGroup` metodille voi kirjoitella testejä kuin myös siirtää `updatePersonalData` alta PersonalDataDTO:n instanssin generoinnin omaan metodiinsa. Sellaista tarvitaan varmaan myös oppijan luonnin yhteydessä.