### PR TITLE
OTR(Backend): OPHOTRKEH-60 personal data insertion logic

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApi.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApi.java
@@ -10,7 +10,7 @@ public interface OnrOperationApi {
 
   Optional<PersonalData> findPersonalDataByIdentityNumber(String identityNumber) throws Exception;
 
-  String insertPersonalData(PersonalData personalData);
+  String insertPersonalData(PersonalData personalData) throws Exception;
 
   void updatePersonalData(PersonalData personalData) throws Exception;
 }

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONArray;
-import org.apache.commons.lang.NotImplementedException;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
@@ -104,10 +103,24 @@ public class OnrOperationApiImpl implements OnrOperationApi {
       .build();
   }
 
-  // TODO: insert personal data in ONR
   @Override
-  public String insertPersonalData(final PersonalData personalData) {
-    throw new NotImplementedException();
+  public String insertPersonalData(final PersonalData personalData) throws Exception {
+    final PersonalDataDTO personalDataDTO = createPersonalDataDTO(personalData);
+
+    final Request request = defaultRequestBuilder()
+      .setUrl(onrServiceUrl + "/henkilo")
+      .setMethod(Methods.POST)
+      .setBody(OBJECT_MAPPER.writeValueAsString(personalDataDTO))
+      .build();
+
+    final Response response = onrClient.executeBlocking(request);
+
+    if (response.getStatusCode() == HttpStatus.CREATED.value()) {
+      final PersonalDataDTO responseDTO = OBJECT_MAPPER.readValue(response.getResponseBody(), new TypeReference<>() {});
+      return responseDTO.getOnrId();
+    } else {
+      throw new RuntimeException("ONR service returned unexpected status code: " + response.getStatusCode());
+    }
   }
 
   @Override

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrService.java
@@ -39,8 +39,7 @@ public class OnrService {
     return api.findPersonalDataByIdentityNumber(identityNumber);
   }
 
-  public String insertPersonalData(final PersonalData data) {
-    // TODO: move setting `individualised` possibly under implementation given this `personalData` is not valid
+  public String insertPersonalData(final PersonalData data) throws Exception {
     final PersonalData personalData = PersonalData
       .builder()
       .individualised(false)

--- a/backend/otr/src/test/java/fi/oph/otr/onr/OnrServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/onr/OnrServiceTest.java
@@ -47,7 +47,7 @@ public class OnrServiceTest {
   private OnrOperationApi onrOperationApi;
 
   @BeforeEach
-  public void setup() {
+  public void setup() throws Exception {
     when(onrOperationApi.insertPersonalData(any())).thenReturn("onrId");
     onrService = new OnrService(onrOperationApi);
   }
@@ -72,7 +72,7 @@ public class OnrServiceTest {
   }
 
   @Test
-  public void testInsertPersonalData() {
+  public void testInsertPersonalData() throws Exception {
     final String onrId = onrService.insertPersonalData(personalData);
 
     final Map<String, PersonalData> cachedPersonalDatas = onrService.getCachedPersonalDatas();
@@ -90,7 +90,7 @@ public class OnrServiceTest {
   }
 
   @Test
-  public void testInsertPersonalDataDoesntUpdateCacheIfExceptionAtApiOccurs() {
+  public void testInsertPersonalDataDoesntUpdateCacheIfExceptionAtApiOccurs() throws Exception {
     doThrow(new RuntimeException()).when(onrOperationApi).insertPersonalData(any());
     assertThrows(RuntimeException.class, () -> onrService.insertPersonalData(personalData));
 


### PR DESCRIPTION
Toiminnallisuus oppijan luontiin tulkkia luotaessa, kun annetulla hetulla vastaavaa oppijaa ei alun ONR:stä löydy. En testannut logiikkaa, kun fronttiakaan ei ole tämän osalta vielä tehty.

Sellainen ajatus lähinnä heräsi toteuttaessa tätä, että olisiko hyvä, jos OnrOperationApi palauttaisi oppijan luonnin yhteydessä koko olion, joka talletettaisiin cacheen sen sijaan, että talletettavalle oliolle päivitetään ainoastaan luodun oppijan onrId. Tuskin tuolla tosin suurta väliä, kun cacheen tiedot haetaan jälleen kuitenkin varsin pian. Ja onko edes mahdollista että nämä eroaisivat toisistaan. Updaten osalta pitäisi varmaan toimia myös samoin jos tässä päädyttäisiin koko olio palauttamaan.

ONR swagger: https://virkailija.opintopolku.fi/oppijanumerorekisteri-service/swagger-ui/#/Henkilot/createHenkiloFromHenkiloCreateDtoUsingPOST