### PR TITLE
AKR(Frontend): Block contact request proceeding if phone number format is wrong

### DIFF
--- a/frontend/packages/akr/src/components/contactRequest/steps/FillContactDetails.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/FillContactDetails.tsx
@@ -48,7 +48,8 @@ export const FillContactDetails = ({
     const hasFieldErrors = !!(
       fieldErrors.firstName ||
       fieldErrors.lastName ||
-      fieldErrors.email
+      fieldErrors.email ||
+      fieldErrors.phoneNumber
     );
     const hasBlankRequiredFields = requiredFieldValues.some((v) =>
       StringUtils.isBlankString(v)

--- a/frontend/packages/akr/src/tests/cypress/integration/contact-request/contact_request.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/contact-request/contact_request.spec.ts
@@ -108,45 +108,25 @@ describe('ContactRequestPage', () => {
       .should('have.length', 3);
   });
 
-  it('should show an error if the format of email and phone number fields are not correct', () => {
+  it('should show an error and not allow proceeding if the format of email and phone number fields are not correct', () => {
     verifyTranslatorsStep();
     onContactRequestPage.next();
 
-    onContactRequestPage.fillFieldByLabel(
-      /sähköpostiosoite/i,
-      'wrong.email.com'
-    );
     onContactRequestPage.fillFieldByLabel(
       /puhelinnumero/i,
       'wrong.phone.number'
     );
     onContactRequestPage.blurFieldByLabel(/puhelinnumero/i);
-
     onContactRequestPage.isNextDisabled();
-    cy.findByText(/sähköpostiosoite on virheellinen/i).should('be.visible');
-    cy.findByText(/puhelinnumero on virheellinen/i).should('be.visible');
-  });
-
-  it('should still allow proceeding if only the phone number field is filled incorrectly', () => {
-    verifyTranslatorsStep();
-    onContactRequestPage.next();
-
-    // Fill name and email fields correctly
-    onContactRequestPage.fillFieldByLabel(/etunimi/i, 'Etunimi');
-    onContactRequestPage.fillFieldByLabel(/sukunimi/i, 'Sukunimi');
     onContactRequestPage.fillFieldByLabel(
       /sähköpostiosoite/i,
-      'test@example.fi'
+      'wrong.email.com'
     );
+    onContactRequestPage.blurFieldByLabel(/sähköpostiosoite/i);
+    onContactRequestPage.isNextDisabled();
 
-    // Type an invalid number to the phone number field
-    onContactRequestPage.fillFieldByLabel(/puhelinnumero/i, 'xxx');
-    onContactRequestPage.blurFieldByLabel(/puhelinnumero/i);
-
-    // Assert error message
+    cy.findByText(/sähköpostiosoite on virheellinen/i).should('be.visible');
     cy.findByText(/puhelinnumero on virheellinen/i).should('be.visible');
-    // Verify user can still proceed
-    onContactRequestPage.isNextEnabled();
   });
 
   it('should show an error if the message field is empty or its length exceeds the limit', () => {


### PR DESCRIPTION
## Yhteenveto

Korjaa alla mainitun ongelman:
              
> _Jos yhteydenottopyynnön yhteydessä puhelinnumeron täyttää virheellisesti, voi silti jatkaa yhteydenoton osalta eteenpäin. Voisi vaatia että puhelinnumero on täytetty oikein jos se on täytetty._

## Check-lista

- [x] Testattu docker-compose:lla
