### PR TITLE
AKR(Frontend): Start using InfoText component

### DIFF
--- a/frontend/packages/akr/package.json
+++ b/frontend/packages/akr/package.json
@@ -21,6 +21,6 @@
     "akr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.17"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@0.0.302"
   }
 }

--- a/frontend/packages/akr/src/components/clerkTranslator/new/NewTranslatorBasicInformation.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/new/NewTranslatorBasicInformation.tsx
@@ -65,7 +65,7 @@ export const NewTranslatorBasicInformation = ({
         handleCheckBoxChange(field)
       }
       editDisabled={false}
-      displayFieldErrorBeforeChange={false}
+      showFieldErrorBeforeChange={false}
     />
   );
 };

--- a/frontend/packages/akr/src/components/clerkTranslator/overview/ClerkTranslatorDetails.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/overview/ClerkTranslatorDetails.tsx
@@ -173,7 +173,7 @@ export const ClerkTranslatorDetails = () => {
           isViewMode={isViewMode}
         />
       }
-      displayFieldErrorBeforeChange={true}
+      showFieldErrorBeforeChange={true}
     />
   );
 };

--- a/frontend/packages/akr/src/interfaces/clerkTranslatorTextField.ts
+++ b/frontend/packages/akr/src/interfaces/clerkTranslatorTextField.ts
@@ -7,6 +7,6 @@ import { ClerkTranslatorBasicInformation } from 'interfaces/clerkTranslator';
 export type ClerkTranslatorTextFieldProps = {
   translator?: ClerkTranslatorBasicInformation;
   field: ClerkTranslatorTextFieldEnum;
-  displayError: boolean;
+  showFieldError: boolean;
   onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
 } & CustomTextFieldProps;

--- a/frontend/packages/akr/src/tests/cypress/integration/clerk/translatorOverview/clerk_translator_details.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/clerk/translatorOverview/clerk_translator_details.spec.ts
@@ -254,4 +254,31 @@ describe('ClerkTranslatorOverview:ClerkTranslatorDetails', () => {
     onDialog.clickButtonByText('Kyllä');
     cy.isOnPage(AppRoutes.ClerkHomePage);
   });
+
+  it('should show field errors when inputs are not valid', () => {
+    onClerkTranslatorOverviewPage.navigateById(translatorResponse.id);
+    cy.wait('@getClerkTranslatorOverview');
+
+    onClerkTranslatorOverviewPage.clickEditTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.editTranslatorField('lastName', 'input', ' ');
+    onClerkTranslatorOverviewPage.editTranslatorField(
+      'firstName',
+      'input',
+      ' '
+    );
+    onClerkTranslatorOverviewPage.editTranslatorField('email', 'input', 'mail');
+    onClerkTranslatorOverviewPage.editTranslatorField(
+      'identityNumber',
+      'input',
+      'id'
+    );
+
+    cy.findAllByText('Tieto on pakollinen').should('have.length', 2);
+    onClerkTranslatorOverviewPage.expectText(
+      'Henkilötunnuksen muotoa ei tunnistettu'
+    );
+    onClerkTranslatorOverviewPage.expectText(
+      'Sähköpostiosoite on virheellinen'
+    );
+  });
 });

--- a/frontend/packages/akr/src/tests/cypress/support/page-objects/clerkTranslatorOverviewPage.ts
+++ b/frontend/packages/akr/src/tests/cypress/support/page-objects/clerkTranslatorOverviewPage.ts
@@ -195,6 +195,10 @@ class ClerkTranslatorOverviewPage {
     }
   }
 
+  expectText(text: string) {
+    cy.findByText(text).should('be.visible');
+  }
+
   expectTranslatorDetailsFields(translator: ClerkTranslatorResponse) {
     const fields = [
       { field: 'firstName', fieldType: 'input' },

--- a/frontend/packages/shared/src/components/index.tsx
+++ b/frontend/packages/shared/src/components/index.tsx
@@ -30,3 +30,4 @@ export { Svg } from './Svg/Svg';
 export { PaginatedTable } from './Table/Table';
 export { ToggleFilterGroup } from './ToggleFilterGroup/ToggleFilterGroup';
 export { LangSelector } from './LangSelector/LangSelector';
+export { InfoText } from './InfoText/InfoText';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2690,7 +2690,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.akr@workspace:packages/akr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.17"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@0.0.302"
   languageName: unknown
   linkType: soft
 
@@ -2787,7 +2787,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.17":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -11614,6 +11614,13 @@ __metadata:
   dependencies:
     kind-of: ^6.0.2
   checksum: 39b3dd9630a774aba288a680e7d2901f5c0eae7b8387fc5c8ea559918b29b3da144b7bdb990d7ccd9e11be05508ac9e459ce51d01fd65e583282f6ffafcba2e7
+  languageName: node
+  linkType: hard
+
+"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@0.0.302":
+  version: 0.0.302
+  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:0.0.302::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F0.0.302%2Ff769049670489a00d91f8f2566e05968331dfc48"
+  checksum: 6d40e87cd66daa6f54e62ea5a4aa19cc6fe8d73255d2272cd033b599b3fffea16b97e11147d59e804f55153d8fa23a9c47078bd9164594acfc5f80362c968212
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Näytetään paremmat info tekstit uuden kääntäjän / kääntäjän muokkaus sivuilla

## Lisätiedot

- Otettu uusi komponentti `InfoText` käyttöön
- Korjattu samalla lomakkeen kenttien leveydet niin että ne ei muutu niitä muokattaessa

## Huomautukset

- Se on ok, että error/info viesteillä on margin-left.
- Tarvitsee https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/180

## Check-lista

- [x] Testattu docker-compose:lla
