### PR TITLE
OPHOTRKEH-107: rekisteröintien hard delete

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkQualificationDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkQualificationDTO.java
@@ -11,7 +11,6 @@ import lombok.NonNull;
 public record ClerkQualificationDTO(
   @NonNull @NotNull Long id,
   @NonNull @NotNull Integer version,
-  @NonNull @NotNull Boolean deleted,
   @NonNull @NotBlank String fromLang,
   @NonNull @NotBlank String toLang,
   @NonNull @NotNull LocalDate beginDate,

--- a/backend/otr/src/main/java/fi/oph/otr/repository/QualificationRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/QualificationRepository.java
@@ -17,7 +17,6 @@ public interface QualificationRepository extends JpaRepository<Qualification, Lo
     " WHERE q.beginDate <= CURRENT_DATE" +
     " AND CURRENT_DATE <= q.endDate" +
     " AND q.permissionToPublish = true" +
-    " AND q.deletedAt IS NULL" +
     " AND i.deletedAt IS NULL" +
     " GROUP BY i.id, q.fromLang, q.toLang"
   )

--- a/backend/otr/src/main/java/fi/oph/otr/service/ClerkInterpreterService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/ClerkInterpreterService.java
@@ -154,7 +154,6 @@ public class ClerkInterpreterService {
       .builder()
       .id(qualification.getId())
       .version(qualification.getVersion())
-      .deleted(qualification.isDeleted())
       .fromLang(qualification.getFromLang())
       .toLang(qualification.getToLang())
       .beginDate(qualification.getBeginDate())

--- a/backend/otr/src/test/java/fi/oph/otr/service/ClerkInterpreterServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/service/ClerkInterpreterServiceTest.java
@@ -328,7 +328,6 @@ class ClerkInterpreterServiceTest {
 
     final ClerkQualificationDTO qualification1 = interpreterDTO.qualifications().get(0);
     assertEquals(0, qualification1.version());
-    assertFalse(qualification1.deleted());
     assertEquals("FI", qualification1.fromLang());
     assertEquals("SE", qualification1.toLang());
     assertEquals(today, qualification1.beginDate());
@@ -737,7 +736,6 @@ class ClerkInterpreterServiceTest {
 
     assertNotNull(qualificationDTO);
     assertEquals(0, qualificationDTO.version());
-    assertFalse(qualificationDTO.deleted());
     assertEquals("FI", qualificationDTO.fromLang());
     assertEquals("CS", qualificationDTO.toLang());
     assertEquals(today, qualificationDTO.beginDate());
@@ -873,7 +871,6 @@ class ClerkInterpreterServiceTest {
     final ClerkQualificationDTO qualificationDTO = interpreterDTO.qualifications().get(0);
 
     assertEquals(updateDTO.version() + 1, qualificationDTO.version());
-    assertFalse(qualificationDTO.deleted());
     assertEquals("FI", qualificationDTO.fromLang());
     assertEquals("NO", qualificationDTO.toLang());
     assertEquals(begin, qualificationDTO.beginDate());

--- a/backend/otr/src/test/java/fi/oph/otr/service/PublicInterpreterServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/service/PublicInterpreterServiceTest.java
@@ -68,7 +68,6 @@ class PublicInterpreterServiceTest {
     final Interpreter interpreter3 = createInterpreter();
     final Interpreter interpreter4 = createInterpreter();
     final Interpreter interpreter5 = createInterpreterDeleted();
-    final Interpreter interpreter6 = createInterpreter();
 
     final MeetingDate meetingDate = Factory.meetingDate();
     entityManager.persist(meetingDate);
@@ -120,8 +119,6 @@ class PublicInterpreterServiceTest {
     createQualification(interpreter4, meetingDate, "FI", "DN", tomorrow, nextWeek, true);
     // Hidden, interpreter marked deleted
     createQualification(interpreter5, meetingDate, "FI", "DE", yesterday, nextWeek, true);
-    // Hidden, deleted
-    createQualificationDeleted(interpreter6, meetingDate, "FI", "FR", yesterday, nextWeek, true);
 
     when(onrService.getCachedPersonalDatas())
       .thenReturn(
@@ -211,26 +208,6 @@ class PublicInterpreterServiceTest {
     qualification.setBeginDate(beginDate);
     qualification.setEndDate(endDate);
     qualification.setPermissionToPublish(permissionToPublish);
-    entityManager.persist(qualification);
-    return qualification;
-  }
-
-  private Qualification createQualificationDeleted(
-    final Interpreter interpreter,
-    final MeetingDate meetingDate,
-    final String fromLang,
-    final String toLang,
-    final LocalDate beginDate,
-    final LocalDate endDate,
-    final boolean permissionToPublish
-  ) {
-    final Qualification qualification = Factory.qualification(interpreter, meetingDate);
-    qualification.setFromLang(fromLang);
-    qualification.setToLang(toLang);
-    qualification.setBeginDate(beginDate);
-    qualification.setEndDate(endDate);
-    qualification.setPermissionToPublish(permissionToPublish);
-    qualification.markDeleted();
     entityManager.persist(qualification);
     return qualification;
   }

--- a/frontend/packages/otr/src/interfaces/qualification.ts
+++ b/frontend/packages/otr/src/interfaces/qualification.ts
@@ -5,7 +5,6 @@ import { QualificationStatus } from 'enums/clerkInterpreter';
 import { ExaminationType } from 'enums/interpreter';
 
 export interface Qualification extends WithId, WithVersion {
-  deleted: boolean;
   fromLang: string;
   toLang: string;
   beginDate: Dayjs;


### PR DESCRIPTION
## Yhteenveto

Muutettu tulkin poistoa ja rekisteröinnin poistoa siten, että rekisteröinnit tuhotaan sen sijaan, että ne vain merkittäisiin poistetuiksi. Myöskään `deleted` kenttää ei rekisteröintien osalta enää fronttiin palauteta.

## Check-lista

- [x] Testattu docker-compose:lla
