### PR TITLE
AKR(Frontend): OPHAKRKEH-401 Disable save button when required clerk translator fields are empty

### DIFF
--- a/frontend/packages/akr/src/components/clerkTranslator/overview/ClerkTranslatorDetails.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/overview/ClerkTranslatorDetails.tsx
@@ -140,6 +140,9 @@ export const ClerkTranslatorDetails = () => {
     dispatch(showNotifierDialog(dialog));
   };
 
+  const hasRequiredDetails =
+    !!translatorDetails?.firstName && !!translatorDetails.lastName;
+
   const onCancel = () => {
     if (!hasLocalChanges) {
       resetToInitialState();
@@ -168,6 +171,7 @@ export const ClerkTranslatorDetails = () => {
           onEdit={onEdit}
           onSave={onSave}
           isViewMode={isViewMode}
+          hasRequiredDetails={hasRequiredDetails}
         />
       }
       showFieldErrorBeforeChange={true}

--- a/frontend/packages/akr/src/components/clerkTranslator/overview/ClerkTranslatorDetailsControlButtons.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/overview/ClerkTranslatorDetailsControlButtons.tsx
@@ -1,4 +1,5 @@
 import EditIcon from '@mui/icons-material/Edit';
+import { FC } from 'react';
 import { CustomButton, LoadingProgressIndicator } from 'shared/components';
 import { APIResponseStatus, Color, Variant } from 'shared/enums';
 
@@ -6,16 +7,20 @@ import { useCommonTranslation } from 'configs/i18n';
 import { useAppSelector } from 'configs/redux';
 import { clerkTranslatorOverviewSelector } from 'redux/selectors/clerkTranslatorOverview';
 
-export const ControlButtons = ({
-  isViewMode,
-  onCancel,
-  onEdit,
-  onSave,
-}: {
+interface ControlButtonsProps {
   isViewMode: boolean;
   onCancel: () => void;
   onEdit: () => void;
   onSave: () => void;
+  hasRequiredDetails: boolean;
+}
+
+export const ControlButtons: FC<ControlButtonsProps> = ({
+  isViewMode,
+  onCancel,
+  onEdit,
+  onSave,
+  hasRequiredDetails,
 }) => {
   const translateCommon = useCommonTranslation();
   const { translatorDetailsStatus } = useAppSelector(
@@ -54,7 +59,7 @@ export const ControlButtons = ({
             variant={Variant.Contained}
             color={Color.Secondary}
             onClick={onSave}
-            disabled={isLoading}
+            disabled={isLoading || !hasRequiredDetails}
           >
             {translateCommon('save')}
           </CustomButton>

--- a/frontend/packages/akr/src/tests/cypress/integration/clerk/clerk_send_email.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/clerk/clerk_send_email.spec.ts
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs';
-
 import { APIEndpoints } from 'enums/api';
 import { AppRoutes } from 'enums/app';
 import { onClerkHomePage } from 'tests/cypress/support/page-objects/clerkHomePage';
@@ -11,9 +9,6 @@ import {
 import { onDialog } from 'tests/cypress/support/page-objects/dialog';
 import { onToast } from 'tests/cypress/support/page-objects/toast';
 import { runWithIntercept } from 'tests/cypress/support/utils/api';
-import { useFixedDate } from 'tests/cypress/support/utils/date';
-
-const fixedDateForTests = dayjs('2022-01-17T12:35:00+0200');
 
 const selectedTranslatorIds = ['3', '4', '5'];
 
@@ -33,7 +28,6 @@ const confirmSend = () => {
 };
 
 beforeEach(() => {
-  useFixedDate(fixedDateForTests);
   runWithIntercept(
     APIEndpoints.ClerkTranslator,
     { fixture: 'clerk_translators_10.json' },

--- a/frontend/packages/akr/src/tests/cypress/integration/clerk/clerk_translator.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/clerk/clerk_translator.spec.ts
@@ -1,15 +1,9 @@
-import dayjs from 'dayjs';
-
 import { APIEndpoints } from 'enums/api';
 import { AuthorisationStatus } from 'enums/clerkTranslator';
 import { onClerkHomePage } from 'tests/cypress/support/page-objects/clerkHomePage';
 import { runWithIntercept } from 'tests/cypress/support/utils/api';
-import { useFixedDate } from 'tests/cypress/support/utils/date';
-
-const fixedDateForTests = dayjs('2022-01-17T12:35:00+0200');
 
 beforeEach(() => {
-  useFixedDate(fixedDateForTests);
   runWithIntercept(
     APIEndpoints.ClerkTranslator,
     { fixture: 'clerk_translators_100.json' },

--- a/frontend/packages/akr/src/tests/cypress/integration/clerk/examination_dates.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/clerk/examination_dates.spec.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import { HTTPStatusCode } from 'shared/enums';
 
 import { APIEndpoints, APIError } from 'enums/api';
@@ -7,10 +6,8 @@ import { onDialog } from 'tests/cypress/support/page-objects/dialog';
 import { onExaminationDatesPage } from 'tests/cypress/support/page-objects/examinationDatesPage';
 import { onToast } from 'tests/cypress/support/page-objects/toast';
 import { createAPIErrorResponse } from 'tests/cypress/support/utils/api';
-import { useFixedDate } from 'tests/cypress/support/utils/date';
 
 let examinationDates;
-const fixedDateForTests = dayjs('2022-01-17T12:35:00+0200');
 const examinationDateToAdd = {
   id: 11,
   version: 0,
@@ -19,8 +16,6 @@ const examinationDateToAdd = {
 const examinationDateToDelete = 5;
 
 beforeEach(() => {
-  useFixedDate(fixedDateForTests);
-
   cy.fixture('examination_dates_10.json').then((dates) => {
     examinationDates = dates;
     cy.intercept('GET', APIEndpoints.ExaminationDate, examinationDates);

--- a/frontend/packages/akr/src/tests/cypress/integration/clerk/meeting_dates.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/clerk/meeting_dates.spec.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import { HTTPStatusCode } from 'shared/enums';
 
 import { APIEndpoints, APIError } from 'enums/api';
@@ -7,10 +6,8 @@ import { onDialog } from 'tests/cypress/support/page-objects/dialog';
 import { onMeetingDatesPage } from 'tests/cypress/support/page-objects/meetingDatesPage';
 import { onToast } from 'tests/cypress/support/page-objects/toast';
 import { createAPIErrorResponse } from 'tests/cypress/support/utils/api';
-import { useFixedDate } from 'tests/cypress/support/utils/date';
 
 let meetingDates;
-const fixedDateForTests = dayjs('2022-01-17T12:35:00+0200');
 const meetingDateToAdd = {
   id: 11,
   version: 0,
@@ -19,8 +16,6 @@ const meetingDateToAdd = {
 const meetingDateToBeDeleted = 5;
 
 beforeEach(() => {
-  useFixedDate(fixedDateForTests);
-
   cy.fixture('meeting_dates_10.json').then((dates) => {
     meetingDates = dates;
     cy.intercept('GET', APIEndpoints.MeetingDate, meetingDates);

--- a/frontend/packages/akr/src/tests/cypress/integration/clerk/translatorOverview/authorisation_details.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/clerk/translatorOverview/authorisation_details.spec.ts
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs';
-
 import { APIEndpoints } from 'enums/api';
 import { AuthorisationStatus } from 'enums/clerkTranslator';
 import { translatorResponse } from 'tests/cypress/fixtures/ts/clerkTranslatorOverview';
@@ -10,14 +8,10 @@ import {
 } from 'tests/cypress/support/page-objects/authorisationDetails';
 import { onClerkTranslatorOverviewPage } from 'tests/cypress/support/page-objects/clerkTranslatorOverviewPage';
 import { onDialog } from 'tests/cypress/support/page-objects/dialog';
-import { useFixedDate } from 'tests/cypress/support/utils/date';
 
-const fixedDateForTests = dayjs('2022-01-17T12:35:00+0200');
 const effectiveAuthorisationId = 10001;
 
 beforeEach(() => {
-  useFixedDate(fixedDateForTests);
-
   cy.intercept(
     `${APIEndpoints.ClerkTranslator}/${translatorResponse.id}`,
     translatorResponse

--- a/frontend/packages/akr/src/tests/cypress/integration/clerk/translatorOverview/clerk_translator_details.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/clerk/translatorOverview/clerk_translator_details.spec.ts
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs';
-
 import { APIEndpoints } from 'enums/api';
 import { AppRoutes, UIMode } from 'enums/app';
 import {
@@ -10,13 +8,8 @@ import { onClerkHomePage } from 'tests/cypress/support/page-objects/clerkHomePag
 import { onClerkTranslatorOverviewPage } from 'tests/cypress/support/page-objects/clerkTranslatorOverviewPage';
 import { onDialog } from 'tests/cypress/support/page-objects/dialog';
 import { onToast } from 'tests/cypress/support/page-objects/toast';
-import { useFixedDate } from 'tests/cypress/support/utils/date';
-
-const fixedDateForTests = dayjs('2022-01-17T12:35:00+0200');
 
 beforeEach(() => {
-  useFixedDate(fixedDateForTests);
-
   cy.intercept(APIEndpoints.ClerkTranslator, {
     fixture: 'clerk_translators_10.json',
   });
@@ -43,7 +36,7 @@ describe('ClerkTranslatorOverview:ClerkTranslatorDetails', () => {
     onClerkTranslatorOverviewPage.navigateById(translatorResponse.id);
     cy.wait('@getClerkTranslatorOverview');
 
-    onClerkTranslatorOverviewPage.clickEditTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickEditTranslatorDetailsButton();
 
     onClerkTranslatorOverviewPage.expectMode(UIMode.EditTranslatorDetails);
   });
@@ -51,22 +44,47 @@ describe('ClerkTranslatorOverview:ClerkTranslatorDetails', () => {
   it('should return from edit mode when cancel is clicked and no changes were made', () => {
     onClerkTranslatorOverviewPage.navigateById(translatorResponse.id);
     cy.wait('@getClerkTranslatorOverview');
-    onClerkTranslatorOverviewPage.clickEditTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickEditTranslatorDetailsButton();
 
-    onClerkTranslatorOverviewPage.clickCancelTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickCancelTranslatorDetailsButton();
     onClerkTranslatorOverviewPage.expectMode(UIMode.View);
+  });
+
+  it('should disable details save button when the required fields are not filled out', () => {
+    onClerkTranslatorOverviewPage.navigateById(translatorResponse.id);
+    cy.wait('@getClerkTranslatorOverview');
+    onClerkTranslatorOverviewPage.clickEditTranslatorDetailsButton();
+
+    onClerkTranslatorOverviewPage.editTranslatorField(
+      'firstName',
+      'input',
+      '{backspace}'
+    );
+    onClerkTranslatorOverviewPage.expectDisabledSaveTranslatorDetailsButton();
+
+    onClerkTranslatorOverviewPage.editTranslatorField(
+      'firstName',
+      'input',
+      'new First name'
+    );
+    onClerkTranslatorOverviewPage.editTranslatorField(
+      'lastName',
+      'input',
+      '{backspace}'
+    );
+    onClerkTranslatorOverviewPage.expectDisabledSaveTranslatorDetailsButton();
   });
 
   it('should open a confirmation dialog when cancel is clicked if changes were made and stay in edit mode if user backs out', () => {
     onClerkTranslatorOverviewPage.navigateById(translatorResponse.id);
     cy.wait('@getClerkTranslatorOverview');
-    onClerkTranslatorOverviewPage.clickEditTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickEditTranslatorDetailsButton();
     onClerkTranslatorOverviewPage.editTranslatorField(
       'lastName',
       'input',
       'testiTesti123'
     );
-    onClerkTranslatorOverviewPage.clickCancelTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickCancelTranslatorDetailsButton();
 
     onDialog.expectText('Haluatko poistua muokkausnäkymästä?');
     onDialog.clickButtonByText('Takaisin');
@@ -77,13 +95,13 @@ describe('ClerkTranslatorOverview:ClerkTranslatorDetails', () => {
   it('should open a confirmation dialog when cancel is clicked if changes were made and return to view mode if user confirms', () => {
     onClerkTranslatorOverviewPage.navigateById(translatorResponse.id);
     cy.wait('@getClerkTranslatorOverview');
-    onClerkTranslatorOverviewPage.clickEditTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickEditTranslatorDetailsButton();
     onClerkTranslatorOverviewPage.editTranslatorField(
       'lastName',
       'input',
       'testiTesti123'
     );
-    onClerkTranslatorOverviewPage.clickCancelTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickCancelTranslatorDetailsButton();
 
     onDialog.expectText('Haluatko poistua muokkausnäkymästä?');
     onDialog.clickButtonByText('Kyllä');
@@ -99,7 +117,7 @@ describe('ClerkTranslatorOverview:ClerkTranslatorDetails', () => {
     onClerkTranslatorOverviewPage.navigateById(translatorResponse.id);
     cy.wait('@getClerkTranslatorOverview');
 
-    onClerkTranslatorOverviewPage.clickEditTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickEditTranslatorDetailsButton();
     onClerkTranslatorOverviewPage.editTranslatorField(
       fieldName,
       fieldType,
@@ -108,7 +126,7 @@ describe('ClerkTranslatorOverview:ClerkTranslatorDetails', () => {
     onClerkTranslatorOverviewPage.expectAssuranceErrorLabel('not.exist');
     onClerkTranslatorOverviewPage.toggleAssuranceSwitch();
     onClerkTranslatorOverviewPage.expectAssuranceErrorLabel('be.visible');
-    onClerkTranslatorOverviewPage.clickSaveTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickSaveTranslatorDetailsButton();
     cy.wait('@updateClerkTranslatorOverview');
 
     onClerkTranslatorOverviewPage.expectMode(UIMode.View);
@@ -249,7 +267,7 @@ describe('ClerkTranslatorOverview:ClerkTranslatorDetails', () => {
   it('should display a confirmation dialog if the back button is clicked and there are unsaved changes', () => {
     onClerkTranslatorOverviewPage.navigateById(translatorResponse.id);
     cy.wait('@getClerkTranslatorOverview');
-    onClerkTranslatorOverviewPage.clickEditTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickEditTranslatorDetailsButton();
     onClerkTranslatorOverviewPage.editTranslatorField(
       'lastName',
       'input',
@@ -266,7 +284,7 @@ describe('ClerkTranslatorOverview:ClerkTranslatorDetails', () => {
     onClerkTranslatorOverviewPage.navigateById(translatorResponse.id);
     cy.wait('@getClerkTranslatorOverview');
 
-    onClerkTranslatorOverviewPage.clickEditTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.clickEditTranslatorDetailsButton();
     onClerkTranslatorOverviewPage.editTranslatorField('lastName', 'input', ' ');
     onClerkTranslatorOverviewPage.editTranslatorField(
       'firstName',

--- a/frontend/packages/akr/src/tests/cypress/integration/clerk/translatorOverview/clerk_translator_overview.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/clerk/translatorOverview/clerk_translator_overview.spec.ts
@@ -1,17 +1,10 @@
-import dayjs from 'dayjs';
-
 import { APIEndpoints } from 'enums/api';
 import { AppRoutes } from 'enums/app';
 import { translatorResponse } from 'tests/cypress/fixtures/ts/clerkTranslatorOverview';
 import { onClerkHomePage } from 'tests/cypress/support/page-objects/clerkHomePage';
 import { onClerkTranslatorOverviewPage } from 'tests/cypress/support/page-objects/clerkTranslatorOverviewPage';
-import { useFixedDate } from 'tests/cypress/support/utils/date';
-
-const fixedDateForTests = dayjs('2022-01-17T12:35:00+0200');
 
 beforeEach(() => {
-  useFixedDate(fixedDateForTests);
-
   cy.intercept(APIEndpoints.ClerkTranslator, {
     fixture: 'clerk_translators_10.json',
   });
@@ -28,7 +21,7 @@ describe('ClerkTranslatorOverview:Page', () => {
     onClerkHomePage.clickTranslatorOverviewLink(translatorResponse.id);
 
     onClerkTranslatorOverviewPage.expectedEnabledAddAuthorisationButton();
-    onClerkTranslatorOverviewPage.expectEnabledEditTranslatorInfoBtn();
+    onClerkTranslatorOverviewPage.expectEnabledEditTranslatorDetailsButton();
   });
 
   it('should display correctly translator and authorisations details', () => {

--- a/frontend/packages/akr/src/tests/cypress/support/index.ts
+++ b/frontend/packages/akr/src/tests/cypress/support/index.ts
@@ -1,2 +1,9 @@
 import '@testing-library/cypress/add-commands';
+import dayjs from 'dayjs';
 import 'tests/cypress/support/commands';
+
+// Use fixed date for all tests
+beforeEach(() => {
+  const fixedDateForTests = dayjs('2022-01-17T12:35:00+0200');
+  cy.clock(fixedDateForTests.toDate());
+});

--- a/frontend/packages/akr/src/tests/cypress/support/page-objects/clerkTranslatorOverviewPage.ts
+++ b/frontend/packages/akr/src/tests/cypress/support/page-objects/clerkTranslatorOverviewPage.ts
@@ -11,15 +11,15 @@ class ClerkTranslatorOverviewPage {
       ),
     backToRegisterBtn: () =>
       cy.findByTestId('clerk-translator-overview-page__back-btn'),
-    editTranslatorInfoBtn: () =>
+    editTranslatorDetailsButton: () =>
       cy.findByTestId(
         'clerk-translator-overview__translator-details__edit-btn'
       ),
-    cancelTranslatorInfoBtn: () =>
+    cancelTranslatorDetailsButton: () =>
       cy.findByTestId(
         'clerk-translator-overview__translator-details__cancel-btn'
       ),
-    saveTranslatorInfoBtn: () =>
+    saveTranslatorDetailsButton: () =>
       cy.findByTestId(
         'clerk-translator-overview__translator-details__save-btn'
       ),
@@ -63,20 +63,20 @@ class ClerkTranslatorOverviewPage {
     this.elements.backToRegisterBtn().should('be.visible').click();
   }
 
-  clickEditTranslatorInfoBtn() {
-    this.elements.editTranslatorInfoBtn().should('be.visible').click();
+  clickEditTranslatorDetailsButton() {
+    this.elements.editTranslatorDetailsButton().should('be.visible').click();
   }
 
   clickAddAuthorisationBtn() {
     this.elements.addAuthorisationBtn().should('be.visible').click();
   }
 
-  clickCancelTranslatorInfoBtn() {
-    this.elements.cancelTranslatorInfoBtn().should('be.visible').click();
+  clickCancelTranslatorDetailsButton() {
+    this.elements.cancelTranslatorDetailsButton().should('be.visible').click();
   }
 
-  clickSaveTranslatorInfoBtn() {
-    this.elements.saveTranslatorInfoBtn().should('be.visible').click();
+  clickSaveTranslatorDetailsButton() {
+    this.elements.saveTranslatorDetailsButton().should('be.visible').click();
   }
 
   editTranslatorField(fieldName: string, fieldType: string, newValue) {
@@ -168,8 +168,15 @@ class ClerkTranslatorOverviewPage {
       .should('be.disabled');
   }
 
-  expectEnabledEditTranslatorInfoBtn() {
-    this.elements.editTranslatorInfoBtn().should('be.enabled');
+  expectEnabledEditTranslatorDetailsButton() {
+    this.elements.editTranslatorDetailsButton().should('be.enabled');
+  }
+
+  expectDisabledSaveTranslatorDetailsButton() {
+    this.elements
+      .saveTranslatorDetailsButton()
+      .should('be.visible')
+      .should('be.disabled');
   }
 
   expectedEnabledAddAuthorisationButton() {
@@ -184,10 +191,10 @@ class ClerkTranslatorOverviewPage {
     switch (mode) {
       case UIMode.View:
         this.elements.addAuthorisationBtn().should('be.visible');
-        this.elements.editTranslatorInfoBtn().should('be.visible');
+        this.elements.editTranslatorDetailsButton().should('be.visible');
         break;
       case UIMode.EditTranslatorDetails:
-        this.elements.cancelTranslatorInfoBtn().should('be.visible');
+        this.elements.cancelTranslatorDetailsButton().should('be.visible');
         break;
       case UIMode.EditAuthorisationDetails:
         // not implemented yet

--- a/frontend/packages/akr/src/tests/cypress/support/utils/date.ts
+++ b/frontend/packages/akr/src/tests/cypress/support/utils/date.ts
@@ -1,3 +1,0 @@
-import { Dayjs } from 'dayjs';
-
-export const useFixedDate = (date: Dayjs) => cy.clock(date.toDate());


### PR DESCRIPTION
## Yhteenveto

Jatkossa jos kääntäjää muokattasessa Sukunimi tai Etunimet on kääntäjän osalta täyttämättä, ei voi tallentaa

## Lisätiedot

Vaikuttaisi vähän siltä, että samalla Cypress testien ajoaika lyheni noin 1.5min

## Check-lista

- [x] Testattu docker-compose:lla
