### PR TITLE
OTR(Backend): OPHOTRKEH-107 poistetuksi merkittyjä rekisteröintejä ei palauteta frontendille

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkQualificationDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkQualificationDTO.java
@@ -11,7 +11,6 @@ import lombok.NonNull;
 public record ClerkQualificationDTO(
   @NonNull @NotNull Long id,
   @NonNull @NotNull Integer version,
-  @NonNull @NotNull Boolean deleted,
   @NonNull @NotBlank String fromLang,
   @NonNull @NotBlank String toLang,
   @NonNull @NotNull LocalDate beginDate,

--- a/backend/otr/src/main/java/fi/oph/otr/repository/QualificationRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/QualificationRepository.java
@@ -11,6 +11,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface QualificationRepository extends JpaRepository<Qualification, Long> {
   @Query(
+    "SELECT q" +
+    " FROM Qualification q" +
+    " JOIN q.interpreter i" +
+    " WHERE q.deletedAt IS NULL" +
+    " AND i.deletedAt IS NULL"
+  )
+  List<Qualification> findExistingQualifications();
+
+  @Query(
     "SELECT new fi.oph.otr.repository.InterpreterQualificationProjection(i.id, q.fromLang, q.toLang)" +
     " FROM Qualification q" +
     " JOIN q.interpreter i" +
@@ -26,8 +35,11 @@ public interface QualificationRepository extends JpaRepository<Qualification, Lo
   @Query(
     "SELECT q.id" +
     " FROM Qualification q" +
+    " JOIN q.interpreter i" +
     " LEFT JOIN q.reminders qr" +
     " WHERE q.endDate BETWEEN ?1 AND ?2" +
+    " AND q.deletedAt IS NULL" +
+    " AND i.deletedAt IS NULL" +
     " GROUP BY q.id, qr.id" +
     " HAVING COUNT(qr.id) = 0 OR MAX(qr.createdAt) < ?3"
   )

--- a/backend/otr/src/main/java/fi/oph/otr/service/ClerkInterpreterService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/ClerkInterpreterService.java
@@ -81,7 +81,7 @@ public class ClerkInterpreterService {
       .collect(Collectors.groupingBy(InterpreterRegionProjection::interpreterId));
 
     final Map<Long, List<Qualification>> interpreterQualifications = qualificationRepository
-      .findAll()
+      .findExistingQualifications()
       .stream()
       .collect(Collectors.groupingBy(q -> q.getInterpreter().getId()));
 
@@ -92,8 +92,10 @@ public class ClerkInterpreterService {
       .stream()
       .map(interpreter -> {
         final PersonalData personalData = personalDatas.get(interpreter.getOnrId());
-        final List<Qualification> qualifications = interpreterQualifications.get(interpreter.getId());
-
+        final List<Qualification> qualifications = interpreterQualifications.getOrDefault(
+          interpreter.getId(),
+          Collections.emptyList()
+        );
         final List<InterpreterRegionProjection> regionProjections = interpreterRegionProjections.getOrDefault(
           interpreter.getId(),
           Collections.emptyList()
@@ -148,7 +150,6 @@ public class ClerkInterpreterService {
       .builder()
       .id(qualification.getId())
       .version(qualification.getVersion())
-      .deleted(qualification.isDeleted())
       .fromLang(qualification.getFromLang())
       .toLang(qualification.getToLang())
       .beginDate(qualification.getBeginDate())

--- a/backend/otr/src/test/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreatorTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreatorTest.java
@@ -54,17 +54,18 @@ public class ExpiringQualificationsEmailCreatorTest {
     final MeetingDate meetingDate = Factory.meetingDate();
     entityManager.persist(meetingDate);
 
-    final Qualification q1 = createQualification(meetingDate, date);
-    final Qualification q2 = createQualification(meetingDate, date.plusDays(10));
-    final Qualification q3 = createQualification(meetingDate, date.plusMonths(3));
+    final Qualification q1 = createQualification(meetingDate, date, false);
+    final Qualification q2 = createQualification(meetingDate, date.plusDays(10), false);
+    final Qualification q3 = createQualification(meetingDate, date.plusMonths(3), false);
 
-    final Qualification expiredQ = createQualification(meetingDate, date.minusDays(1));
-    final Qualification qExpiringLater = createQualification(meetingDate, date.plusMonths(3).plusDays(1));
+    final Qualification deletedQ = createQualification(meetingDate, date.plusDays(10), true);
+    final Qualification expiredQ = createQualification(meetingDate, date.minusDays(1), false);
+    final Qualification qExpiringLater = createQualification(meetingDate, date.plusMonths(3).plusDays(1), false);
 
-    final Qualification remindedQ1 = createQualification(meetingDate, date.plusMonths(1));
+    final Qualification remindedQ1 = createQualification(meetingDate, date.plusMonths(1), false);
     createQualificationReminder(remindedQ1);
 
-    final Qualification remindedQ2 = createQualification(meetingDate, date.plusMonths(2));
+    final Qualification remindedQ2 = createQualification(meetingDate, date.plusMonths(2), false);
     createQualificationReminder(remindedQ2);
     createQualificationReminder(remindedQ2);
 
@@ -81,13 +82,20 @@ public class ExpiringQualificationsEmailCreatorTest {
     assertTrue(expiringQIds.contains(q3.getId()));
   }
 
-  private Qualification createQualification(final MeetingDate meetingDate, final LocalDate endDate) {
+  private Qualification createQualification(
+    final MeetingDate meetingDate,
+    final LocalDate endDate,
+    final boolean isDeleted
+  ) {
     final Interpreter interpreter = Factory.interpreter();
     entityManager.persist(interpreter);
 
     final Qualification qualification = Factory.qualification(interpreter, meetingDate);
     qualification.setBeginDate(endDate.minusYears(1));
     qualification.setEndDate(endDate);
+    if (isDeleted) {
+      qualification.markDeleted();
+    }
     entityManager.persist(qualification);
 
     return qualification;

--- a/backend/otr/src/test/java/fi/oph/otr/service/ClerkInterpreterServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/service/ClerkInterpreterServiceTest.java
@@ -321,7 +321,6 @@ class ClerkInterpreterServiceTest {
 
     final ClerkQualificationDTO qualification1 = interpreterDTO.qualifications().get(0);
     assertEquals(0, qualification1.version());
-    assertFalse(qualification1.deleted());
     assertEquals("FI", qualification1.fromLang());
     assertEquals("SE", qualification1.toLang());
     assertEquals(today, qualification1.beginDate());
@@ -718,6 +717,8 @@ class ClerkInterpreterServiceTest {
     createInterpreter(meetingDate, "2");
 
     final ClerkInterpreterDTO dto = clerkInterpreterService.deleteInterpreter(id);
+    assertTrue(dto.deleted());
+    assertEquals(0, dto.qualifications().size());
 
     interpreterRepository
       .findAll()
@@ -727,7 +728,7 @@ class ClerkInterpreterServiceTest {
         assertEquals(isDeleted, interpreter.isDeleted());
         interpreter.getQualifications().forEach(q -> assertEquals(isDeleted, q.isDeleted()));
       });
-    assertTrue(dto.deleted());
+
     verify(auditService).logById(OtrOperation.DELETE_INTERPRETER, id);
     verifyNoMoreInteractions(auditService);
   }
@@ -772,7 +773,6 @@ class ClerkInterpreterServiceTest {
 
     assertNotNull(qualificationDTO);
     assertEquals(0, qualificationDTO.version());
-    assertFalse(qualificationDTO.deleted());
     assertEquals("FI", qualificationDTO.fromLang());
     assertEquals("CS", qualificationDTO.toLang());
     assertEquals(today, qualificationDTO.beginDate());
@@ -908,7 +908,6 @@ class ClerkInterpreterServiceTest {
     final ClerkQualificationDTO qualificationDTO = interpreterDTO.qualifications().get(0);
 
     assertEquals(updateDTO.version() + 1, qualificationDTO.version());
-    assertFalse(qualificationDTO.deleted());
     assertEquals("FI", qualificationDTO.fromLang());
     assertEquals("NO", qualificationDTO.toLang());
     assertEquals(begin, qualificationDTO.beginDate());
@@ -967,8 +966,11 @@ class ClerkInterpreterServiceTest {
     entityManager.persist(qualification2);
 
     final ClerkInterpreterDTO dto = clerkInterpreterService.deleteQualification(qualification1.getId());
+    assertEquals(1, dto.qualifications().size());
+    assertEquals(qualification2.getId(), dto.qualifications().get(0).id());
 
-    dto.qualifications().forEach(q -> assertEquals(Objects.equals(qualification1.getId(), q.id()), q.deleted()));
+    assertTrue(qualificationRepository.getReferenceById(qualification1.getId()).isDeleted());
+
     verify(auditService).logQualification(OtrOperation.DELETE_QUALIFICATION, interpreter, qualification1.getId());
     verifyNoMoreInteractions(auditService);
   }

--- a/frontend/packages/otr/src/interfaces/qualification.ts
+++ b/frontend/packages/otr/src/interfaces/qualification.ts
@@ -5,7 +5,6 @@ import { QualificationStatus } from 'enums/clerkInterpreter';
 import { ExaminationType } from 'enums/interpreter';
 
 export interface Qualification extends WithId, WithVersion {
-  deleted: boolean;
   fromLang: string;
   toLang: string;
   beginDate: Dayjs;


### PR DESCRIPTION
## Huomautukset

Korjattu samassa yhteydessä `ExpiringQualificationsEmailCreator`:n bugi, jossa muistutussähköposteja lähetettiin myös poistettuihin rekisteröinteihin liittyen.

## Check-lista

- [x] Testattu docker-compose:lla
