### PR TITLE
AKR(Frontend): Add privacy statement confirmation to contact request

### DIFF
--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -8,8 +8,8 @@
         "datePicker": {
           "label": "Tutkintopäivämäärä"
         },
-        "header": "Lisää tutkintopäivä",
-        "examinationDateAlreadyExists": "Valitsemasi päivä on jo olemassaoleva tutkintopäivä."
+        "examinationDateAlreadyExists": "Valitsemasi päivä on jo olemassaoleva tutkintopäivä.",
+        "header": "Lisää tutkintopäivä"
       },
       "addMeetingDate": {
         "buttons": {
@@ -71,8 +71,8 @@
             "removal": {
               "ariaLabel": "Poista auktorisointi",
               "dialog": {
-                "confirmButton": "Poista auktorisointi",
                 "description": "Tätä toimintoa ei voi peruuttaa!",
+                "confirmButton": "Poista auktorisointi",
                 "header": "Haluatko varmasti poistaa auktorisoinnin?"
               }
             }
@@ -81,10 +81,10 @@
             "add": "Lisää auktorisointi"
           },
           "fields": {
-            "examinationDate": "Tutkintopäivä",
             "basis": "Peruste",
             "diaryNumber": "Asiatunnus",
             "endDate": "Päättymispäivä",
+            "examinationDate": "Tutkintopäivä",
             "isEffective": "Voimassa",
             "languagePair": "Kielipari",
             "permissionToPublish": "Julkaisulupa",
@@ -100,8 +100,8 @@
         },
         "toasts": {
           "notFound": "Valittua kääntäjää ei löytynyt",
-          "updated": "Tiedot tallennettiin",
-          "updateFailed": "Tietojen tallennus epäonnistui"
+          "updateFailed": "Tietojen tallennus epäonnistui",
+          "updated": "Tiedot tallennettiin"
         },
         "translatorDetails": {
           "cancelUpdateDialog": {
@@ -133,20 +133,20 @@
         }
       },
       "contactRequestForm": {
+        "description": "Tällä yhteydenottolomakkeella voit jättää valitsemillesi auktorisoiduille kääntäjille yhteydenottopyynnön. Kirjoitathan viestiin mahdollisimman tarkan kuvauksen tarvittavasta käännöstyöstä.",
         "cancelRequestDialog": {
           "description": "Haluatko peruuttaa yhteydenottopyynnön? Menetät täyttämäsi tiedot.",
           "title": "Peruuta yhteydenottopyyntö"
         },
         "characters": "merkkiä",
         "chosenTranslatorsForLanguagePair": "Valitsemasi kääntäjät kielistä",
-        "description": "Tällä yhteydenottolomakkeella voit jättää valitsemillesi auktorisoiduille kääntäjille yhteydenottopyynnön. Kirjoitathan viestiin mahdollisimman tarkan kuvauksen tarvittavasta käännöstyöstä.",
         "doneStep": {
           "description": "Tämä sivu ohjaa sinut automaattisesti takaisin etusivulle. Jos mitään ei tapahdu voit klikata alla olevasta napista.",
           "title": "Yhteydenottopyyntösi on lähetetty ja sinuun ollaan yhteydessä."
         },
         "errorDialog": {
-          "back": "Takaisin",
           "description": "Kokeile myöhemmin uudelleen. Jos ongelma toistuu, ota yhteyttä sähköpostilla: auktoris.lautakunta@oph.fi",
+          "back": "Takaisin",
           "title": "Virhe lähetettäessä yhteydenottopyyntöä"
         },
         "formLabels": {
@@ -158,14 +158,19 @@
           "phoneNumber": "Puhelinnumero",
           "writeMessageHere": "Viesti"
         },
+        "privacyStatement": {
+          "ariaLabel": "Tietosuojaseloste",
+          "label": "Olen lukenut tämän palvelun <0>tietosuojaselosteen</0> ja hyväksyn sen.",
+          "linkLabel": "tietosuojaselosteen"
+        },
         "steps": {
-          "active": "Aktiivinen",
-          "completed": "Suoritettu",
           "Done": "Valmis!",
           "FillContactDetails": "Täytä yhteystietosi",
           "PreviewAndSend": "Esikatsele ja lähetä",
           "VerifyTranslators": "Vahvista kääntäjät",
-          "WriteMessage": "Kirjoita viesti"
+          "WriteMessage": "Kirjoita viesti",
+          "active": "Aktiivinen",
+          "completed": "Suoritettu"
         },
         "title": "Yhteydenottopyynnön jättäminen",
         "verifySelectedTranslatorsStep": {
@@ -185,8 +190,8 @@
         }
       },
       "examinationDatesToggleFilters": {
-        "upcoming": "Tulevat",
-        "passed": "Menneet"
+        "passed": "Menneet",
+        "upcoming": "Tulevat"
       },
       "footer": {
         "accessibility": {
@@ -207,13 +212,13 @@
           "accessibility": {
             "text": "Saavutettavuusseloste"
           },
-          "privacy": {
-            "text": "Tietosuojaseloste"
-          },
           "aktHomepage": {
             "ariaLabel": "Auktorisoidun kääntäjän tutkintojärjestelmä (oph.fi), avaa uudessa välilehdessä",
             "link": "https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/auktorisoidun-kaantajan-tutkinto",
             "text": "Auktorisoidun kääntäjän tutkintojärjestelmä (oph.fi)"
+          },
+          "privacy": {
+            "text": "Tietosuojaseloste"
           }
         }
       },
@@ -252,34 +257,34 @@
         "upcoming": "Tulevat"
       },
       "newAuthorisation": {
+        "cancelDialog": {
+          "header": "Haluatko varmasti peruuttaa?"
+        },
         "fieldLabel": {
-          "examinationDate": "Tutkintopäivä (vain AUT)",
           "basis": "Auktorisoinnin peruste",
           "diaryNumber": "Asiatunnus",
+          "examinationDate": "Tutkintopäivä (vain AUT)",
           "from": "Kielipari (mistä)",
           "termBeginDate": "Auktorisoinnin alkamispäivä",
           "termEndDate": "Auktorisoinnin päättymispäivä",
           "to": "Kielipari (mihin)"
         },
         "fieldPlaceholders": {
-          "examinationDate": "Tutkintopäivä",
           "basis": "Peruste",
           "diaryNumber": "Asiatunnus",
+          "examinationDate": "Tutkintopäivä",
           "from": "Mistä",
           "termBeginDate": "Alkamispäivä",
           "termEndDate": "Päättymispäivä",
           "to": "Mihin"
         },
         "switch": {
-          "permissionToPublish": "Julkaisulupa",
-          "inEffect": "Voimassa"
+          "inEffect": "Voimassa",
+          "permissionToPublish": "Julkaisulupa"
         },
         "toasts": {
-          "success": "Auktorisointi lisätty onnistuneesti",
-          "error": "Auktorisoinnin lisäys ei onnistunut, yritä myöhemmin uudelleen"
-        },
-        "cancelDialog": {
-          "header": "Haluatko varmasti peruuttaa?"
+          "error": "Auktorisoinnin lisäys ei onnistunut, yritä myöhemmin uudelleen",
+          "success": "Auktorisointi lisätty onnistuneesti"
         }
       },
       "publicTranslatorFilters": {
@@ -305,8 +310,8 @@
           "title": "Haku kääntäjän nimellä"
         },
         "toasts": {
-          "selectLanguagePair": "Valitse kielipari",
           "contactRequestNeedsLanguagePairs": "Valitse kielipari ottaaksesi yhteyttä kääntäjään",
+          "selectLanguagePair": "Valitse kielipari",
           "translatorsSelected": "Voit valita vain yhden kieliparin yhteydenottoon"
         },
         "town": {
@@ -328,13 +333,13 @@
     },
     "errors": {
       "api": {
-        "generic": "Toiminto epäonnistui, yritä myöhemmin uudelleen",
         "authorisationBasisAndExaminationDateMismatch": "Auktorisoinnin lisäys/muokkaus epäonnistui, koska peruste ja tutkintopäivä ovat ristiriidassa keskenään",
         "authorisationDeleteLastAuthorisation": "Auktorisoinnin poisto epäonnistui, koska kääntäjän viimeistä auktorisointia ei voi poistaa",
         "authorisationMissingExaminationDate": "Auktorisoinnin lisäys/muokkaus epäonnistui, koska valitulla päivämäärällä ei ole tutkintopäivää",
         "authorisationMissingMeetingDate": "Auktorisoinnin lisäys/muokkaus epäonnistui, koska valitulla päivämäärällä ei ole kokouspäivää",
         "examinationDateCreateDuplicateDate": "Tutkintopäivän lisäys epäonnistui, koska valitulla päivämäärällä on jo tutkintopäivä",
         "examinationDateDeleteHasAuthorisations": "Tutkintopäivän poisto epäonnistui, koska sille on kirjattu auktorisointeja",
+        "generic": "Toiminto epäonnistui, yritä myöhemmin uudelleen",
         "meetingDateCreateDuplicateDate": "Kokouspäivän lisäys epäonnistui, koska valitulla päivämäärällä on jo kokouspäivä",
         "meetingDateDeleteHasAuthorisations": "Kokouspäivän poisto epäonnistui, koska sille on kirjattu auktorisointeja",
         "meetingDateUpdateDuplicateDate": "Kokouspäivän muokkaus epäonnistui, koska valitulla päivämäärällä on jo kokouspäivä",
@@ -357,11 +362,24 @@
     },
     "pages": {
       "clerkHomepage": {
-        "title": "Auktorisoitujen kääntäjien rekisteri",
         "buttons": {
-          "sendEmail": "Lähetä sähköposti",
           "emptySelection": "Tyhjennä valinnat",
-          "newTranslator": "Lisää kääntäjä"
+          "newTranslator": "Lisää kääntäjä",
+          "sendEmail": "Lähetä sähköposti"
+        },
+        "title": "Auktorisoitujen kääntäjien rekisteri"
+      },
+      "clerkNewTranslatorPage": {
+        "addedAuthorisationsTitle": "Lisätyt auktorisoinnit",
+        "cancelAddNewTranslatorDialog": {
+          "title": "Haluatko varmasti peruuttaa uuden kääntäjän lisäyksen?"
+        },
+        "removeAuthorisationDialog": {
+          "title": "Haluatko varmasti poistaa auktorisoinnin?"
+        },
+        "title": "Lisää kääntäjä",
+        "toasts": {
+          "success": "Kääntäjän tiedot tallennettiin!"
         }
       },
       "clerkSendEmailPage": {
@@ -395,18 +413,8 @@
       "clerkTranslatorOverviewPage": {
         "title": "Kääntäjän tiedot"
       },
-      "clerkNewTranslatorPage": {
-        "title": "Lisää kääntäjä",
-        "toasts": {
-          "success": "Kääntäjän tiedot tallennettiin!"
-        },
-        "removeAuthorisationDialog": {
-          "title": "Haluatko varmasti poistaa auktorisoinnin?"
-        },
-        "cancelAddNewTranslatorDialog": {
-          "title": "Haluatko varmasti peruuttaa uuden kääntäjän lisäyksen?"
-        },
-        "addedAuthorisationsTitle": "Lisätyt auktorisoinnit"
+      "examinationDatesPage": {
+        "title": "Tutkintopäivät"
       },
       "homepage": {
         "description": "Auktorisoitujen kääntäjien tutkintolautakunta ylläpitää rekisteriä auktorisoiduista kääntäjistä. Hakukoneella voit hakea kääntäjiä joko nimen tai kieliparin mukaan. Voit jättää valitsemillesi kääntäjille yhteydenottopyynnön alla olevalla hakulomakkeella.",
@@ -420,9 +428,6 @@
       },
       "meetingDatesPage": {
         "title": "Kokouspäivät"
-      },
-      "examinationDatesPage": {
-        "title": "Tutkintopäivät"
       },
       "notFoundPage": {
         "description": "Osoite saattaa olla väärä tai vanhentunut. Voit palata etusivulle alla olevasta napista",

--- a/frontend/packages/akr/src/components/contactRequest/ContactRequestFormUtils.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/ContactRequestFormUtils.tsx
@@ -170,7 +170,7 @@ export const StepContents = ({
     case ContactRequestFormStep.WriteMessage:
       return <WriteMessage disableNext={disableNext} />;
     case ContactRequestFormStep.PreviewAndSend:
-      return <PreviewAndSend />;
+      return <PreviewAndSend disableNext={disableNext} />;
     case ContactRequestFormStep.Done:
       return <Done />;
     default:

--- a/frontend/packages/akr/src/components/contactRequest/ControlButtons.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/ControlButtons.tsx
@@ -131,7 +131,7 @@ export const ControlButtons = ({
             onClick={onContactRequestSubmit}
             data-testid="contact-request-page__submit-btn"
             endIcon={<ArrowForwardIcon />}
-            disabled={isLoading}
+            disabled={disableNext || isLoading}
           >
             {translateCommon('send')}
           </CustomButton>

--- a/frontend/packages/akr/src/components/contactRequest/steps/PreviewAndSend.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/PreviewAndSend.tsx
@@ -1,4 +1,9 @@
-import { CustomTextField, H3 } from 'shared/components';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { Checkbox, FormControlLabel } from '@mui/material';
+import { useEffect } from 'react';
+import { Trans } from 'react-i18next';
+import { CustomTextField, ExtLink, H3 } from 'shared/components';
+import { Color } from 'shared/enums';
 import { InputFieldUtils } from 'shared/utils';
 
 import {
@@ -8,15 +13,50 @@ import {
   StepHeading,
 } from 'components/contactRequest/ContactRequestFormUtils';
 import { useAppTranslation } from 'configs/i18n';
-import { useAppSelector } from 'configs/redux';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { AppRoutes } from 'enums/app';
 import { ContactRequestFormStep } from 'enums/contactRequest';
+import { setContactRequest } from 'redux/actions/contactRequest';
 import { contactRequestSelector } from 'redux/selectors/contactRequest';
 
-export const PreviewAndSend = () => {
+const PrivacyStatementCheckboxLabel = () => {
+  const { t } = useAppTranslation({
+    keyPrefix: 'akr.component.contactRequestForm.privacyStatement',
+  });
+
+  return (
+    <Trans t={t} i18nKey="label">
+      <ExtLink
+        className="contact-request-page__grid__privacy-statement-checkbox-label__link"
+        text={t('linkLabel')}
+        href={AppRoutes.PrivacyPolicyPage}
+        endIcon={<OpenInNewIcon />}
+        aria-label={t('ariaLabel')}
+      />
+    </Trans>
+  );
+};
+
+export const PreviewAndSend = ({
+  disableNext,
+}: {
+  disableNext: (disabled: boolean) => void;
+}) => {
   const { t } = useAppTranslation({
     keyPrefix: 'akr.component.contactRequestForm',
   });
+
+  // Redux
   const { request } = useAppSelector(contactRequestSelector);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    disableNext(!request?.confirmation);
+  }, [disableNext, request]);
+
+  const handleCheckboxClick = () => {
+    dispatch(setContactRequest({ confirmation: !request?.confirmation }));
+  };
 
   const getMessageHelperText = () => {
     return `${
@@ -43,6 +83,17 @@ export const PreviewAndSend = () => {
           helperText={getMessageHelperText()}
           multiline
           fullWidth
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              onClick={handleCheckboxClick}
+              color={Color.Secondary}
+              data-testid="contact-request-page__privacy-statement-checkbox"
+            />
+          }
+          label={<PrivacyStatementCheckboxLabel />}
+          className="contact-request-page__grid__privacy-statement-checkbox-label"
         />
       </div>
     </div>

--- a/frontend/packages/akr/src/interfaces/contactRequest.ts
+++ b/frontend/packages/akr/src/interfaces/contactRequest.ts
@@ -15,6 +15,7 @@ export interface ContactRequest extends ContactDetails {
   message: string;
   translatorIds: Array<number>;
   languagePair: LanguagePair;
+  confirmation: boolean;
 }
 
 export interface ContactRequestState {

--- a/frontend/packages/akr/src/redux/reducers/contactRequest.ts
+++ b/frontend/packages/akr/src/redux/reducers/contactRequest.ts
@@ -28,6 +28,7 @@ const defaultState = {
     lastName: '',
     message: '',
     phoneNumber: '',
+    confirmation: false,
   },
   messageError: '',
 };

--- a/frontend/packages/akr/src/styles/pages/_contact-request-page.scss
+++ b/frontend/packages/akr/src/styles/pages/_contact-request-page.scss
@@ -64,6 +64,20 @@
       margin-left: 5rem;
       max-width: 80%;
     }
+
+    &__privacy-statement-checkbox-label {
+      margin-right: 0;
+
+      &__link {
+        font-size: 1.6rem;
+        padding: 0 3px 0 0;
+        text-transform: lowercase;
+
+        & span {
+          margin-left: 2px;
+        }
+      }
+    }
   }
 
   &__heading {

--- a/frontend/packages/akr/src/tests/cypress/integration/contact-request/contact_request.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/contact-request/contact_request.spec.ts
@@ -28,11 +28,11 @@ beforeEach(() => {
 
 describe('ContactRequestPage', () => {
   it('should not allow proceeding if all translators are deselected', () => {
-    onContactRequestPage.elements.nextButton().should('be.enabled');
+    onContactRequestPage.isNextEnabled();
     TEST_TRANSLATOR_IDS.forEach((id) =>
       onContactRequestPage.deselectTranslator(id)
     );
-    onContactRequestPage.elements.nextButton().should('be.disabled');
+    onContactRequestPage.isNextDisabled();
   });
 
   it('should bring user back to home page if cancel button is clicked', () => {
@@ -122,7 +122,7 @@ describe('ContactRequestPage', () => {
     );
     onContactRequestPage.blurFieldByLabel(/puhelinnumero/i);
 
-    onContactRequestPage.elements.nextButton().should('be.disabled');
+    onContactRequestPage.isNextDisabled();
     cy.findByText(/sähköpostiosoite on virheellinen/i).should('be.visible');
     cy.findByText(/puhelinnumero on virheellinen/i).should('be.visible');
   });
@@ -146,7 +146,7 @@ describe('ContactRequestPage', () => {
     // Assert error message
     cy.findByText(/puhelinnumero on virheellinen/i).should('be.visible');
     // Verify user can still proceed
-    onContactRequestPage.elements.nextButton().should('be.enabled');
+    onContactRequestPage.isNextEnabled();
   });
 
   it('should show an error if the message field is empty or its length exceeds the limit', () => {
@@ -156,12 +156,24 @@ describe('ContactRequestPage', () => {
 
     onContactRequestPage.blurFieldByLabel(/^viesti/i);
     cy.findByText(/tieto on pakollinen/i).should('be.visible');
-    onContactRequestPage.elements.nextButton().should('be.disabled');
+    onContactRequestPage.isNextDisabled();
 
     onContactRequestPage.pasteToFieldByLabel(/^viesti/i, LONG_TEST_MESSAGE);
     onContactRequestPage.elements.byLabel(/^viesti/i).type('{enter}');
 
     cy.findByText(/teksti on liian pitkä/i).should('be.visible');
-    onContactRequestPage.elements.nextButton().should('be.disabled');
+    onContactRequestPage.isNextDisabled();
+  });
+
+  it('should allow submitting the request only if the privacy statement is accepted', () => {
+    verifyTranslatorsStep();
+    fillContactDetailsStep();
+    writeMessageStep();
+    onContactRequestPage.next();
+
+    onContactRequestPage.isSubmitDisabled();
+    onContactRequestPage.confirmPrivacyStatement();
+
+    onContactRequestPage.isSubmitEnabled();
   });
 });

--- a/frontend/packages/akr/src/tests/cypress/support/page-objects/contactRequestPage.ts
+++ b/frontend/packages/akr/src/tests/cypress/support/page-objects/contactRequestPage.ts
@@ -13,6 +13,8 @@ class ContactRequestPage {
     homepageButton: () => cy.findByTestId('contact-request-page__homepage-btn'),
     byLabel: (label: Matcher) =>
       cy.get('.contact-request-page').findByLabelText(label),
+    privacyStatementCheckbox: () =>
+      cy.findByTestId('contact-request-page__privacy-statement-checkbox'),
   };
 
   previous() {
@@ -51,12 +53,24 @@ class ContactRequestPage {
     this.elements.byLabel(label).focus().blur();
   }
 
+  confirmPrivacyStatement() {
+    this.elements.privacyStatementCheckbox().should('be.visible').click();
+  }
+
   isNextEnabled() {
     this.elements.nextButton().should('be.enabled');
   }
 
   isNextDisabled() {
     this.elements.nextButton().should('be.disabled');
+  }
+
+  isSubmitEnabled() {
+    this.elements.submitButton().should('be.enabled');
+  }
+
+  isSubmitDisabled() {
+    this.elements.submitButton().should('be.disabled');
   }
 
   expectRequestToBeSent() {
@@ -126,6 +140,7 @@ const assertContactDetails = () => {
 
 export const previewAndSendStep = () => {
   onContactRequestPage.next();
+  onContactRequestPage.confirmPrivacyStatement();
 
   assertSelectedTranslators();
   assertContactDetails();


### PR DESCRIPTION
Alustava toteutus siitä, että yhteydenottopyynnön lähetyksessä vaaditaan sekä käyttöehtojen että tietosuojaselosteen hyväksyntä. Palvelusta ei taida olla parhaillaan käyttöehtoja? Tuon osuuden käyttöehtojen hyväksymisestä voisi poistaa jos näin.

Kaipaa muutenkin kommentteja toteutukseen, varsinkin css-puoli joka ei vastaa ihan Jiran tilaa.

Edit:
Ja näemmä testit vaativat myös korjausta vielä mut palaan noihin kun tää toimii muuten järkevästi.