### PR TITLE
Feature/ophotrkeh 57 part 5

### DIFF
--- a/frontend/packages/otr/package.json
+++ b/frontend/packages/otr/package.json
@@ -25,6 +25,6 @@
     "otr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.15"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.18"
   }
 }

--- a/frontend/packages/otr/public/i18n/fi-FI/common.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/common.json
@@ -1,6 +1,7 @@
 {
   "otr": {
     "common": {
+      "add": "Lisää",
       "allRegions": "Koko Suomi",
       "back": "Takaisin",
       "cancel": "Peruuta",

--- a/frontend/packages/otr/public/i18n/fi-FI/common.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/common.json
@@ -2,6 +2,7 @@
   "otr": {
     "common": {
       "add": "Lisää",
+      "addQualification": "Lisää rekisteröinti",
       "allRegions": "Koko Suomi",
       "back": "Takaisin",
       "cancel": "Peruuta",

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -73,30 +73,28 @@
             "changePermissionToPublish": {
               "ariaLabel": "Vaihda julkaisulupaa",
               "dialog": {
-                "description": "Tämä muuttaa kieliparin näkymistä julkisessa rekisterissä.",
+                "description": "Tämä muuttaa rekisteröinnin näkymistä julkisessa rekisterissä.",
                 "header": "Haluatko varmasti vaihtaa julkaisulupaa?"
               }
             },
             "removal": {
-              "ariaLabel": "Poista kielipari",
+              "ariaLabel": "Poista rekisteröinti",
               "dialog": {
                 "description": "Tätä toimintoa ei voi peruuttaa!",
-                "confirmButton": "Poista kielipari",
-                "header": "Haluatko varmasti poistaa kieliparin?"
+                "confirmButton": "Poista rekisteröinti",
+                "header": "Haluatko varmasti poistaa rekisteröinnin?"
               }
             }
           },
-          "buttons": {
-            "add": "Lisää tutkinto"
-          },
           "fields": {
+            "diaryNumber": "Asiatunnus",
             "endDate": "Päättymispäivä",
             "examinationType": "Koulutus",
             "languagePair": "Kielipari",
             "permissionToPublish": "Julkaisulupa",
             "startDate": "Alkamispäivä"
           },
-          "header": "Kieliparit",
+          "header": "Rekisteröinnit",
           "noQualifications": "Valituille kriteereille ei löytynyt tutkintoja",
           "toggleFilters": {
             "effective": "Voimassa olevat",
@@ -158,28 +156,27 @@
           "header": "Haluatko varmasti peruuttaa?"
         },
         "fieldLabel": {
-          "basis": "Koulutus",
           "beginDate": "Rekisteröinnin alkamispäivä",
           "diaryNumber": "Asiatunnus",
           "endDate": "Rekisteröinnin päättymispäivä",
+          "examination": "Koulutus",
           "from": "Kielipari (mistä)",
           "to": "Kielipari (mihin)"
         },
         "fieldPlaceholders": {
-          "basis": "Peruste",
           "beginDate": "Alkamispäivä",
           "diaryNumber": "Asiatunnus",
           "endDate": "Päättymispäivä",
+          "examination": "Koulutus",
           "from": "Mistä",
           "to": "Mihin"
         },
         "switch": {
-          "inEffect": "Voimassa",
           "permissionToPublish": "Julkaisulupa"
         },
         "toasts": {
-          "error": "Kieliparin lisäys ei onnistunut, yritä myöhemmin uudelleen",
-          "success": "Kielipari lisätty onnistuneesti"
+          "error": "Rekisteröinnin lisäys ei onnistunut, yritä myöhemmin uudelleen",
+          "success": "Rekisteröinti lisätty onnistuneesti"
         }
       },
       "publicInterpreterFilters": {

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -153,6 +153,35 @@
           "sv": "På svenska"
         }
       },
+      "newQualification": {
+        "cancelDialog": {
+          "header": "Haluatko varmasti peruuttaa?"
+        },
+        "fieldLabel": {
+          "basis": "Koulutus",
+          "beginDate": "Rekisteröinnin alkamispäivä",
+          "diaryNumber": "Asiatunnus",
+          "endDate": "Rekisteröinnin päättymispäivä",
+          "from": "Kielipari (mistä)",
+          "to": "Kielipari (mihin)"
+        },
+        "fieldPlaceholders": {
+          "basis": "Peruste",
+          "beginDate": "Alkamispäivä",
+          "diaryNumber": "Asiatunnus",
+          "endDate": "Päättymispäivä",
+          "from": "Mistä",
+          "to": "Mihin"
+        },
+        "switch": {
+          "inEffect": "Voimassa",
+          "permissionToPublish": "Julkaisulupa"
+        },
+        "toasts": {
+          "error": "Kieliparin lisäys ei onnistunut, yritä myöhemmin uudelleen",
+          "success": "Kielipari lisätty onnistuneesti"
+        }
+      },
       "publicInterpreterFilters": {
         "name": {
           "placeholder": "Nimi",

--- a/frontend/packages/otr/src/components/clerkInterpreter/add/AddQualification.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/add/AddQualification.tsx
@@ -39,7 +39,7 @@ interface NewQualification
 }
 
 const newQualification: NewQualification = {
-  fromLang: '',
+  fromLang: 'FI',
   toLang: '',
   examinationType: undefined as unknown as ExaminationType,
   beginDate: undefined,
@@ -178,7 +178,7 @@ export const AddQualification = ({
               autoHighlight
               label={t('fieldPlaceholders.from')}
               variant={TextFieldVariant.Outlined}
-              languages={QualificationUtils.getKoodistoLangKeys()}
+              languages={['FI']}
               excludedLanguage={qualification.toLang || undefined}
               value={getLanguageSelectValue(qualification.fromLang)}
               onChange={handleLanguageSelectChange('fromLang')}
@@ -238,6 +238,7 @@ export const AddQualification = ({
               }
               label=""
               setValue={handleBeginDateChange}
+              maxDate={dayjs()}
             />
           </div>
           <div className="rows gapped-xs">

--- a/frontend/packages/otr/src/components/clerkInterpreter/add/AddQualification.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/add/AddQualification.tsx
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import { ChangeEvent, useEffect, useState } from 'react';
 import {
   AutocompleteValue,
@@ -11,7 +11,6 @@ import {
   languageToComboBoxOption,
   LoadingProgressIndicator,
   Text,
-  valueAsOption,
 } from 'shared/components';
 import { Color, TextFieldVariant, Variant } from 'shared/enums';
 import { CommonUtils, DateUtils, StringUtils } from 'shared/utils';
@@ -33,7 +32,13 @@ interface AddQualificationProps {
   onQualificationAdd(qualification: Qualification): void;
 }
 
-const newQualification: Qualification = {
+interface NewQualification
+  extends Omit<Qualification, 'beginDate' | 'endDate'> {
+  beginDate?: Dayjs;
+  endDate?: Dayjs;
+}
+
+const newQualification: NewQualification = {
   fromLang: '',
   toLang: '',
   examinationType: undefined as unknown as ExaminationType,
@@ -50,7 +55,7 @@ export const AddQualification = ({
   onCancel,
 }: AddQualificationProps) => {
   const [qualification, setQualification] =
-    useState<Qualification>(newQualification);
+    useState<NewQualification>(newQualification);
   const [isQualificationDataChanged, setIsQualificationDataChanged] =
     useState(false);
 
@@ -143,6 +148,21 @@ export const AddQualification = ({
     }
   };
 
+  const examinationTypeToOption = (examinationType: ExaminationType) => {
+    switch (examinationType) {
+      case ExaminationType.LegalInterpreterExam:
+        return {
+          label: translateCommon('examinationType.legalInterpreterExam'),
+          value: ExaminationType.LegalInterpreterExam,
+        };
+      case ExaminationType.Other:
+        return {
+          label: translateCommon('examinationType.degreeStudies'),
+          value: ExaminationType.Other,
+        };
+    }
+  };
+
   const testIdPrefix = 'add-qualification-field';
 
   useNavigationProtection(isQualificationDataChanged);
@@ -185,10 +205,12 @@ export const AddQualification = ({
               data-testid={`${testIdPrefix}-basis`}
               autoHighlight
               label={t('fieldPlaceholders.basis')}
-              values={Object.values(ExaminationType).map(valueAsOption)}
+              values={Object.values(ExaminationType).map(
+                examinationTypeToOption
+              )}
               value={
                 qualification.examinationType
-                  ? valueAsOption(qualification.examinationType)
+                  ? examinationTypeToOption(qualification.examinationType)
                   : null
               }
               variant={TextFieldVariant.Outlined}
@@ -227,7 +249,9 @@ export const AddQualification = ({
                   : ''
               }
               label=""
-              setValue={handleBeginDateChange}
+              setValue={() => {
+                return;
+              }}
               disabled={true}
             />
           </div>
@@ -260,7 +284,9 @@ export const AddQualification = ({
               data-testid="add-qualification-modal__save"
               variant={Variant.Contained}
               color={Color.Secondary}
-              onClick={() => addAndResetQualification(qualification)}
+              onClick={() =>
+                addAndResetQualification(qualification as Qualification)
+              }
               disabled={isAddButtonDisabled()}
             >
               {translateCommon('add')}
@@ -271,7 +297,9 @@ export const AddQualification = ({
             data-testid="add-qualification-modal__save"
             variant={Variant.Contained}
             color={Color.Secondary}
-            onClick={() => addAndResetQualification(qualification)}
+            onClick={() =>
+              addAndResetQualification(qualification as Qualification)
+            }
             disabled={isAddButtonDisabled()}
           >
             {translateCommon('add')}

--- a/frontend/packages/otr/src/components/clerkInterpreter/add/AddQualification.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/add/AddQualification.tsx
@@ -1,0 +1,283 @@
+import dayjs from 'dayjs';
+import { ChangeEvent, useEffect, useState } from 'react';
+import {
+  AutocompleteValue,
+  ComboBox,
+  CustomButton,
+  CustomSwitch,
+  CustomTextField,
+  DatePicker,
+  LanguageSelect,
+  languageToComboBoxOption,
+  LoadingProgressIndicator,
+  Text,
+  valueAsOption,
+} from 'shared/components';
+import { Color, TextFieldVariant, Variant } from 'shared/enums';
+import { CommonUtils, DateUtils, StringUtils } from 'shared/utils';
+
+import {
+  useAppTranslation,
+  useCommonTranslation,
+  useKoodistoLanguagesTranslation,
+} from 'configs/i18n';
+import { ExaminationType } from 'enums/interpreter';
+import { useNavigationProtection } from 'hooks/useNavigationProtection';
+import { Qualification } from 'interfaces/qualification';
+import { QualificationUtils } from 'utils/qualifications';
+
+interface AddQualificationProps {
+  interpreterId?: number;
+  isLoading?: boolean;
+  onCancel: () => void;
+  onQualificationAdd(qualification: Qualification): void;
+}
+
+const newQualification: Qualification = {
+  fromLang: '',
+  toLang: '',
+  examinationType: undefined as unknown as ExaminationType,
+  beginDate: undefined,
+  endDate: undefined,
+  permissionToPublish: true,
+  diaryNumber: '',
+};
+
+export const AddQualification = ({
+  interpreterId,
+  isLoading,
+  onQualificationAdd,
+  onCancel,
+}: AddQualificationProps) => {
+  const [qualification, setQualification] =
+    useState<Qualification>(newQualification);
+  const [isQualificationDataChanged, setIsQualificationDataChanged] =
+    useState(false);
+
+  const translateCommon = useCommonTranslation();
+  const translateLanguage = useKoodistoLanguagesTranslation();
+  const { t } = useAppTranslation({
+    keyPrefix: 'otr.component.newQualification',
+  });
+
+  useEffect(() => {
+    setQualification((prevState) => ({
+      ...prevState,
+      tempId: CommonUtils.createUniqueId(),
+    }));
+  }, []);
+
+  const handleLanguageSelectChange =
+    (fieldName: string) =>
+    ({}, value: AutocompleteValue) => {
+      setQualification({
+        ...qualification,
+        [fieldName]: value?.value ?? '',
+      });
+      setIsQualificationDataChanged(true);
+    };
+
+  const handleExaminationTypeChange = ({}, value: AutocompleteValue) => {
+    const examinationType = value?.value as ExaminationType;
+
+    setQualification({
+      ...qualification,
+      examinationType,
+    });
+    setIsQualificationDataChanged(true);
+  };
+
+  const handleBeginDateChange = (value: string) => {
+    const PERIOD_OF_VALIDITY = 5;
+    const beginDate = value ? dayjs(value) : undefined;
+    const endDate = beginDate?.add(PERIOD_OF_VALIDITY, 'year');
+    setQualification({
+      ...qualification,
+      beginDate,
+      endDate,
+    });
+    setIsQualificationDataChanged(true);
+  };
+
+  const handleSwitchValueChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setQualification({
+      ...qualification,
+      permissionToPublish: event?.target.checked,
+    });
+    setIsQualificationDataChanged(true);
+  };
+
+  const handleDiaryNumberChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setQualification({
+      ...qualification,
+      diaryNumber: event?.target.value,
+    });
+    setIsQualificationDataChanged(true);
+  };
+
+  const getLanguageSelectValue = (language?: string) =>
+    language ? languageToComboBoxOption(translateLanguage, language) : null;
+
+  const isAddButtonDisabled = () => {
+    const { beginDate, examinationType, ...otherProps } = qualification;
+
+    const isOtherPropsNotDefined = Object.values(otherProps).some((p) =>
+      StringUtils.isBlankString(p)
+    );
+
+    return (
+      isLoading || isOtherPropsNotDefined || !beginDate || !examinationType
+    );
+  };
+
+  const addAndResetQualification = (qualification: Qualification) => {
+    onQualificationAdd({
+      ...qualification,
+      ...(interpreterId && { interpreterId }),
+    });
+    if (!interpreterId) {
+      setQualification(newQualification);
+      onCancel();
+    }
+  };
+
+  const testIdPrefix = 'add-qualification-field';
+
+  useNavigationProtection(isQualificationDataChanged);
+
+  return (
+    <>
+      <div className="rows gapped">
+        <div className="add-qualification__fields gapped align-items-start full-max-width">
+          <div className="rows gapped-xs">
+            <Text className="bold">{t('fieldLabel.from')}</Text>
+            <LanguageSelect
+              data-testid={`${testIdPrefix}-from`}
+              autoHighlight
+              label={t('fieldPlaceholders.from')}
+              variant={TextFieldVariant.Outlined}
+              languages={QualificationUtils.getKoodistoLangKeys()}
+              excludedLanguage={qualification.toLang || undefined}
+              value={getLanguageSelectValue(qualification.fromLang)}
+              onChange={handleLanguageSelectChange('fromLang')}
+              translateLanguage={translateLanguage}
+            />
+          </div>
+          <div className="rows gapped-xs">
+            <Text className="bold">{t('fieldLabel.to')}</Text>
+            <LanguageSelect
+              data-testid={`${testIdPrefix}-to`}
+              autoHighlight
+              label={t('fieldPlaceholders.to')}
+              variant={TextFieldVariant.Outlined}
+              languages={QualificationUtils.getKoodistoLangKeys()}
+              excludedLanguage={qualification.fromLang || undefined}
+              value={getLanguageSelectValue(qualification.toLang)}
+              onChange={handleLanguageSelectChange('toLang')}
+              translateLanguage={translateLanguage}
+            />
+          </div>
+          <div className="rows gapped-xs">
+            <Text className="bold">{t('fieldLabel.basis')}</Text>
+            <ComboBox
+              data-testid={`${testIdPrefix}-basis`}
+              autoHighlight
+              label={t('fieldPlaceholders.basis')}
+              values={Object.values(ExaminationType).map(valueAsOption)}
+              value={
+                qualification.examinationType
+                  ? valueAsOption(qualification.examinationType)
+                  : null
+              }
+              variant={TextFieldVariant.Outlined}
+              onChange={handleExaminationTypeChange}
+            />
+          </div>
+          <div className="rows gapped-xs">
+            <Text className="bold">{t('fieldLabel.diaryNumber')}</Text>
+            <CustomTextField
+              data-testid={`${testIdPrefix}-diaryNumber`}
+              label={t('fieldPlaceholders.diaryNumber')}
+              value={qualification.diaryNumber}
+              onChange={handleDiaryNumberChange}
+            />
+          </div>
+        </div>
+        <div className="add-qualification__fields gapped align-items-start">
+          <div className="rows gapped-xs">
+            <Text className="bold">{t('fieldLabel.beginDate')}</Text>
+            <DatePicker
+              value={
+                qualification.beginDate
+                  ? DateUtils.serializeDate(qualification.beginDate)
+                  : ''
+              }
+              label=""
+              setValue={handleBeginDateChange}
+            />
+          </div>
+          <div className="rows gapped-xs">
+            <Text className="bold">{t('fieldLabel.endDate')}</Text>
+            <DatePicker
+              value={
+                qualification.endDate
+                  ? DateUtils.serializeDate(qualification.endDate)
+                  : ''
+              }
+              label=""
+              setValue={handleBeginDateChange}
+              disabled={true}
+            />
+          </div>
+          <div className="rows gapped-xs">
+            <Text className="bold">{t('switch.permissionToPublish')}</Text>
+            <CustomSwitch
+              dataTestId={`${testIdPrefix}-permissionToPublish`}
+              value={qualification.permissionToPublish}
+              leftLabel={translateCommon('no')}
+              rightLabel={translateCommon('yes')}
+              onChange={handleSwitchValueChange}
+            />
+          </div>
+        </div>
+      </div>
+      <div className="columns gapped margin-top-lg flex-end">
+        <CustomButton
+          disabled={isLoading}
+          data-testid="add-qualification-modal__cancel"
+          className="margin-right-xs"
+          onClick={onCancel}
+          variant={Variant.Text}
+          color={Color.Secondary}
+        >
+          {translateCommon('cancel')}
+        </CustomButton>
+        {isLoading ? (
+          <LoadingProgressIndicator isLoading={isLoading}>
+            <CustomButton
+              data-testid="add-qualification-modal__save"
+              variant={Variant.Contained}
+              color={Color.Secondary}
+              onClick={() => addAndResetQualification(qualification)}
+              disabled={isAddButtonDisabled()}
+            >
+              {translateCommon('add')}
+            </CustomButton>
+          </LoadingProgressIndicator>
+        ) : (
+          <CustomButton
+            data-testid="add-qualification-modal__save"
+            variant={Variant.Contained}
+            color={Color.Secondary}
+            onClick={() => addAndResetQualification(qualification)}
+            disabled={isAddButtonDisabled()}
+          >
+            {translateCommon('add')}
+          </CustomButton>
+        )}
+      </div>
+    </>
+  );
+};

--- a/frontend/packages/otr/src/components/clerkInterpreter/add/AddQualification.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/add/AddQualification.tsx
@@ -200,11 +200,11 @@ export const AddQualification = ({
             />
           </div>
           <div className="rows gapped-xs">
-            <Text className="bold">{t('fieldLabel.basis')}</Text>
+            <Text className="bold">{t('fieldLabel.examination')}</Text>
             <ComboBox
-              data-testid={`${testIdPrefix}-basis`}
+              data-testid={`${testIdPrefix}-examination`}
               autoHighlight
-              label={t('fieldPlaceholders.basis')}
+              label={t('fieldPlaceholders.examination')}
               values={Object.values(ExaminationType).map(
                 examinationTypeToOption
               )}

--- a/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingRow.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingRow.tsx
@@ -33,26 +33,22 @@ export const ClerkInterpreterListingRow = ({
         <Text>{`${firstName} ${lastName}`}</Text>
       </TableCell>
       <TableCell>
-        {qualifications
-          .filter((q) => !q.deleted)
-          .map(({ fromLang, toLang }, k) => (
-            <Text key={k}>
-              {translateLanguage(fromLang)}
-              {` - `}
-              {translateLanguage(toLang)}
-            </Text>
-          ))}
+        {qualifications.map(({ fromLang, toLang }, k) => (
+          <Text key={k}>
+            {translateLanguage(fromLang)}
+            {` - `}
+            {translateLanguage(toLang)}
+          </Text>
+        ))}
       </TableCell>
       <TableCell>
-        {qualifications
-          .filter((q) => !q.deleted)
-          .map(({ beginDate, endDate }, k) => (
-            <Text key={k}>
-              {DateUtils.formatOptionalDate(beginDate)}
-              {` - `}
-              {DateUtils.formatOptionalDate(endDate)}
-            </Text>
-          ))}{' '}
+        {qualifications.map(({ beginDate, endDate }, k) => (
+          <Text key={k}>
+            {DateUtils.formatOptionalDate(beginDate)}
+            {` - `}
+            {DateUtils.formatOptionalDate(endDate)}
+          </Text>
+        ))}{' '}
       </TableCell>
       <TableCell>
         <Text>{RegionUtils.translateAndConcatRegions(regions)}</Text>

--- a/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingRow.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingRow.tsx
@@ -33,22 +33,26 @@ export const ClerkInterpreterListingRow = ({
         <Text>{`${firstName} ${lastName}`}</Text>
       </TableCell>
       <TableCell>
-        {qualifications.map(({ fromLang, toLang }, k) => (
-          <Text key={k}>
-            {translateLanguage(fromLang)}
-            {` - `}
-            {translateLanguage(toLang)}
-          </Text>
-        ))}
+        {qualifications
+          .filter((q) => !q.deleted)
+          .map(({ fromLang, toLang }, k) => (
+            <Text key={k}>
+              {translateLanguage(fromLang)}
+              {` - `}
+              {translateLanguage(toLang)}
+            </Text>
+          ))}
       </TableCell>
       <TableCell>
-        {qualifications.map(({ beginDate, endDate }, k) => (
-          <Text key={k}>
-            {DateUtils.formatOptionalDate(beginDate)}
-            {` - `}
-            {DateUtils.formatOptionalDate(endDate)}
-          </Text>
-        ))}{' '}
+        {qualifications
+          .filter((q) => !q.deleted)
+          .map(({ beginDate, endDate }, k) => (
+            <Text key={k}>
+              {DateUtils.formatOptionalDate(beginDate)}
+              {` - `}
+              {DateUtils.formatOptionalDate(endDate)}
+            </Text>
+          ))}{' '}
       </TableCell>
       <TableCell>
         <Text>{RegionUtils.translateAndConcatRegions(regions)}</Text>

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useCallback, useEffect, useState } from 'react';
-import { APIResponseStatus, Severity } from 'shared/enums';
+import { APIResponseStatus, Duration, Severity } from 'shared/enums';
 import { ComboBoxOption } from 'shared/interfaces';
 
 import { ControlButtons } from 'components/clerkInterpreter/overview/ClerkInterpreterDetailsControlButtons';
@@ -60,7 +60,8 @@ export const ClerkInterpreterDetails = () => {
     ) {
       const toast = NotifierUtils.createNotifierToast(
         Severity.Success,
-        t('toasts.updated')
+        t('toasts.updated'),
+        Duration.Short
       );
       dispatch(showNotifierToast(toast));
       dispatch(resetClerkInterpreterDetailsUpdate());

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
@@ -48,10 +48,11 @@ export const ClerkInterpreterDetails = () => {
   });
 
   const resetToInitialState = useCallback(() => {
+    dispatch(resetClerkInterpreterDetailsUpdate());
     resetLocalInterpreterDetails();
     setHasLocalChanges(false);
     setCurrentUIMode(UIMode.View);
-  }, [resetLocalInterpreterDetails]);
+  }, [dispatch, resetLocalInterpreterDetails]);
 
   useEffect(() => {
     if (
@@ -64,9 +65,7 @@ export const ClerkInterpreterDetails = () => {
         Duration.Short
       );
       dispatch(showNotifierToast(toast));
-      dispatch(resetClerkInterpreterDetailsUpdate());
-      setCurrentUIMode(UIMode.View);
-      setHasLocalChanges(false);
+      resetToInitialState();
     } else if (
       interpreterDetailsUpdateStatus === APIResponseStatus.Cancelled &&
       currentUIMode === UIMode.EditInterpreterDetails

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationDetails.tsx
@@ -1,5 +1,5 @@
 import { Add as AddIcon } from '@mui/icons-material';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   CustomButton,
   CustomModal,
@@ -41,13 +41,19 @@ export const QualificationDetails = () => {
   // Redux
   const dispatch = useAppDispatch();
   const { interpreter } = useAppSelector(clerkInterpreterOverviewSelector);
-  const { addQualificationStatus } = useAppSelector(qualificationSelector);
+  const { addStatus } = useAppSelector(qualificationSelector);
 
   // I18n
   const { t } = useAppTranslation({
     keyPrefix: 'otr.component.clerkInterpreterOverview.qualifications',
   });
   const translateCommon = useCommonTranslation();
+
+  useEffect(() => {
+    if (addStatus === APIResponseStatus.Success) {
+      handleCloseModal();
+    }
+  }, [addStatus]);
 
   if (!interpreter) {
     return null;
@@ -87,7 +93,7 @@ export const QualificationDetails = () => {
     dispatch(addQualification(qualification));
   };
 
-  const onQualificationRemove = (qualification: Qualification) => {
+  const handleRemoveQualification = (qualification: Qualification) => {
     const notifier = NotifierUtils.createNotifierDialog(
       t('actions.removal.dialog.header'),
       Severity.Info,
@@ -118,13 +124,13 @@ export const QualificationDetails = () => {
         open={open}
         onCloseModal={handleCloseModal}
         ariaLabelledBy="modal-title"
-        modalTitle={'Lisää kielipari'}
+        modalTitle={translateCommon('addQualification')}
       >
         <AddQualification
           interpreterId={interpreter.id}
           onCancel={handleCloseModal}
           onQualificationAdd={handleAddQualification}
-          isLoading={addQualificationStatus === APIResponseStatus.InProgress}
+          isLoading={addStatus === APIResponseStatus.InProgress}
         />
       </CustomModal>
       <div className="rows gapped-xs">
@@ -138,20 +144,20 @@ export const QualificationDetails = () => {
             onButtonClick={filterByQualificationStatus}
           />
           <CustomButton
-            data-testid="clerk-interpreter-overview__qualifications-details__add-button"
+            data-testid="clerk-interpreter-overview__qualification-details__add-button"
             variant={Variant.Contained}
             color={Color.Secondary}
             startIcon={<AddIcon />}
             onClick={handleOpenModal}
           >
-            {t('buttons.add')}
+            {translateCommon('addQualification')}
           </CustomButton>
         </div>
         {activeQualifications.length ? (
           <QualificationListing
             qualifications={activeQualifications}
             permissionToPublishReadOnly={false}
-            onQualificationRemove={onQualificationRemove}
+            handleRemoveQualification={handleRemoveQualification}
           />
         ) : (
           <Text className="centered bold margin-top-lg">

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationListing.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationListing.tsx
@@ -22,6 +22,7 @@ import {
   useKoodistoLanguagesTranslation,
 } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { ExaminationType } from 'enums/interpreter';
 import { Qualification } from 'interfaces/qualification';
 import { updateQualificationPublishPermission } from 'redux/reducers/clerkInterpreterOverview';
 import {
@@ -81,6 +82,17 @@ export const QualificationListing = ({
     dispatch(showNotifierDialog(notifier));
   };
 
+  const getExaminationTypeText = (examinationtype: ExaminationType) => {
+    switch (examinationtype) {
+      case ExaminationType.LegalInterpreterExam:
+        return translateCommon('examinationType.legalInterpreterExam');
+      case ExaminationType.Other:
+        return translateCommon('examinationType.degreeStudies');
+      default:
+        return '';
+    }
+  };
+
   return (
     <LoadingProgressIndicator isLoading={isLoading}>
       <Table
@@ -114,7 +126,7 @@ export const QualificationListing = ({
               </TableCell>
               <TableCell>
                 <div className="columns gapped-xs">
-                  <Text>{q.examinationType}</Text>
+                  <Text>{getExaminationTypeText(q.examinationType)}</Text>
                 </div>
               </TableCell>
               <TableCell>

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationListing.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationListing.tsx
@@ -35,9 +35,11 @@ import { NotifierUtils } from 'utils/notifier';
 export const QualificationListing = ({
   qualifications,
   permissionToPublishReadOnly,
+  onQualificationRemove,
 }: {
   qualifications: Array<Qualification>;
   permissionToPublishReadOnly: boolean;
+  onQualificationRemove: (q: Qualification) => void;
 }) => {
   const translateLanguage = useKoodistoLanguagesTranslation();
   const translateCommon = useCommonTranslation();
@@ -111,68 +113,70 @@ export const QualificationListing = ({
           </TableRow>
         </TableHead>
         <TableBody>
-          {qualifications.map((q, i) => (
-            <TableRow
-              key={q.id ?? q.tempId}
-              data-testid={`qualifications-table__id-${
-                q.id ?? `${i}-unsaved`
-              }-row`}
-            >
-              <TableCell>
-                <Text>
-                  {`${translateLanguage(q.fromLang)}
-             - ${translateLanguage(q.toLang)}`}
-                </Text>
-              </TableCell>
-              <TableCell>
-                <div className="columns gapped-xs">
-                  <Text>{getExaminationTypeText(q.examinationType)}</Text>
-                </div>
-              </TableCell>
-              <TableCell>
-                <Text>{DateUtils.formatOptionalDate(dayjs(q.beginDate))}</Text>
-              </TableCell>
-              <TableCell>
-                <Text>{DateUtils.formatOptionalDate(dayjs(q.endDate))}</Text>
-              </TableCell>
-              <TableCell>
-                {permissionToPublishReadOnly ? (
+          {qualifications
+            .filter((q) => !q.deleted)
+            .map((q, i) => (
+              <TableRow
+                key={q.id ?? q.tempId}
+                data-testid={`qualifications-table__id-${
+                  q.id ?? `${i}-unsaved`
+                }-row`}
+              >
+                <TableCell>
                   <Text>
-                    {q.permissionToPublish
-                      ? translateCommon('yes')
-                      : translateCommon('no')}
+                    {`${translateLanguage(q.fromLang)}
+             - ${translateLanguage(q.toLang)}`}
                   </Text>
-                ) : (
-                  <CustomSwitch
-                    value={q.permissionToPublish}
-                    onChange={() => {
-                      onPublishPermissionChange(q);
-                    }}
-                    leftLabel={translateCommon('no')}
-                    rightLabel={translateCommon('yes')}
-                    aria-label={t(
-                      'actions.changePermissionToPublish.ariaLabel'
-                    )}
-                  />
-                )}
-              </TableCell>
-              <TableCell className="centered">
-                <CustomIconButton
-                  onChange={() => {
-                    return;
-                  }}
-                  aria-label={t('actions.removal.ariaLabel')}
-                  data-testid={
-                    q.id
-                      ? `qualifications-table__id-${q.id}-row__delete-button`
-                      : `qualifications-table__id-${i}-unsaved}-row__delete-button`
-                  }
-                >
-                  <DeleteIcon color={Color.Error} />
-                </CustomIconButton>
-              </TableCell>
-            </TableRow>
-          ))}
+                </TableCell>
+                <TableCell>
+                  <div className="columns gapped-xs">
+                    <Text>{getExaminationTypeText(q.examinationType)}</Text>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Text>
+                    {DateUtils.formatOptionalDate(dayjs(q.beginDate))}
+                  </Text>
+                </TableCell>
+                <TableCell>
+                  <Text>{DateUtils.formatOptionalDate(dayjs(q.endDate))}</Text>
+                </TableCell>
+                <TableCell>
+                  {permissionToPublishReadOnly ? (
+                    <Text>
+                      {q.permissionToPublish
+                        ? translateCommon('yes')
+                        : translateCommon('no')}
+                    </Text>
+                  ) : (
+                    <CustomSwitch
+                      value={q.permissionToPublish}
+                      onChange={() => {
+                        onPublishPermissionChange(q);
+                      }}
+                      leftLabel={translateCommon('no')}
+                      rightLabel={translateCommon('yes')}
+                      aria-label={t(
+                        'actions.changePermissionToPublish.ariaLabel'
+                      )}
+                    />
+                  )}
+                </TableCell>
+                <TableCell className="centered">
+                  <CustomIconButton
+                    onClick={() => onQualificationRemove(q)}
+                    aria-label={t('actions.removal.ariaLabel')}
+                    data-testid={
+                      q.id
+                        ? `qualifications-table__id-${q.id}-row__delete-button`
+                        : `qualifications-table__id-${i}-unsaved}-row__delete-button`
+                    }
+                  >
+                    <DeleteIcon color={Color.Error} />
+                  </CustomIconButton>
+                </TableCell>
+              </TableRow>
+            ))}
         </TableBody>
       </Table>
     </LoadingProgressIndicator>

--- a/frontend/packages/otr/src/enums/api.ts
+++ b/frontend/packages/otr/src/enums/api.ts
@@ -2,6 +2,7 @@ export enum APIEndpoints {
   PublicInterpreter = '/otr/api/v1/interpreter',
   ClerkInterpreter = '/otr/api/v1/clerk/interpreter',
   ClerkUser = '/otr/api/v1/clerk/user',
+  Qualification = '/otr/api/v1/clerk/interpreter/qualification',
 }
 
 /**

--- a/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
@@ -59,4 +59,6 @@ export interface ClerkInterpreterOverviewState {
   overviewStatus: APIResponseStatus;
   interpreterDetailsUpdateStatus: APIResponseStatus;
   qualificationDetailsUpdateStatus: APIResponseStatus;
+  qualification?: Qualification;
+  qualificationStatus: APIResponseStatus;
 }

--- a/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
@@ -59,6 +59,4 @@ export interface ClerkInterpreterOverviewState {
   overviewStatus: APIResponseStatus;
   interpreterDetailsUpdateStatus: APIResponseStatus;
   qualificationDetailsUpdateStatus: APIResponseStatus;
-  qualification?: Qualification;
-  qualificationStatus: APIResponseStatus;
 }

--- a/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
@@ -58,5 +58,4 @@ export interface ClerkInterpreterOverviewState {
   interpreter?: ClerkInterpreter;
   overviewStatus: APIResponseStatus;
   interpreterDetailsUpdateStatus: APIResponseStatus;
-  qualificationDetailsUpdateStatus: APIResponseStatus;
 }

--- a/frontend/packages/otr/src/interfaces/qualification.ts
+++ b/frontend/packages/otr/src/interfaces/qualification.ts
@@ -1,4 +1,5 @@
 import { Dayjs } from 'dayjs';
+import { APIResponseStatus } from 'shared/enums';
 import { WithId, WithVersion } from 'shared/interfaces';
 
 import { QualificationStatus } from 'enums/clerkInterpreter';
@@ -7,20 +8,27 @@ import { ExaminationType } from 'enums/interpreter';
 export interface Qualification extends WithId, WithVersion {
   fromLang: string;
   toLang: string;
-  beginDate: Dayjs;
-  endDate: Dayjs;
+  beginDate?: Dayjs;
+  endDate?: Dayjs;
   examinationType: ExaminationType;
   permissionToPublish: boolean;
   diaryNumber?: string;
   tempId?: string;
+  interpreterId?: number;
 }
 
 export interface QualificationResponse
   extends Omit<Qualification, 'beginDate' | 'endDate'> {
   beginDate: string;
   endDate: string;
+  deleted: boolean;
 }
 
 export type QualificationsGroupedByStatus = {
   [key in QualificationStatus]: Array<Qualification>;
 };
+
+export interface QualificationState {
+  qualification: Qualification | Record<string, never>;
+  status: APIResponseStatus;
+}

--- a/frontend/packages/otr/src/interfaces/qualification.ts
+++ b/frontend/packages/otr/src/interfaces/qualification.ts
@@ -1,11 +1,13 @@
 import { Dayjs } from 'dayjs';
-import { APIResponseStatus } from 'shared/enums';
-import { WithId, WithVersion } from 'shared/interfaces';
+import { WithId, WithTempId, WithVersion } from 'shared/interfaces';
 
 import { QualificationStatus } from 'enums/clerkInterpreter';
 import { ExaminationType } from 'enums/interpreter';
 
-export interface Qualification extends WithId, WithVersion {
+export interface Qualification
+  extends Partial<WithId>,
+    Partial<WithVersion>,
+    Partial<WithTempId> {
   fromLang: string;
   toLang: string;
   beginDate: Dayjs;
@@ -13,24 +15,15 @@ export interface Qualification extends WithId, WithVersion {
   examinationType: ExaminationType;
   permissionToPublish: boolean;
   diaryNumber?: string;
-  tempId?: string;
   interpreterId?: number;
-  deleted?: boolean;
 }
 
 export interface QualificationResponse
   extends Omit<Qualification, 'beginDate' | 'endDate'> {
   beginDate: string;
   endDate: string;
-  deleted: boolean;
 }
 
 export type QualificationsGroupedByStatus = {
   [key in QualificationStatus]: Array<Qualification>;
 };
-
-export interface QualificationState {
-  qualification: Qualification | Record<string, never>;
-  addQualificationStatus: APIResponseStatus;
-  removeQualificationStatus: APIResponseStatus;
-}

--- a/frontend/packages/otr/src/interfaces/qualification.ts
+++ b/frontend/packages/otr/src/interfaces/qualification.ts
@@ -8,8 +8,8 @@ import { ExaminationType } from 'enums/interpreter';
 export interface Qualification extends WithId, WithVersion {
   fromLang: string;
   toLang: string;
-  beginDate?: Dayjs;
-  endDate?: Dayjs;
+  beginDate: Dayjs;
+  endDate: Dayjs;
   examinationType: ExaminationType;
   permissionToPublish: boolean;
   diaryNumber?: string;

--- a/frontend/packages/otr/src/interfaces/qualification.ts
+++ b/frontend/packages/otr/src/interfaces/qualification.ts
@@ -15,6 +15,7 @@ export interface Qualification extends WithId, WithVersion {
   diaryNumber?: string;
   tempId?: string;
   interpreterId?: number;
+  deleted?: boolean;
 }
 
 export interface QualificationResponse
@@ -30,5 +31,6 @@ export type QualificationsGroupedByStatus = {
 
 export interface QualificationState {
   qualification: Qualification | Record<string, never>;
-  status: APIResponseStatus;
+  addQualificationStatus: APIResponseStatus;
+  removeQualificationStatus: APIResponseStatus;
 }

--- a/frontend/packages/otr/src/pages/ClerkInterpreterOverviewPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkInterpreterOverviewPage.tsx
@@ -2,7 +2,7 @@ import { Box, Paper } from '@mui/material';
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { H1 } from 'shared/components';
-import { APIResponseStatus, Severity } from 'shared/enums';
+import { APIResponseStatus, Duration, Severity } from 'shared/enums';
 
 import { ClerkInterpreterDetails } from 'components/clerkInterpreter/overview/ClerkInterpreterDetails';
 import { QualificationDetails } from 'components/clerkInterpreter/overview/QualificationDetails';
@@ -16,6 +16,7 @@ import {
   resetClerkInterpreterOverview,
 } from 'redux/reducers/clerkInterpreterOverview';
 import { showNotifierToast } from 'redux/reducers/notifier';
+import { resetQualification } from 'redux/reducers/qualification';
 import { clerkInterpreterOverviewSelector } from 'redux/selectors/clerkInterpreterOverview';
 import { qualificationSelector } from 'redux/selectors/qualification';
 import { NotifierUtils } from 'utils/notifier';
@@ -55,7 +56,8 @@ export const ClerkInterpreterOverviewPage = () => {
       // Show an error
       const toast = NotifierUtils.createNotifierToast(
         Severity.Error,
-        t('pages.clerkInterpreterOverviewPage.toasts.notFound')
+        t('pages.clerkInterpreterOverviewPage.toasts.notFound'),
+        Duration.Short
       );
       dispatch(showNotifierToast(toast));
       navigate(AppRoutes.ClerkHomePage);
@@ -71,6 +73,7 @@ export const ClerkInterpreterOverviewPage = () => {
 
   useEffect(() => {
     return () => {
+      dispatch(resetQualification());
       dispatch(resetClerkInterpreterOverview());
     };
   }, [dispatch]);
@@ -79,13 +82,15 @@ export const ClerkInterpreterOverviewPage = () => {
     if (addQualificationStatus === APIResponseStatus.Success) {
       const toast = NotifierUtils.createNotifierToast(
         Severity.Success,
-        t('component.clerkInterpreterOverview.toasts.updated')
+        t('component.clerkInterpreterOverview.toasts.updated'),
+        Duration.Short
       );
       dispatch(showNotifierToast(toast));
     } else if (addQualificationStatus === APIResponseStatus.Error) {
       const toast = NotifierUtils.createNotifierToast(
         Severity.Error,
-        t('component.clerkInterpreterOverview.toasts.updateFailed')
+        t('component.clerkInterpreterOverview.toasts.updateFailed'),
+        Duration.Short
       );
       dispatch(showNotifierToast(toast));
     }

--- a/frontend/packages/otr/src/pages/ClerkInterpreterOverviewPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkInterpreterOverviewPage.tsx
@@ -16,7 +16,7 @@ import {
   resetClerkInterpreterOverview,
 } from 'redux/reducers/clerkInterpreterOverview';
 import { showNotifierToast } from 'redux/reducers/notifier';
-import { resetQualification } from 'redux/reducers/qualification';
+import { resetQualificationState } from 'redux/reducers/qualification';
 import { clerkInterpreterOverviewSelector } from 'redux/selectors/clerkInterpreterOverview';
 import { qualificationSelector } from 'redux/selectors/qualification';
 import { NotifierUtils } from 'utils/notifier';
@@ -29,7 +29,7 @@ export const ClerkInterpreterOverviewPage = () => {
   const { overviewStatus, interpreter } = useAppSelector(
     clerkInterpreterOverviewSelector
   );
-  const { addQualificationStatus } = useAppSelector(qualificationSelector);
+  const { addStatus } = useAppSelector(qualificationSelector);
 
   const selectedInterpreterId = interpreter?.id;
   // React Router
@@ -71,29 +71,22 @@ export const ClerkInterpreterOverviewPage = () => {
 
   useEffect(() => {
     return () => {
-      dispatch(resetQualification());
+      dispatch(resetQualificationState());
       dispatch(resetClerkInterpreterOverview());
     };
   }, [dispatch]);
 
   useEffect(() => {
-    if (addQualificationStatus === APIResponseStatus.Success) {
+    if (addStatus === APIResponseStatus.Success) {
       const toast = NotifierUtils.createNotifierToast(
         Severity.Success,
-        t('component.clerkInterpreterOverview.toasts.updated'),
+        t('component.newQualification.toasts.success'),
         Duration.Short
       );
       dispatch(showNotifierToast(toast));
-    } else if (addQualificationStatus === APIResponseStatus.Error) {
-      const toast = NotifierUtils.createNotifierToast(
-        Severity.Error,
-        t('component.clerkInterpreterOverview.toasts.updateFailed'),
-        Duration.Short
-      );
-      dispatch(showNotifierToast(toast));
-      dispatch(resetQualification());
+      dispatch(resetQualificationState());
     }
-  }, [addQualificationStatus, dispatch, t]);
+  }, [addStatus, dispatch, t]);
 
   return (
     <Box className="clerk-interpreter-overview-page">

--- a/frontend/packages/otr/src/pages/ClerkInterpreterOverviewPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkInterpreterOverviewPage.tsx
@@ -29,9 +29,7 @@ export const ClerkInterpreterOverviewPage = () => {
   const { overviewStatus, interpreter } = useAppSelector(
     clerkInterpreterOverviewSelector
   );
-  const { status: addQualificationStatus } = useAppSelector(
-    qualificationSelector
-  );
+  const { addQualificationStatus } = useAppSelector(qualificationSelector);
 
   const selectedInterpreterId = interpreter?.id;
   // React Router
@@ -93,6 +91,7 @@ export const ClerkInterpreterOverviewPage = () => {
         Duration.Short
       );
       dispatch(showNotifierToast(toast));
+      dispatch(resetQualification());
     }
   }, [addQualificationStatus, dispatch, t]);
 

--- a/frontend/packages/otr/src/pages/ClerkInterpreterOverviewPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkInterpreterOverviewPage.tsx
@@ -17,6 +17,7 @@ import {
 } from 'redux/reducers/clerkInterpreterOverview';
 import { showNotifierToast } from 'redux/reducers/notifier';
 import { clerkInterpreterOverviewSelector } from 'redux/selectors/clerkInterpreterOverview';
+import { qualificationSelector } from 'redux/selectors/qualification';
 import { NotifierUtils } from 'utils/notifier';
 
 export const ClerkInterpreterOverviewPage = () => {
@@ -26,6 +27,9 @@ export const ClerkInterpreterOverviewPage = () => {
   const dispatch = useAppDispatch();
   const { overviewStatus, interpreter } = useAppSelector(
     clerkInterpreterOverviewSelector
+  );
+  const { status: addQualificationStatus } = useAppSelector(
+    qualificationSelector
   );
 
   const selectedInterpreterId = interpreter?.id;
@@ -70,6 +74,22 @@ export const ClerkInterpreterOverviewPage = () => {
       dispatch(resetClerkInterpreterOverview());
     };
   }, [dispatch]);
+
+  useEffect(() => {
+    if (addQualificationStatus === APIResponseStatus.Success) {
+      const toast = NotifierUtils.createNotifierToast(
+        Severity.Success,
+        t('component.clerkInterpreterOverview.toasts.updated')
+      );
+      dispatch(showNotifierToast(toast));
+    } else if (addQualificationStatus === APIResponseStatus.Error) {
+      const toast = NotifierUtils.createNotifierToast(
+        Severity.Error,
+        t('component.clerkInterpreterOverview.toasts.updateFailed')
+      );
+      dispatch(showNotifierToast(toast));
+    }
+  }, [addQualificationStatus, dispatch, t]);
 
   return (
     <Box className="clerk-interpreter-overview-page">

--- a/frontend/packages/otr/src/redux/reducers/clerkInterpreterOverview.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkInterpreterOverview.ts
@@ -6,13 +6,11 @@ import {
   ClerkInterpreter,
   ClerkInterpreterOverviewState,
 } from 'interfaces/clerkInterpreter';
-import { Qualification } from 'interfaces/qualification';
 
 const initialState: ClerkInterpreterOverviewState = {
   interpreter: undefined,
   overviewStatus: APIResponseStatus.NotStarted,
   interpreterDetailsUpdateStatus: APIResponseStatus.NotStarted,
-  qualificationDetailsUpdateStatus: APIResponseStatus.NotStarted,
 };
 
 const clerkInterpreterOverviewSlice = createSlice({
@@ -22,6 +20,12 @@ const clerkInterpreterOverviewSlice = createSlice({
     loadClerkInterpreterOverview(state, _action: PayloadAction<WithId>) {
       state.overviewStatus = APIResponseStatus.InProgress;
     },
+    setClerkInterpreterOverview(
+      state,
+      action: PayloadAction<ClerkInterpreter>
+    ) {
+      state.interpreter = action.payload;
+    },
     storeClerkInterpreterOverview(
       state,
       action: PayloadAction<ClerkInterpreter>
@@ -29,7 +33,7 @@ const clerkInterpreterOverviewSlice = createSlice({
       state.overviewStatus = APIResponseStatus.Success;
       state.interpreter = action.payload;
     },
-    loadingClerkInterpreterOverviewFailed(state) {
+    rejectLoadClerkInterpreterOverview(state) {
       state.overviewStatus = APIResponseStatus.Error;
     },
     resetClerkInterpreterOverview(state) {
@@ -37,8 +41,6 @@ const clerkInterpreterOverviewSlice = createSlice({
       state.interpreter = initialState.interpreter;
       state.interpreterDetailsUpdateStatus =
         initialState.interpreterDetailsUpdateStatus;
-      state.qualificationDetailsUpdateStatus =
-        initialState.qualificationDetailsUpdateStatus;
     },
     resetClerkInterpreterDetailsUpdate(state) {
       state.interpreterDetailsUpdateStatus =
@@ -50,7 +52,7 @@ const clerkInterpreterOverviewSlice = createSlice({
     ) {
       state.interpreterDetailsUpdateStatus = APIResponseStatus.InProgress;
     },
-    storeClerkInterpreterOverviewUpdateSuccess(
+    storeClerkInterpreterOverviewUpdate(
       state,
       action: PayloadAction<ClerkInterpreter>
     ) {
@@ -60,18 +62,6 @@ const clerkInterpreterOverviewSlice = createSlice({
     rejectClerkInterpreterOverviewUpdate(state) {
       state.interpreterDetailsUpdateStatus = APIResponseStatus.Error;
     },
-    updateQualificationPublishPermission(
-      state,
-      _action: PayloadAction<Qualification>
-    ) {
-      state.qualificationDetailsUpdateStatus = APIResponseStatus.InProgress;
-    },
-    updateQualificationPublishPermissionSuccess(state) {
-      state.qualificationDetailsUpdateStatus = APIResponseStatus.Success;
-    },
-    rejectQualificationPublishPermissionUpdate(state) {
-      state.qualificationDetailsUpdateStatus = APIResponseStatus.Error;
-    },
   },
 });
 
@@ -79,14 +69,12 @@ export const clerkInterpreterOverviewReducer =
   clerkInterpreterOverviewSlice.reducer;
 export const {
   loadClerkInterpreterOverview,
+  setClerkInterpreterOverview,
   storeClerkInterpreterOverview,
-  loadingClerkInterpreterOverviewFailed,
+  rejectLoadClerkInterpreterOverview,
   resetClerkInterpreterOverview,
   resetClerkInterpreterDetailsUpdate,
   updateClerkInterpreterDetails,
   rejectClerkInterpreterOverviewUpdate,
-  storeClerkInterpreterOverviewUpdateSuccess,
-  updateQualificationPublishPermission,
-  updateQualificationPublishPermissionSuccess,
-  rejectQualificationPublishPermissionUpdate,
+  storeClerkInterpreterOverviewUpdate,
 } = clerkInterpreterOverviewSlice.actions;

--- a/frontend/packages/otr/src/redux/reducers/clerkInterpreterOverview.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkInterpreterOverview.ts
@@ -13,8 +13,6 @@ const initialState: ClerkInterpreterOverviewState = {
   overviewStatus: APIResponseStatus.NotStarted,
   interpreterDetailsUpdateStatus: APIResponseStatus.NotStarted,
   qualificationDetailsUpdateStatus: APIResponseStatus.NotStarted,
-  qualification: undefined,
-  qualificationStatus: APIResponseStatus.NotStarted,
 };
 
 const clerkInterpreterOverviewSlice = createSlice({
@@ -37,6 +35,10 @@ const clerkInterpreterOverviewSlice = createSlice({
     resetClerkInterpreterOverview(state) {
       state.overviewStatus = initialState.overviewStatus;
       state.interpreter = initialState.interpreter;
+      state.interpreterDetailsUpdateStatus =
+        initialState.interpreterDetailsUpdateStatus;
+      state.qualificationDetailsUpdateStatus =
+        initialState.qualificationDetailsUpdateStatus;
     },
     resetClerkInterpreterDetailsUpdate(state) {
       state.interpreterDetailsUpdateStatus =

--- a/frontend/packages/otr/src/redux/reducers/clerkInterpreterOverview.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkInterpreterOverview.ts
@@ -6,12 +6,15 @@ import {
   ClerkInterpreter,
   ClerkInterpreterOverviewState,
 } from 'interfaces/clerkInterpreter';
+import { Qualification } from 'interfaces/qualification';
 
 const initialState: ClerkInterpreterOverviewState = {
   interpreter: undefined,
   overviewStatus: APIResponseStatus.NotStarted,
   interpreterDetailsUpdateStatus: APIResponseStatus.NotStarted,
   qualificationDetailsUpdateStatus: APIResponseStatus.NotStarted,
+  qualification: undefined,
+  qualificationStatus: APIResponseStatus.NotStarted,
 };
 
 const clerkInterpreterOverviewSlice = createSlice({
@@ -55,6 +58,18 @@ const clerkInterpreterOverviewSlice = createSlice({
     rejectClerkInterpreterOverviewUpdate(state) {
       state.interpreterDetailsUpdateStatus = APIResponseStatus.Error;
     },
+    updateQualificationPublishPermission(
+      state,
+      _action: PayloadAction<Qualification>
+    ) {
+      state.qualificationDetailsUpdateStatus = APIResponseStatus.InProgress;
+    },
+    updateQualificationPublishPermissionSuccess(state) {
+      state.qualificationDetailsUpdateStatus = APIResponseStatus.Success;
+    },
+    rejectQualificationPublishPermissionUpdate(state) {
+      state.qualificationDetailsUpdateStatus = APIResponseStatus.Error;
+    },
   },
 });
 
@@ -69,4 +84,7 @@ export const {
   updateClerkInterpreterDetails,
   rejectClerkInterpreterOverviewUpdate,
   storeClerkInterpreterOverviewUpdateSuccess,
+  updateQualificationPublishPermission,
+  updateQualificationPublishPermissionSuccess,
+  rejectQualificationPublishPermissionUpdate,
 } = clerkInterpreterOverviewSlice.actions;

--- a/frontend/packages/otr/src/redux/reducers/qualification.ts
+++ b/frontend/packages/otr/src/redux/reducers/qualification.ts
@@ -1,52 +1,69 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { APIResponseStatus } from 'shared/enums';
 
-import { Qualification, QualificationState } from 'interfaces/qualification';
+import { Qualification } from 'interfaces/qualification';
+
+interface QualificationState {
+  addStatus: APIResponseStatus;
+  updateStatus: APIResponseStatus;
+  removeStatus: APIResponseStatus;
+}
 
 const initialState: QualificationState = {
-  addQualificationStatus: APIResponseStatus.NotStarted,
-  removeQualificationStatus: APIResponseStatus.NotStarted,
-  qualification: {},
+  addStatus: APIResponseStatus.NotStarted,
+  removeStatus: APIResponseStatus.NotStarted,
+  updateStatus: APIResponseStatus.NotStarted,
 };
 
 const qualificationSlice = createSlice({
   name: 'qualification',
   initialState,
   reducers: {
-    resetQualification(state) {
-      state.removeQualificationStatus = initialState.removeQualificationStatus;
-      state.addQualificationStatus = initialState.addQualificationStatus;
-      state.qualification = initialState.qualification;
+    resetQualificationState(state) {
+      state.removeStatus = initialState.removeStatus;
+      state.addStatus = initialState.addStatus;
+      state.updateStatus = initialState.updateStatus;
     },
-    addQualification(state, action: PayloadAction<Qualification>) {
-      state.addQualificationStatus = APIResponseStatus.InProgress;
-      state.qualification = action.payload;
+    addQualification(state, _action: PayloadAction<Qualification>) {
+      state.addStatus = APIResponseStatus.InProgress;
     },
     rejectAddQualification(state) {
-      state.addQualificationStatus = APIResponseStatus.Error;
+      state.addStatus = APIResponseStatus.Error;
     },
-    addQualificationSuccess(state) {
-      state.addQualificationStatus = APIResponseStatus.Success;
+    addQualificationSucceeded(state) {
+      state.addStatus = APIResponseStatus.Success;
     },
     removeQualification(state, _action: PayloadAction<number>) {
-      state.removeQualificationStatus = APIResponseStatus.InProgress;
+      state.removeStatus = APIResponseStatus.InProgress;
     },
     rejectRemoveQualification(state) {
-      state.addQualificationStatus = APIResponseStatus.Error;
+      state.removeStatus = APIResponseStatus.Error;
     },
-    removeQualificationSuccess(state) {
-      state.addQualificationStatus = APIResponseStatus.Success;
+    removeQualificationSucceeded(state) {
+      state.removeStatus = APIResponseStatus.Success;
+    },
+    updateQualification(state, _action: PayloadAction<Qualification>) {
+      state.updateStatus = APIResponseStatus.InProgress;
+    },
+    rejectUpdateQualification(state) {
+      state.updateStatus = APIResponseStatus.Error;
+    },
+    updateQualificationSucceeded(state) {
+      state.updateStatus = APIResponseStatus.Success;
     },
   },
 });
 
-export const qualifcationReducer = qualificationSlice.reducer;
+export const qualificationReducer = qualificationSlice.reducer;
 export const {
+  resetQualificationState,
   addQualification,
   rejectAddQualification,
-  addQualificationSuccess,
-  resetQualification,
+  addQualificationSucceeded,
   removeQualification,
   rejectRemoveQualification,
-  removeQualificationSuccess,
+  removeQualificationSucceeded,
+  updateQualification,
+  updateQualificationSucceeded,
+  rejectUpdateQualification,
 } = qualificationSlice.actions;

--- a/frontend/packages/otr/src/redux/reducers/qualification.ts
+++ b/frontend/packages/otr/src/redux/reducers/qualification.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { APIResponseStatus } from 'shared/enums';
+
+import { Qualification, QualificationState } from 'interfaces/qualification';
+
+const initialState: QualificationState = {
+  status: APIResponseStatus.NotStarted,
+  qualification: {},
+};
+
+const qualificationSlice = createSlice({
+  name: 'qualification',
+  initialState,
+  reducers: {
+    addQualification(state, action: PayloadAction<Qualification>) {
+      state.status = APIResponseStatus.InProgress;
+      state.qualification = action.payload;
+    },
+    rejectAddQualification(state) {
+      state.status = APIResponseStatus.Error;
+    },
+    addQualificationSuccess(state) {
+      state.status = APIResponseStatus.Success;
+    },
+  },
+});
+
+export const qualifcationReducer = qualificationSlice.reducer;
+export const {
+  addQualification,
+  rejectAddQualification,
+  addQualificationSuccess,
+} = qualificationSlice.actions;

--- a/frontend/packages/otr/src/redux/reducers/qualification.ts
+++ b/frontend/packages/otr/src/redux/reducers/qualification.ts
@@ -12,6 +12,10 @@ const qualificationSlice = createSlice({
   name: 'qualification',
   initialState,
   reducers: {
+    resetQualification(state) {
+      state.status = initialState.status;
+      state.qualification = initialState.qualification;
+    },
     addQualification(state, action: PayloadAction<Qualification>) {
       state.status = APIResponseStatus.InProgress;
       state.qualification = action.payload;
@@ -30,4 +34,5 @@ export const {
   addQualification,
   rejectAddQualification,
   addQualificationSuccess,
+  resetQualification,
 } = qualificationSlice.actions;

--- a/frontend/packages/otr/src/redux/reducers/qualification.ts
+++ b/frontend/packages/otr/src/redux/reducers/qualification.ts
@@ -4,7 +4,8 @@ import { APIResponseStatus } from 'shared/enums';
 import { Qualification, QualificationState } from 'interfaces/qualification';
 
 const initialState: QualificationState = {
-  status: APIResponseStatus.NotStarted,
+  addQualificationStatus: APIResponseStatus.NotStarted,
+  removeQualificationStatus: APIResponseStatus.NotStarted,
   qualification: {},
 };
 
@@ -13,18 +14,28 @@ const qualificationSlice = createSlice({
   initialState,
   reducers: {
     resetQualification(state) {
-      state.status = initialState.status;
+      state.removeQualificationStatus = initialState.removeQualificationStatus;
+      state.addQualificationStatus = initialState.addQualificationStatus;
       state.qualification = initialState.qualification;
     },
     addQualification(state, action: PayloadAction<Qualification>) {
-      state.status = APIResponseStatus.InProgress;
+      state.addQualificationStatus = APIResponseStatus.InProgress;
       state.qualification = action.payload;
     },
     rejectAddQualification(state) {
-      state.status = APIResponseStatus.Error;
+      state.addQualificationStatus = APIResponseStatus.Error;
     },
     addQualificationSuccess(state) {
-      state.status = APIResponseStatus.Success;
+      state.addQualificationStatus = APIResponseStatus.Success;
+    },
+    removeQualification(state, _action: PayloadAction<number>) {
+      state.removeQualificationStatus = APIResponseStatus.InProgress;
+    },
+    rejectRemoveQualification(state) {
+      state.addQualificationStatus = APIResponseStatus.Error;
+    },
+    removeQualificationSuccess(state) {
+      state.addQualificationStatus = APIResponseStatus.Success;
     },
   },
 });
@@ -35,4 +46,7 @@ export const {
   rejectAddQualification,
   addQualificationSuccess,
   resetQualification,
+  removeQualification,
+  rejectRemoveQualification,
+  removeQualificationSuccess,
 } = qualificationSlice.actions;

--- a/frontend/packages/otr/src/redux/sagas/clerkInterpreterOverview.ts
+++ b/frontend/packages/otr/src/redux/sagas/clerkInterpreterOverview.ts
@@ -93,10 +93,10 @@ function* doUpdateQualificationPublishPermission(
     const apiResponse: AxiosResponse<ClerkInterpreterResponse> = yield call(
       axiosInstance.put,
       APIEndpoints.Qualification,
-      {
+      SerializationUtils.serializeQualification({
         ...action.payload,
         permissionToPublish: !action.payload.permissionToPublish,
-      }
+      })
     );
     const interpreter = SerializationUtils.deserializeClerkInterpreter(
       apiResponse.data

--- a/frontend/packages/otr/src/redux/sagas/index.ts
+++ b/frontend/packages/otr/src/redux/sagas/index.ts
@@ -4,6 +4,7 @@ import { watchFetchClerkInterpreters } from 'redux/sagas/clerkInterpreter';
 import { watchFetchClerkInterpreterOverview } from 'redux/sagas/clerkInterpreterOverview';
 import { watchFetchClerkUser } from 'redux/sagas/clerkUser';
 import { watchFetchPublicInterpreters } from 'redux/sagas/publicInterpreter';
+import { watchAddQualification } from 'redux/sagas/qualification';
 
 export default function* rootSaga() {
   yield all([
@@ -11,5 +12,6 @@ export default function* rootSaga() {
     watchFetchClerkInterpreters(),
     watchFetchClerkInterpreterOverview(),
     watchFetchClerkUser(),
+    watchAddQualification(),
   ]);
 }

--- a/frontend/packages/otr/src/redux/sagas/index.ts
+++ b/frontend/packages/otr/src/redux/sagas/index.ts
@@ -4,7 +4,10 @@ import { watchFetchClerkInterpreters } from 'redux/sagas/clerkInterpreter';
 import { watchFetchClerkInterpreterOverview } from 'redux/sagas/clerkInterpreterOverview';
 import { watchFetchClerkUser } from 'redux/sagas/clerkUser';
 import { watchFetchPublicInterpreters } from 'redux/sagas/publicInterpreter';
-import { watchAddQualification } from 'redux/sagas/qualification';
+import {
+  watchAddQualification,
+  watchRemoveQualification,
+} from 'redux/sagas/qualification';
 
 export default function* rootSaga() {
   yield all([
@@ -13,5 +16,6 @@ export default function* rootSaga() {
     watchFetchClerkInterpreterOverview(),
     watchFetchClerkUser(),
     watchAddQualification(),
+    watchRemoveQualification(),
   ]);
 }

--- a/frontend/packages/otr/src/redux/sagas/index.ts
+++ b/frontend/packages/otr/src/redux/sagas/index.ts
@@ -4,10 +4,7 @@ import { watchFetchClerkInterpreters } from 'redux/sagas/clerkInterpreter';
 import { watchFetchClerkInterpreterOverview } from 'redux/sagas/clerkInterpreterOverview';
 import { watchFetchClerkUser } from 'redux/sagas/clerkUser';
 import { watchFetchPublicInterpreters } from 'redux/sagas/publicInterpreter';
-import {
-  watchAddQualification,
-  watchRemoveQualification,
-} from 'redux/sagas/qualification';
+import { watchQualificationUpdates } from 'redux/sagas/qualification';
 
 export default function* rootSaga() {
   yield all([
@@ -15,7 +12,6 @@ export default function* rootSaga() {
     watchFetchClerkInterpreters(),
     watchFetchClerkInterpreterOverview(),
     watchFetchClerkUser(),
-    watchAddQualification(),
-    watchRemoveQualification(),
+    watchQualificationUpdates(),
   ]);
 }

--- a/frontend/packages/otr/src/redux/sagas/qualification.ts
+++ b/frontend/packages/otr/src/redux/sagas/qualification.ts
@@ -1,63 +1,102 @@
 import { PayloadAction } from '@reduxjs/toolkit';
-import { AxiosResponse } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { call, put, takeLatest } from 'redux-saga/effects';
 
 import axiosInstance from 'configs/axios';
 import { APIEndpoints } from 'enums/api';
 import { ClerkInterpreterResponse } from 'interfaces/clerkInterpreter';
 import { Qualification } from 'interfaces/qualification';
-import { loadClerkInterpreterOverview } from 'redux/reducers/clerkInterpreterOverview';
+import { setClerkInterpreterOverview } from 'redux/reducers/clerkInterpreterOverview';
+import { showNotifierToast } from 'redux/reducers/notifier';
 import {
   addQualification,
-  addQualificationSuccess,
+  addQualificationSucceeded,
   rejectAddQualification,
   rejectRemoveQualification,
+  rejectUpdateQualification,
   removeQualification,
-  removeQualificationSuccess,
+  removeQualificationSucceeded,
+  updateQualification,
+  updateQualificationSucceeded,
 } from 'redux/reducers/qualification';
+import { NotifierUtils } from 'utils/notifier';
 import { SerializationUtils } from 'utils/serialization';
 
-function* onAddQualification(action: PayloadAction<Qualification>) {
+function* addQualificationSaga(action: PayloadAction<Qualification>) {
   try {
     const { interpreterId } = action.payload;
     if (!interpreterId) {
       throw new Error();
     }
-    yield call(
+    const apiResponse: AxiosResponse<ClerkInterpreterResponse> = yield call(
       axiosInstance.post,
       `${APIEndpoints.ClerkInterpreter}/${interpreterId}/qualification`,
       SerializationUtils.serializeQualification(action.payload)
-    );
-
-    yield put(addQualificationSuccess());
-    yield put(loadClerkInterpreterOverview({ id: interpreterId }));
-  } catch (error) {
-    yield put(rejectAddQualification());
-  }
-}
-
-function* onRemoveQualification(action: PayloadAction<number>) {
-  try {
-    const apiResponse: AxiosResponse<ClerkInterpreterResponse> = yield call(
-      axiosInstance.delete,
-      `${APIEndpoints.ClerkInterpreter}/qualification/${action.payload}`
     );
 
     const interpreter = SerializationUtils.deserializeClerkInterpreter(
       apiResponse.data
     );
 
-    yield put(removeQualificationSuccess());
-    yield put(loadClerkInterpreterOverview({ id: interpreter.id }));
+    yield put(setClerkInterpreterOverview(interpreter));
+    yield put(addQualificationSucceeded());
   } catch (error) {
-    yield put(rejectRemoveQualification());
+    yield put(rejectAddQualification());
+    yield put(
+      showNotifierToast(
+        NotifierUtils.createAxiosErrorNotifierToast(error as AxiosError)
+      )
+    );
   }
 }
 
-export function* watchAddQualification() {
-  yield takeLatest(addQualification, onAddQualification);
+function* removeQualificationSaga(action: PayloadAction<number>) {
+  try {
+    const apiResponse: AxiosResponse<ClerkInterpreterResponse> = yield call(
+      axiosInstance.delete,
+      `${APIEndpoints.Qualification}/${action.payload}`
+    );
+
+    const interpreter = SerializationUtils.deserializeClerkInterpreter(
+      apiResponse.data
+    );
+
+    yield put(setClerkInterpreterOverview(interpreter));
+    yield put(removeQualificationSucceeded());
+  } catch (error) {
+    yield put(rejectRemoveQualification());
+    yield put(
+      showNotifierToast(
+        NotifierUtils.createAxiosErrorNotifierToast(error as AxiosError)
+      )
+    );
+  }
 }
 
-export function* watchRemoveQualification() {
-  yield takeLatest(removeQualification, onRemoveQualification);
+function* updateQualificationSaga(action: PayloadAction<Qualification>) {
+  try {
+    const apiResponse: AxiosResponse<ClerkInterpreterResponse> = yield call(
+      axiosInstance.put,
+      APIEndpoints.Qualification,
+      SerializationUtils.serializeQualification(action.payload)
+    );
+    const interpreter = SerializationUtils.deserializeClerkInterpreter(
+      apiResponse.data
+    );
+    yield put(setClerkInterpreterOverview(interpreter));
+    yield put(updateQualificationSucceeded());
+  } catch (error) {
+    yield put(rejectUpdateQualification());
+    yield put(
+      showNotifierToast(
+        NotifierUtils.createAxiosErrorNotifierToast(error as AxiosError)
+      )
+    );
+  }
+}
+
+export function* watchQualificationUpdates() {
+  yield takeLatest(addQualification, addQualificationSaga);
+  yield takeLatest(removeQualification, removeQualificationSaga);
+  yield takeLatest(updateQualification, updateQualificationSaga);
 }

--- a/frontend/packages/otr/src/redux/sagas/qualification.ts
+++ b/frontend/packages/otr/src/redux/sagas/qualification.ts
@@ -1,0 +1,36 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import { call, put, takeLatest } from 'redux-saga/effects';
+
+import axiosInstance from 'configs/axios';
+import { APIEndpoints } from 'enums/api';
+import { Qualification } from 'interfaces/qualification';
+import { loadClerkInterpreterOverview } from 'redux/reducers/clerkInterpreterOverview';
+import {
+  addQualification,
+  addQualificationSuccess,
+  rejectAddQualification,
+} from 'redux/reducers/qualification';
+import { SerializationUtils } from 'utils/serialization';
+
+function* onAddQualification(action: PayloadAction<Qualification>) {
+  try {
+    const { interpreterId } = action.payload;
+    if (!interpreterId) {
+      throw new Error();
+    }
+    yield call(
+      axiosInstance.post,
+      `${APIEndpoints.ClerkInterpreter}/${interpreterId}/qualification`,
+      SerializationUtils.serializeQualification(action.payload)
+    );
+
+    yield put(addQualificationSuccess());
+    yield put(loadClerkInterpreterOverview({ id: interpreterId }));
+  } catch (error) {
+    yield put(rejectAddQualification());
+  }
+}
+
+export function* watchAddQualification() {
+  yield takeLatest(addQualification, onAddQualification);
+}

--- a/frontend/packages/otr/src/redux/sagas/qualification.ts
+++ b/frontend/packages/otr/src/redux/sagas/qualification.ts
@@ -1,14 +1,19 @@
 import { PayloadAction } from '@reduxjs/toolkit';
+import { AxiosResponse } from 'axios';
 import { call, put, takeLatest } from 'redux-saga/effects';
 
 import axiosInstance from 'configs/axios';
 import { APIEndpoints } from 'enums/api';
+import { ClerkInterpreterResponse } from 'interfaces/clerkInterpreter';
 import { Qualification } from 'interfaces/qualification';
 import { loadClerkInterpreterOverview } from 'redux/reducers/clerkInterpreterOverview';
 import {
   addQualification,
   addQualificationSuccess,
   rejectAddQualification,
+  rejectRemoveQualification,
+  removeQualification,
+  removeQualificationSuccess,
 } from 'redux/reducers/qualification';
 import { SerializationUtils } from 'utils/serialization';
 
@@ -31,6 +36,28 @@ function* onAddQualification(action: PayloadAction<Qualification>) {
   }
 }
 
+function* onRemoveQualification(action: PayloadAction<number>) {
+  try {
+    const apiResponse: AxiosResponse<ClerkInterpreterResponse> = yield call(
+      axiosInstance.delete,
+      `${APIEndpoints.ClerkInterpreter}/qualification/${action.payload}`
+    );
+
+    const interpreter = SerializationUtils.deserializeClerkInterpreter(
+      apiResponse.data
+    );
+
+    yield put(removeQualificationSuccess());
+    yield put(loadClerkInterpreterOverview({ id: interpreter.id }));
+  } catch (error) {
+    yield put(rejectRemoveQualification());
+  }
+}
+
 export function* watchAddQualification() {
   yield takeLatest(addQualification, onAddQualification);
+}
+
+export function* watchRemoveQualification() {
+  yield takeLatest(removeQualification, onRemoveQualification);
 }

--- a/frontend/packages/otr/src/redux/selectors/qualification.ts
+++ b/frontend/packages/otr/src/redux/selectors/qualification.ts
@@ -1,0 +1,3 @@
+import { RootState } from 'configs/redux';
+
+export const qualificationSelector = (state: RootState) => state.qualification;

--- a/frontend/packages/otr/src/redux/store/index.ts
+++ b/frontend/packages/otr/src/redux/store/index.ts
@@ -6,6 +6,7 @@ import { clerkInterpreterOverviewReducer } from 'redux/reducers/clerkInterpreter
 import { clerkUserReducer } from 'redux/reducers/clerkUser';
 import { notifierReducer } from 'redux/reducers/notifier';
 import { publicInterpreterReducer } from 'redux/reducers/publicInterpreter';
+import { qualifcationReducer } from 'redux/reducers/qualification';
 import rootSaga from 'redux/sagas/index';
 
 const saga = createSagaMiddleware();
@@ -17,6 +18,7 @@ const store = configureStore({
     publicInterpreter: publicInterpreterReducer,
     clerkUser: clerkUserReducer,
     notifier: notifierReducer,
+    qualification: qualifcationReducer,
   },
   middleware: [saga],
 });

--- a/frontend/packages/otr/src/redux/store/index.ts
+++ b/frontend/packages/otr/src/redux/store/index.ts
@@ -6,7 +6,7 @@ import { clerkInterpreterOverviewReducer } from 'redux/reducers/clerkInterpreter
 import { clerkUserReducer } from 'redux/reducers/clerkUser';
 import { notifierReducer } from 'redux/reducers/notifier';
 import { publicInterpreterReducer } from 'redux/reducers/publicInterpreter';
-import { qualifcationReducer } from 'redux/reducers/qualification';
+import { qualificationReducer } from 'redux/reducers/qualification';
 import rootSaga from 'redux/sagas/index';
 
 const saga = createSagaMiddleware();
@@ -18,7 +18,7 @@ const store = configureStore({
     publicInterpreter: publicInterpreterReducer,
     clerkUser: clerkUserReducer,
     notifier: notifierReducer,
-    qualification: qualifcationReducer,
+    qualification: qualificationReducer,
   },
   middleware: [saga],
 });

--- a/frontend/packages/otr/src/styles/components/clerkInterpreter/_add-qualification.scss
+++ b/frontend/packages/otr/src/styles/components/clerkInterpreter/_add-qualification.scss
@@ -1,0 +1,7 @@
+.add-qualification {
+  &__fields {
+    align-items: flex-end;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}

--- a/frontend/packages/otr/src/styles/styles.scss
+++ b/frontend/packages/otr/src/styles/styles.scss
@@ -5,6 +5,7 @@
 @import 'base/base';
 
 // Components
+@import 'components/clerkInterpreter/add-qualification';
 @import 'components/layouts/header';
 @import 'components/layouts/footer';
 @import 'components/publicInterpreter/public-interpreter-listing';

--- a/frontend/packages/otr/src/utils/qualifications.ts
+++ b/frontend/packages/otr/src/utils/qualifications.ts
@@ -7,10 +7,15 @@ import {
   Qualification,
   QualificationsGroupedByStatus,
 } from 'interfaces/qualification';
+import koodistoLangsFI from 'public/i18n/koodisto/langs/koodisto_langs_fi-FI.json';
 
 const EXPIRING_QUALIFICATION_THRESHOLD_MONTHS = 3;
 
 export class QualificationUtils {
+  static getKoodistoLangKeys() {
+    return Object.keys(koodistoLangsFI?.otr?.koodisto?.languages);
+  }
+
   static isQualificationEffective(
     { beginDate, endDate }: Qualification,
     currentDate: Dayjs

--- a/frontend/packages/otr/src/utils/serialization.ts
+++ b/frontend/packages/otr/src/utils/serialization.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import { DateUtils } from 'shared/utils';
 
 import {
   ClerkInterpreter,
@@ -44,6 +45,27 @@ export class SerializationUtils {
       permissionToPublishPhone,
       permissionToPublishOtherContactInfo,
       regions,
+    };
+  }
+
+  static serializeQualification(qualification: Qualification) {
+    const { fromLang, toLang } = qualification;
+    const {
+      beginDate,
+      endDate,
+      examinationType,
+      permissionToPublish,
+      diaryNumber,
+    } = qualification;
+
+    return {
+      fromLang,
+      toLang,
+      examinationType,
+      beginDate: DateUtils.serializeDate(beginDate),
+      endDate: DateUtils.serializeDate(endDate),
+      permissionToPublish,
+      diaryNumber: diaryNumber ? diaryNumber.trim() : undefined,
     };
   }
 

--- a/frontend/packages/otr/src/utils/serialization.ts
+++ b/frontend/packages/otr/src/utils/serialization.ts
@@ -49,23 +49,13 @@ export class SerializationUtils {
   }
 
   static serializeQualification(qualification: Qualification) {
-    const { fromLang, toLang } = qualification;
-    const {
-      beginDate,
-      endDate,
-      examinationType,
-      permissionToPublish,
-      diaryNumber,
-    } = qualification;
+    const { beginDate, endDate, diaryNumber, ...rest } = qualification;
 
     return {
-      fromLang,
-      toLang,
-      examinationType,
       beginDate: DateUtils.serializeDate(beginDate),
       endDate: DateUtils.serializeDate(endDate),
-      permissionToPublish,
       diaryNumber: diaryNumber ? diaryNumber.trim() : undefined,
+      ...rest,
     };
   }
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2305,7 +2305,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.otr@workspace:packages/otr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.15"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.18"
   languageName: unknown
   linkType: soft
 
@@ -10917,10 +10917,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+<<<<<<< HEAD
 "shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.15":
   version: 1.0.15
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.0.15::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.0.15%2F1fb76e7415c075881d2e75dbeba3f75b51889412"
   checksum: 6e3526d56bc8df7f54aea3982588acb60cc3f2a1eeda627e12cc15070e033f9ce3759fc8bc2c77cad41d8bee040716843691beb3ee8db1ecbda2f2aacf5307de
+=======
+"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.17":
+  version: 1.0.17
+  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.0.17::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.0.17%2F74caeefa5e12ec80ed7d513c036038f12e440374"
+  checksum: edbadacea92cff7ad47da2eb32f5e182691539e3c490e8c7cfda953dbb7aa87daafb0984a18dc395a3f9d9dbc1ff8d1b9d560f55eb5ff5e876c07a94c2adf40b
+>>>>>>> 7c92f51 (OTR(Frontend): Limited fromLanguage to FI and set max date when adding new language pair)
   languageName: node
   linkType: hard
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10917,17 +10917,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-<<<<<<< HEAD
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.15":
-  version: 1.0.15
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.0.15::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.0.15%2F1fb76e7415c075881d2e75dbeba3f75b51889412"
-  checksum: 6e3526d56bc8df7f54aea3982588acb60cc3f2a1eeda627e12cc15070e033f9ce3759fc8bc2c77cad41d8bee040716843691beb3ee8db1ecbda2f2aacf5307de
-=======
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.17":
-  version: 1.0.17
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.0.17::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.0.17%2F74caeefa5e12ec80ed7d513c036038f12e440374"
-  checksum: edbadacea92cff7ad47da2eb32f5e182691539e3c490e8c7cfda953dbb7aa87daafb0984a18dc395a3f9d9dbc1ff8d1b9d560f55eb5ff5e876c07a94c2adf40b
->>>>>>> 7c92f51 (OTR(Frontend): Limited fromLanguage to FI and set max date when adding new language pair)
+"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.18":
+  version: 1.0.18
+  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.0.18::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.0.18%2F5335f37dc51c052cb301240397e72d4dd42dfd15"
+  checksum: 691c0e65724a60e94af31ce5e4a31b24a589e10a5ddd3ae375115d5ec460353084bed0f198639e322f9095456d98b14e10c982e47e3437e7c4d6e4c94a5f64f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Kielipareja voi nyt poistaa tulkin muokkausnäkymässä. Tämän lisäksi tulkin listaus ja muokkausnäkymässä näytetään vain kieliparit, joiden status ei ole "deleted". 

## Huomautukset

Viimeisen kieliparin poistaminen on backendin puolella estetty, joten kääntäjällä on aina vähintään yksi kielipari

## Check-lista

- [x] Testattu docker-compose:lla
- [x] Exceli päivitetty
