### PR TITLE
OTR(Frontend): Add helptext to search results

### DIFF
--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -192,7 +192,8 @@
             "phoneNumber": "Puhelinnumero"
           },
           "ariaLabel": "Avaa lisätiedot"
-        }
+        },
+        "searchResultsInfo": "Klikkaa riviä näyttääksesi yhteystiedot"
       }
     },
     "errors": {

--- a/frontend/packages/otr/src/components/publicInterpreter/listing/PublicInterpreterListing.tsx
+++ b/frontend/packages/otr/src/components/publicInterpreter/listing/PublicInterpreterListing.tsx
@@ -5,6 +5,7 @@ import {
   H2,
   H3,
   PaginatedTable,
+  Text,
 } from 'shared/components';
 import { APIResponseStatus, Color } from 'shared/enums';
 import { useWindowProperties } from 'shared/hooks';
@@ -61,6 +62,9 @@ export const PublicInterpreterListing = ({
           <div className="columns" ref={listingHeaderRef}>
             <div className="grow">
               <H2>{translateCommon('searchResults')}</H2>
+              <Text className="margin-top-sm">
+                {t('component.publicInterpreterListing.searchResultsInfo')}
+              </Text>
             </div>
           </div>
           <PaginatedTable


### PR DESCRIPTION
## Yhteenveto

Kun OTR:ssä on haku suoritettu, "Hakutulokset" -tekstin alla tulisi lukea "Klikkaa riviä näyttääksesi yhteystiedot"

## Huomautukset

UI kuvat löytyy Jira tiketista.

## Check-lista

- [X] Käännösten Excel-tiedosto päivitetty
- [X] Testattu docker-compose:lla
