### PR TITLE
Feature/ophotrkeh 111  reminder email scheduler fixes

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreator.java
+++ b/backend/otr/src/main/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreator.java
@@ -1,10 +1,13 @@
 package fi.oph.otr.scheduled;
 
+import fi.oph.otr.model.Interpreter;
+import fi.oph.otr.model.Qualification;
 import fi.oph.otr.repository.QualificationRepository;
 import fi.oph.otr.service.email.ClerkEmailService;
 import fi.oph.otr.util.SchedulingUtil;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import javax.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -41,6 +44,9 @@ public class ExpiringQualificationsEmailCreator {
       qualificationRepository
         .findExpiringQualifications(expiryBetweenStart, expiryBetweenEnd, previousReminderSentBefore)
         .forEach(qualificationId -> {
+          if (hasEquivalentQualificationExpiringLater(qualificationId)) {
+            return;
+          }
           try {
             clerkEmailService.createQualificationExpiryEmail(qualificationId);
           } catch (Exception e) {
@@ -48,5 +54,20 @@ public class ExpiringQualificationsEmailCreator {
           }
         });
     });
+  }
+
+  private boolean hasEquivalentQualificationExpiringLater(final Long expiringQualificationId) {
+    final Qualification expiringQualification = qualificationRepository.getReferenceById(expiringQualificationId);
+    final Interpreter interpreter = expiringQualification.getInterpreter();
+    return interpreter
+      .getQualifications()
+      .stream()
+      .filter(q -> q.getId() != expiringQualificationId && !q.isDeleted())
+      .anyMatch(q ->
+        q.getEndDate().isAfter(expiringQualification.getEndDate()) &&
+        Objects.equals(expiringQualification.getFromLang(), q.getFromLang()) &&
+        Objects.equals(expiringQualification.getToLang(), q.getToLang()) &&
+        Objects.equals(expiringQualification.getExaminationType(), q.getExaminationType())
+      );
   }
 }

--- a/backend/otr/src/test/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreatorTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreatorTest.java
@@ -1,7 +1,6 @@
 package fi.oph.otr.scheduled;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -14,7 +13,9 @@ import fi.oph.otr.model.QualificationReminder;
 import fi.oph.otr.repository.QualificationRepository;
 import fi.oph.otr.service.email.ClerkEmailService;
 import java.time.LocalDate;
-import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,39 +71,111 @@ public class ExpiringQualificationsEmailCreatorTest {
     createQualificationReminder(remindedQ2);
     createQualificationReminder(remindedQ2);
 
+    final Interpreter interpreter = createInterpreter(false);
+    final Qualification qExpiringButHasEquivalentQualificationNotExpiring = createQualification(
+      interpreter,
+      meetingDate,
+      date,
+      false
+    );
+    final Qualification qNotExpiringWhichPreventsEquivalentQualificationReminder = createQualification(
+      interpreter,
+      meetingDate,
+      date.plusMonths(3).plusDays(1),
+      false
+    );
+
+    final Qualification equivalentToExpiringButDeleted = createQualification(
+      q1.getInterpreter(),
+      meetingDate,
+      date.plusMonths(3).plusDays(1),
+      true
+    );
+
+    final Qualification qExpiringButHasEquivalentQualificationAlsoExpiring = createQualification(
+      interpreter,
+      meetingDate,
+      date,
+      false,
+      "FI",
+      "DE"
+    );
+    final Qualification qExpiringWhichPreventsEquivalentQualificationReminder = createQualification(
+      interpreter,
+      meetingDate,
+      date.plusMonths(1),
+      false,
+      "FI",
+      "DE"
+    );
+
     emailCreator.checkExpiringQualifications();
 
-    verify(clerkEmailService, times(3)).createQualificationExpiryEmail(longCaptor.capture());
+    verify(clerkEmailService, times(4)).createQualificationExpiryEmail(longCaptor.capture());
 
-    final List<Long> expiringQIds = longCaptor.getAllValues();
-
-    assertEquals(3, expiringQIds.size());
-
-    assertTrue(expiringQIds.contains(q1.getId()));
-    assertTrue(expiringQIds.contains(q2.getId()));
-    assertTrue(expiringQIds.contains(q3.getId()));
+    final Set<Long> expectedQualificationIds = Stream
+      .of(q1, q2, q3, qExpiringWhichPreventsEquivalentQualificationReminder)
+      .map(Qualification::getId)
+      .collect(Collectors.toSet());
+    final Set<Long> qualificationIds = Set.copyOf(longCaptor.getAllValues());
+    assertEquals(expectedQualificationIds, qualificationIds);
   }
 
   private Qualification createQualification(final MeetingDate meetingDate, final LocalDate endDate) {
     return createQualification(meetingDate, endDate, false, false);
   }
 
-  private Qualification createQualification(final MeetingDate meetingDate, final LocalDate endDate, final boolean qualificationDeleted, final boolean interpreterDeleted) {
-    final Interpreter interpreter = Factory.interpreter();
-    if(interpreterDeleted) {
-      interpreter.markDeleted();
-    }
-    entityManager.persist(interpreter);
+  private Qualification createQualification(
+    final MeetingDate meetingDate,
+    final LocalDate endDate,
+    final boolean qualificationDeleted,
+    final boolean interpreterDeleted
+  ) {
+    final Interpreter interpreter = createInterpreter(interpreterDeleted);
+    return createQualification(interpreter, meetingDate, endDate, qualificationDeleted);
+  }
 
+  private Qualification createQualification(
+    final Interpreter interpreter,
+    final MeetingDate meetingDate,
+    final LocalDate endDate,
+    final boolean qualificationDeleted
+  ) {
+    return createQualification(interpreter, meetingDate, endDate, qualificationDeleted, null, null);
+  }
+
+  private Qualification createQualification(
+    final Interpreter interpreter,
+    final MeetingDate meetingDate,
+    final LocalDate endDate,
+    final boolean qualificationDeleted,
+    final String fromLang,
+    final String toLang
+  ) {
     final Qualification qualification = Factory.qualification(interpreter, meetingDate);
     qualification.setBeginDate(endDate.minusYears(1));
     qualification.setEndDate(endDate);
-    if(qualificationDeleted) {
+    if (qualificationDeleted) {
       qualification.markDeleted();
+    }
+    if (fromLang != null) {
+      qualification.setFromLang(fromLang);
+    }
+    if (toLang != null) {
+      qualification.setToLang(toLang);
     }
     entityManager.persist(qualification);
 
     return qualification;
+  }
+
+  private Interpreter createInterpreter(final boolean interpreterDeleted) {
+    final Interpreter interpreter = Factory.interpreter();
+    if (interpreterDeleted) {
+      interpreter.markDeleted();
+    }
+    entityManager.persist(interpreter);
+    return interpreter;
   }
 
   private void createQualificationReminder(final Qualification qualification) {

--- a/backend/otr/src/test/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreatorTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreatorTest.java
@@ -54,18 +54,19 @@ public class ExpiringQualificationsEmailCreatorTest {
     final MeetingDate meetingDate = Factory.meetingDate();
     entityManager.persist(meetingDate);
 
-    final Qualification q1 = createQualification(meetingDate, date, false);
-    final Qualification q2 = createQualification(meetingDate, date.plusDays(10), false);
-    final Qualification q3 = createQualification(meetingDate, date.plusMonths(3), false);
+    final Qualification q1 = createQualification(meetingDate, date);
+    final Qualification q2 = createQualification(meetingDate, date.plusDays(10));
+    final Qualification q3 = createQualification(meetingDate, date.plusMonths(3));
 
-    final Qualification deletedQ = createQualification(meetingDate, date.plusDays(10), true);
-    final Qualification expiredQ = createQualification(meetingDate, date.minusDays(1), false);
-    final Qualification qExpiringLater = createQualification(meetingDate, date.plusMonths(3).plusDays(1), false);
+    final Qualification expiredQ = createQualification(meetingDate, date.minusDays(1));
+    final Qualification qExpiringLater = createQualification(meetingDate, date.plusMonths(3).plusDays(1));
+    final Qualification qDeleted = createQualification(meetingDate, date, true, false);
+    final Qualification iDeleted = createQualification(meetingDate, date, false, true);
 
-    final Qualification remindedQ1 = createQualification(meetingDate, date.plusMonths(1), false);
+    final Qualification remindedQ1 = createQualification(meetingDate, date.plusMonths(1));
     createQualificationReminder(remindedQ1);
 
-    final Qualification remindedQ2 = createQualification(meetingDate, date.plusMonths(2), false);
+    final Qualification remindedQ2 = createQualification(meetingDate, date.plusMonths(2));
     createQualificationReminder(remindedQ2);
     createQualificationReminder(remindedQ2);
 
@@ -82,18 +83,21 @@ public class ExpiringQualificationsEmailCreatorTest {
     assertTrue(expiringQIds.contains(q3.getId()));
   }
 
-  private Qualification createQualification(
-    final MeetingDate meetingDate,
-    final LocalDate endDate,
-    final boolean isDeleted
-  ) {
+  private Qualification createQualification(final MeetingDate meetingDate, final LocalDate endDate) {
+    return createQualification(meetingDate, endDate, false, false);
+  }
+
+  private Qualification createQualification(final MeetingDate meetingDate, final LocalDate endDate, final boolean qualificationDeleted, final boolean interpreterDeleted) {
     final Interpreter interpreter = Factory.interpreter();
+    if(interpreterDeleted) {
+      interpreter.markDeleted();
+    }
     entityManager.persist(interpreter);
 
     final Qualification qualification = Factory.qualification(interpreter, meetingDate);
     qualification.setBeginDate(endDate.minusYears(1));
     qualification.setEndDate(endDate);
-    if (isDeleted) {
+    if(qualificationDeleted) {
       qualification.markDeleted();
     }
     entityManager.persist(qualification);


### PR DESCRIPTION
## Yhteenveto
Ei lähetetä muistutussähköpostia tarpeettomasti tilanteissa jossa
- kielipari tai tulkki on poistettu (soft delete)
- vanhenevalle kieliparille löytyy vastaava kielipari, joka ei kyselyn aikaikkunassa vanhene

## Lisätiedot

## Huomautukset
Tehty koodina, koska nyt ei ajatukset taipuneet SQLään. Jos nähdään tarpeelliseksi voidaan muuntaa SQL:ksi nyt kun on toimivat testit.

## Check-lista

- [ ] Testattu docker-compose:lla
