### PR TITLE
Feature/ophotrkeh 111  reminder email scheduler fixes

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/repository/QualificationRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/QualificationRepository.java
@@ -26,8 +26,11 @@ public interface QualificationRepository extends JpaRepository<Qualification, Lo
   @Query(
     "SELECT q.id" +
     " FROM Qualification q" +
+    " JOIN q.interpreter i" +
     " LEFT JOIN q.reminders qr" +
     " WHERE q.endDate BETWEEN ?1 AND ?2" +
+    " AND q.deletedAt IS NULL" +
+    " AND i.deletedAt IS NULL" +
     " GROUP BY q.id, qr.id" +
     " HAVING COUNT(qr.id) = 0 OR MAX(qr.createdAt) < ?3"
   )

--- a/backend/otr/src/test/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreatorTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreatorTest.java
@@ -60,6 +60,8 @@ public class ExpiringQualificationsEmailCreatorTest {
 
     final Qualification expiredQ = createQualification(meetingDate, date.minusDays(1));
     final Qualification qExpiringLater = createQualification(meetingDate, date.plusMonths(3).plusDays(1));
+    final Qualification qDeleted = createQualification(meetingDate, date, true, false);
+    final Qualification iDeleted = createQualification(meetingDate, date, false, true);
 
     final Qualification remindedQ1 = createQualification(meetingDate, date.plusMonths(1));
     createQualificationReminder(remindedQ1);
@@ -82,12 +84,22 @@ public class ExpiringQualificationsEmailCreatorTest {
   }
 
   private Qualification createQualification(final MeetingDate meetingDate, final LocalDate endDate) {
+    return createQualification(meetingDate, endDate, false, false);
+  }
+
+  private Qualification createQualification(final MeetingDate meetingDate, final LocalDate endDate, final boolean qualificationDeleted, final boolean interpreterDeleted) {
     final Interpreter interpreter = Factory.interpreter();
+    if(interpreterDeleted) {
+      interpreter.markDeleted();
+    }
     entityManager.persist(interpreter);
 
     final Qualification qualification = Factory.qualification(interpreter, meetingDate);
     qualification.setBeginDate(endDate.minusYears(1));
     qualification.setEndDate(endDate);
+    if(qualificationDeleted) {
+      qualification.markDeleted();
+    }
     entityManager.persist(qualification);
 
     return qualification;


### PR DESCRIPTION
## Yhteenveto

Korjattu ettei muistutussähköposteja lähetetä tarpeettomasti.

Ei lähetetä muistutussähköpostia jos
- kielipari tai kääntäjä on poistettu (soft delete)
- kieliparille löytyy vastaava kielipari joka ei kyselyn aikaikkunassa vanhene

## Lisätiedot
## Huomautukset
## Check-lista

- [ ] Testattu docker-compose:lla
