### PR TITLE
OTR(Frontend): OPHOTRKEH-121 hakutoiminto uuden tulkin luontiin

### DIFF
--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -290,6 +290,22 @@
           "updated": "Tiedot tallennettiin"
         }
       },
+      "clerkPersonSearchPage": {
+        "buttons": {
+          "proceed": "Syötä manuaalisesti",
+          "search": "Suorita haku"
+        },
+        "noResult": {
+          "description": "Tällä henkilötunnuksella ei löytynyt tietoja. Tarkista onko henkilötunnus kirjoitettu oikein tai syötä tiedot manuaalisesti.",
+          "label": "Tietoja ei löytynyt"
+        },
+        "placeholder": "Syötä henkilötunnus",
+        "search": {
+          "description": "Järjestelmä hakee henkilötiedot automaattisesti oppijanumerorekisteristä.",
+          "label": "Hae tiedot oppijanumerorekisteristä"
+        },
+        "title": "Lisää oikeustulkki"
+      },
       "homepage": {
         "description": "Opetushallitus ylläpitää oikeustulkkirekisteriä, johon oikeustulkkirekisterilautakunnan hyväksymät oikeustulkit merkitään. Hakukoneella voit hakea tulkkia joko nimen, kieliparin tai toiminta-alueen mukaan. Julkinen oikeustulkkirekisteri sisältää tiedot vain niistä tulkeista, jotka ovat antaneet luvan tietojensa julkaisemiseen verkossa.",
         "filters": {

--- a/frontend/packages/otr/src/enums/api.ts
+++ b/frontend/packages/otr/src/enums/api.ts
@@ -1,6 +1,7 @@
 export enum APIEndpoints {
   PublicInterpreter = '/otr/api/v1/interpreter',
   ClerkInterpreter = '/otr/api/v1/clerk/interpreter',
+  ClerkPersonSearch = '/otr/api/v1/clerk/person',
   ClerkUser = '/otr/api/v1/clerk/user',
   Qualification = '/otr/api/v1/clerk/interpreter/qualification',
   MeetingDate = '/otr/api/v1/clerk/meetingDate',

--- a/frontend/packages/otr/src/enums/app.ts
+++ b/frontend/packages/otr/src/enums/app.ts
@@ -7,6 +7,8 @@ export enum AppRoutes {
   ClerkHomePage = '/otr/virkailija',
   MeetingDatesPage = '/otr/virkailija/kokouspaivat',
   ClerkInterpreterOverviewPage = '/otr/virkailija/tulkki/:interpreterId',
+  ClerkPersonSearchPage = '/otr/virkailija/lisaa-tulkki/haku',
+  ClerkNewInterpreterPage = '/otr/virkailija/lisaa-tulkki',
   ClerkLocalLogoutPage = '/otr/cas/localLogout',
   AccessibilityStatementPage = '/otr/saavutettavuusseloste',
   NotFoundPage = '*',

--- a/frontend/packages/otr/src/interfaces/clerkPerson.ts
+++ b/frontend/packages/otr/src/interfaces/clerkPerson.ts
@@ -1,0 +1,13 @@
+export interface ClerkPerson {
+  onrId: string;
+  isIndividualised: boolean;
+  identityNumber: string;
+  lastName: string;
+  firstName: string;
+  nickName: string;
+  // Optional fields
+  street?: string;
+  postalCode?: string;
+  town?: string;
+  country?: string;
+}

--- a/frontend/packages/otr/src/pages/ClerkHomePage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkHomePage.tsx
@@ -37,7 +37,7 @@ export const ClerkHomePage: FC = () => {
               startIcon={<AddIcon />}
               color={Color.Secondary}
               variant={Variant.Contained}
-              to={AppRoutes.ClerkHomePage}
+              to={AppRoutes.ClerkPersonSearchPage}
             >
               {t('addInterpreter')}
             </CustomButtonLink>

--- a/frontend/packages/otr/src/pages/ClerkPersonSearchPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkPersonSearchPage.tsx
@@ -1,0 +1,156 @@
+import { Box, Paper } from '@mui/material';
+import { ChangeEvent, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
+import {
+  CustomButton,
+  CustomTextField,
+  H1,
+  H3,
+  LoadingProgressIndicator,
+  Text,
+} from 'shared/components';
+import {
+  APIResponseStatus,
+  Color,
+  TextFieldTypes,
+  Variant,
+} from 'shared/enums';
+import { InputFieldUtils } from 'shared/utils';
+
+import { TopControls } from 'components/clerkInterpreter/overview/TopControls';
+import { useAppTranslation } from 'configs/i18n';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { AppRoutes } from 'enums/app';
+import {
+  resetClerkPersonSearchStatus,
+  searchClerkPerson,
+} from 'redux/reducers/clerkPersonSearch';
+import { clerkPersonSearchSelector } from 'redux/selectors/clerkPersonSearch';
+
+export const ClerkPersonSearchPage = () => {
+  const { t } = useAppTranslation({ keyPrefix: 'otr' });
+  const navigate = useNavigate();
+
+  // State
+  const [identityNumber, setIdentityNumber] = useState('');
+  const [searchDisabled, setSearchDisabled] = useState(true);
+  const [fieldError, setFieldError] = useState('');
+
+  // Redux
+  const { status, person } = useAppSelector(clerkPersonSearchSelector);
+  const isLoading = status == APIResponseStatus.InProgress;
+  const personNotFound = status == APIResponseStatus.Success && !person;
+  const dispatch = useAppDispatch();
+
+  const handleIdentityNumberChange =
+    () => (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+
+      setIdentityNumber(value);
+      setSearchDisabled(getIdentityCodeError(value).length > 0);
+    };
+
+  const handleIdentityNumberErrors =
+    () => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const error = getIdentityCodeError(event.target.value);
+      setFieldError(error ? t(error) : '');
+    };
+
+  const getIdentityCodeError = (value: string) => {
+    return InputFieldUtils.inspectCustomTextFieldErrors(
+      TextFieldTypes.PersonalIdentityCode,
+      value
+    );
+  };
+
+  const handleSearch = () => {
+    dispatch(searchClerkPerson(identityNumber));
+  };
+
+  const handleProceed = () => {
+    navigate(AppRoutes.ClerkNewInterpreterPage);
+  };
+
+  useEffect(() => {
+    return () => {
+      dispatch(resetClerkPersonSearchStatus());
+    };
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (status === APIResponseStatus.Success && person) {
+      navigate(AppRoutes.ClerkNewInterpreterPage);
+    }
+  }, [navigate, status, person]);
+
+  return (
+    <Box className="clerk-person-search-page">
+      <H1>{t('pages.clerkPersonSearchPage.title')}</H1>
+      <Paper
+        elevation={3}
+        className="clerk-person-search-page__content-container rows"
+      >
+        <TopControls />
+        <div className="rows gapped">
+          <div className="columns margin-top-lg">
+            <div className="columns margin-top-lg grow">
+              <H3>
+                {personNotFound
+                  ? t('pages.clerkPersonSearchPage.noResult.label')
+                  : t('pages.clerkPersonSearchPage.search.label')}
+              </H3>
+            </div>
+          </div>
+          <div className="columns">
+            <Text>
+              {personNotFound
+                ? t('pages.clerkPersonSearchPage.noResult.description')
+                : t('pages.clerkPersonSearchPage.search.description')}
+            </Text>
+          </div>
+          <div className="columns gapped margin-top-lg">
+            <CustomTextField
+              className="clerk-person-search-page__ssn__field"
+              data-testid="clerk-person-search-page__ssn__field"
+              label={t('pages.clerkPersonSearchPage.placeholder')}
+              value={identityNumber}
+              onChange={handleIdentityNumberChange()}
+              onBlur={handleIdentityNumberErrors()}
+              error={fieldError.length > 0 || personNotFound}
+              helperText={fieldError}
+              sx={{
+                '& .MuiFormHelperText-root': {
+                  height: 0,
+                },
+              }}
+            />
+            <div className="columns">
+              <LoadingProgressIndicator isLoading={isLoading}>
+                <CustomButton
+                  data-testid="clerk-person-search-page__ssn__search-button"
+                  variant={Variant.Contained}
+                  color={Color.Secondary}
+                  disabled={searchDisabled || isLoading}
+                  onClick={handleSearch}
+                >
+                  {t('pages.clerkPersonSearchPage.buttons.search')}
+                </CustomButton>
+              </LoadingProgressIndicator>
+            </div>
+          </div>
+          <div className="columns margin-top-lg">
+            {personNotFound && (
+              <CustomButton
+                variant={Variant.Outlined}
+                color={Color.Secondary}
+                onClick={handleProceed}
+              >
+                {t('pages.clerkPersonSearchPage.buttons.proceed')}
+              </CustomButton>
+            )}
+          </div>
+        </div>
+      </Paper>
+    </Box>
+  );
+};

--- a/frontend/packages/otr/src/redux/reducers/clerkPersonSearch.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkPersonSearch.ts
@@ -1,0 +1,50 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { APIResponseStatus } from 'shared/enums';
+
+import { ClerkPerson } from 'interfaces/clerkPerson';
+
+interface ClerkPersonSearchState {
+  status: APIResponseStatus;
+  identityNumber: string;
+  person: ClerkPerson | undefined;
+}
+
+const initialState: ClerkPersonSearchState = {
+  status: APIResponseStatus.NotStarted,
+  identityNumber: '',
+  person: undefined,
+};
+
+const clerkPersonSearchSlice = createSlice({
+  name: 'clerkPersonSearch',
+  initialState,
+  reducers: {
+    resetClerkPersonSearchStatus(state) {
+      state.status = initialState.status;
+    },
+    rejectClerkPersonSearch(state) {
+      state.status = APIResponseStatus.Error;
+      state.identityNumber = initialState.identityNumber;
+      state.person = initialState.person;
+    },
+    searchClerkPerson(state, action: PayloadAction<string>) {
+      state.status = APIResponseStatus.InProgress;
+      state.identityNumber = action.payload;
+    },
+    storeClerkPersonSearch(
+      state,
+      action: PayloadAction<ClerkPerson | undefined>
+    ) {
+      state.status = APIResponseStatus.Success;
+      state.person = action.payload;
+    },
+  },
+});
+
+export const clerkPersonSearchReducer = clerkPersonSearchSlice.reducer;
+export const {
+  resetClerkPersonSearchStatus,
+  rejectClerkPersonSearch,
+  searchClerkPerson,
+  storeClerkPersonSearch,
+} = clerkPersonSearchSlice.actions;

--- a/frontend/packages/otr/src/redux/sagas/clerkPersonSearch.ts
+++ b/frontend/packages/otr/src/redux/sagas/clerkPersonSearch.ts
@@ -1,0 +1,37 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import { AxiosError, AxiosResponse } from 'axios';
+import { call, put, takeLatest } from 'redux-saga/effects';
+
+import axiosInstance from 'configs/axios';
+import { APIEndpoints } from 'enums/api';
+import { ClerkPerson } from 'interfaces/clerkPerson';
+import {
+  rejectClerkPersonSearch,
+  searchClerkPerson,
+  storeClerkPersonSearch,
+} from 'redux/reducers/clerkPersonSearch';
+import { showNotifierToast } from 'redux/reducers/notifier';
+import { NotifierUtils } from 'utils/notifier';
+
+function* searchClerkPersonSaga(action: PayloadAction<string>) {
+  try {
+    const response: AxiosResponse<ClerkPerson> = yield call(
+      axiosInstance.get,
+      `${APIEndpoints.ClerkPersonSearch}/?identityNumber=${action.payload}`
+    );
+    const clerkPerson = response.data ? response.data : undefined;
+
+    yield put(storeClerkPersonSearch(clerkPerson));
+  } catch (error) {
+    yield put(rejectClerkPersonSearch());
+    yield put(
+      showNotifierToast(
+        NotifierUtils.createAxiosErrorNotifierToast(error as AxiosError)
+      )
+    );
+  }
+}
+
+export function* watchClerkPersonSearch() {
+  yield takeLatest(searchClerkPerson, searchClerkPersonSaga);
+}

--- a/frontend/packages/otr/src/redux/sagas/index.ts
+++ b/frontend/packages/otr/src/redux/sagas/index.ts
@@ -2,6 +2,7 @@ import { all } from 'redux-saga/effects';
 
 import { watchClerkInterpreters } from 'redux/sagas/clerkInterpreter';
 import { watchClerkInterpreterOverview } from 'redux/sagas/clerkInterpreterOverview';
+import { watchClerkPersonSearch } from 'redux/sagas/clerkPersonSearch';
 import { watchClerkUser } from 'redux/sagas/clerkUser';
 import { watchMeetingDates } from 'redux/sagas/meetingDate';
 import { watchPublicInterpreters } from 'redux/sagas/publicInterpreter';
@@ -12,6 +13,7 @@ export default function* rootSaga() {
     watchPublicInterpreters(),
     watchClerkInterpreters(),
     watchClerkInterpreterOverview(),
+    watchClerkPersonSearch(),
     watchClerkUser(),
     watchQualificationUpdates(),
     watchMeetingDates(),

--- a/frontend/packages/otr/src/redux/selectors/clerkPersonSearch.ts
+++ b/frontend/packages/otr/src/redux/selectors/clerkPersonSearch.ts
@@ -1,0 +1,4 @@
+import { RootState } from 'configs/redux';
+
+export const clerkPersonSearchSelector = (state: RootState) =>
+  state.clerkPersonSearch;

--- a/frontend/packages/otr/src/redux/store/index.ts
+++ b/frontend/packages/otr/src/redux/store/index.ts
@@ -3,6 +3,7 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import { clerkInterpreterReducer } from 'redux/reducers/clerkInterpreter';
 import { clerkInterpreterOverviewReducer } from 'redux/reducers/clerkInterpreterOverview';
+import { clerkPersonSearchReducer } from 'redux/reducers/clerkPersonSearch';
 import { clerkUserReducer } from 'redux/reducers/clerkUser';
 import { meetingDateReducer } from 'redux/reducers/meetingDate';
 import { notifierReducer } from 'redux/reducers/notifier';
@@ -16,6 +17,7 @@ const store = configureStore({
   reducer: {
     clerkInterpreter: clerkInterpreterReducer,
     clerkInterpreterOverview: clerkInterpreterOverviewReducer,
+    clerkPersonSearch: clerkPersonSearchReducer,
     publicInterpreter: publicInterpreterReducer,
     clerkUser: clerkUserReducer,
     meetingDate: meetingDateReducer,

--- a/frontend/packages/otr/src/routers/AppRouter.tsx
+++ b/frontend/packages/otr/src/routers/AppRouter.tsx
@@ -7,6 +7,7 @@ import { Notifier } from 'components/notification/Notifier';
 import { AppRoutes } from 'enums/app';
 import { ClerkHomePage } from 'pages/ClerkHomePage';
 import { ClerkInterpreterOverviewPage } from 'pages/ClerkInterpreterOverviewPage';
+import { ClerkPersonSearchPage } from 'pages/ClerkPersonSearchPage';
 import { MeetingDatesPage } from 'pages/MeetingDatesPage';
 import { PublicHomePage } from 'pages/PublicHomePage';
 
@@ -34,6 +35,10 @@ export const AppRouter: FC = () => {
               <Route
                 path={AppRoutes.ClerkInterpreterOverviewPage}
                 element={<ClerkInterpreterOverviewPage />}
+              />
+              <Route
+                path={AppRoutes.ClerkPersonSearchPage}
+                element={<ClerkPersonSearchPage />}
               />
             </Routes>
           </div>

--- a/frontend/packages/otr/src/styles/pages/_clerk-person-search-page.scss
+++ b/frontend/packages/otr/src/styles/pages/_clerk-person-search-page.scss
@@ -1,0 +1,11 @@
+.clerk-person-search-page {
+  flex: 1;
+
+  & &__content-container {
+    padding: 3rem;
+  }
+
+  &__ssn__field {
+    flex-basis: 26%;
+  }
+}

--- a/frontend/packages/otr/src/styles/styles.scss
+++ b/frontend/packages/otr/src/styles/styles.scss
@@ -15,5 +15,6 @@
 // Pages
 @import 'pages/clerk-homepage';
 @import 'pages/clerk-interpreter-overview-page';
+@import 'pages/clerk-person-search-page';
 @import 'pages/meeting-dates-page';
 @import 'pages/public-homepage';

--- a/frontend/packages/otr/src/tests/cypress/integration/clerk_person_search_page.spec.ts
+++ b/frontend/packages/otr/src/tests/cypress/integration/clerk_person_search_page.spec.ts
@@ -1,0 +1,35 @@
+import { onClerkPersonSearchPage } from 'tests/cypress/support/page-objects/clerkPersonSearchPage';
+
+describe('ClerkPersonSearchPage', () => {
+  beforeEach(() => {
+    cy.openClerkPersonSearchPage();
+  });
+
+  it('should enable search button with correct SSN', () => {
+    onClerkPersonSearchPage.expectSocialSecurityNumberSearchButtonDisabled();
+    onClerkPersonSearchPage.typeSocialSecurityNumber('090687-913J');
+    onClerkPersonSearchPage.expectSocialSecurityNumberSearchButtonEnabled();
+  });
+
+  it('should show error with incorrect SSN', () => {
+    onClerkPersonSearchPage.expectSocialSecurityNumberSearchButtonDisabled();
+    onClerkPersonSearchPage.typeSocialSecurityNumber('090687-913Jaaa');
+    onClerkPersonSearchPage.blurFieldByLabel('Syötä henkilötunnus');
+    onClerkPersonSearchPage.expectSocialSecurityNumberFieldError(
+      'Henkilötunnuksen muotoa ei tunnistettu'
+    );
+    onClerkPersonSearchPage.expectSocialSecurityNumberSearchButtonDisabled();
+  });
+
+  it('should show error with empty SSN', () => {
+    onClerkPersonSearchPage.expectSocialSecurityNumberSearchButtonDisabled();
+    onClerkPersonSearchPage.typeSocialSecurityNumber(
+      '123 {selectall}{backspace}'
+    );
+    onClerkPersonSearchPage.blurFieldByLabel('Syötä henkilötunnus');
+    onClerkPersonSearchPage.expectSocialSecurityNumberFieldError(
+      'Tieto on pakollinen'
+    );
+    onClerkPersonSearchPage.expectSocialSecurityNumberSearchButtonDisabled();
+  });
+});

--- a/frontend/packages/otr/src/tests/cypress/support/commands.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/commands.ts
@@ -8,6 +8,10 @@ Cypress.Commands.add('openClerkHomePage', () => {
   cy.visit(AppRoutes.ClerkHomePage);
 });
 
+Cypress.Commands.add('openClerkPersonSearchPage', () => {
+  cy.visit(AppRoutes.ClerkPersonSearchPage);
+});
+
 Cypress.Commands.add('openMeetingDatesPage', () => {
   cy.visit(AppRoutes.MeetingDatesPage);
 });

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkPersonSearchPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkPersonSearchPage.ts
@@ -1,0 +1,51 @@
+import { Matcher } from '@testing-library/dom';
+
+class ClerkPersonSearchPage {
+  elements = {
+    socialSecurityNumberField: () =>
+      cy.findByTestId('clerk-person-search-page__ssn__field'),
+    socialSecurityNumberSearchButton: () =>
+      cy.findByTestId('clerk-person-search-page__ssn__search-button'),
+    byLabel: (label: Matcher) =>
+      cy
+        .findByTestId('clerk-person-search-page__ssn__field')
+        .findByLabelText(label),
+  };
+
+  typeSocialSecurityNumber(socialSecurityNumber: string) {
+    this.elements
+      .socialSecurityNumberField()
+      .should('be.visible')
+      .type(socialSecurityNumber);
+  }
+
+  clickSearchButton() {
+    this.elements
+      .socialSecurityNumberSearchButton()
+      .should('be.visible')
+      .click();
+  }
+
+  expectSocialSecurityNumberFieldError(fieldError: string) {
+    const regexp = new RegExp(fieldError, 'i');
+
+    this.elements
+      .socialSecurityNumberField()
+      .findByText(regexp)
+      .should('exist');
+  }
+
+  blurFieldByLabel(label: Matcher) {
+    this.elements.byLabel(label).focus().blur();
+  }
+
+  expectSocialSecurityNumberSearchButtonEnabled() {
+    this.elements.socialSecurityNumberSearchButton().should('be.enabled');
+  }
+
+  expectSocialSecurityNumberSearchButtonDisabled() {
+    this.elements.socialSecurityNumberSearchButton().should('be.disabled');
+  }
+}
+
+export const onClerkPersonSearchPage = new ClerkPersonSearchPage();

--- a/frontend/packages/otr/src/tests/cypress/support/types/index.d.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/types/index.d.ts
@@ -5,6 +5,7 @@ declare global {
     interface Chainable {
       openPublicHomePage(): void;
       openClerkHomePage(): void;
+      openClerkPersonSearchPage(): void;
       openMeetingDatesPage(): void;
       usePhoneViewport(): void;
       goBack(): void;

--- a/frontend/packages/otr/src/tests/jest/pages/__snapshots__/ClerkHomePage.test.tsx.snap
+++ b/frontend/packages/otr/src/tests/jest/pages/__snapshots__/ClerkHomePage.test.tsx.snap
@@ -45,7 +45,7 @@ Object {
                 >
                   <a
                     class="custom-button-link"
-                    href="/otr/virkailija"
+                    href="/otr/virkailija/lisaa-tulkki/haku"
                   >
                     <button
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium css-6d27ud-MuiButtonBase-root-MuiButton-root"
@@ -1558,7 +1558,7 @@ Object {
               >
                 <a
                   class="custom-button-link"
-                  href="/otr/virkailija"
+                  href="/otr/virkailija/lisaa-tulkki/haku"
                 >
                   <button
                     class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium css-6d27ud-MuiButtonBase-root-MuiButton-root"


### PR DESCRIPTION
## Yhteenveto

Toteuttaa sivun, jolla haetaan uuden lisättävän tulkin henkilötietoja tämän hetun perusteella. Jos tiedot löytyvät, tehdään välitön selaimen ohjaus tulkin lisäyssivulle, jonne nuo tiedot rendataan. Mikäli tulkkia ei löydy, voi haun yrittää uusia mahd. eri hetulla mahdollisuutena myös siirtyä manuaalisesti lisäämään tulkkia annetulla hetulla.

## Testaus

`OnrOperationApiMock` alla määritelty neljä testihetua, joiden osalta backend palauttaa henkilötietoja. Muiden hetujen osalta paluurvo on null.
```
final String individualised1 = "090687-913J";
final String individualised2 = "170378-966N";
final String manuallyCreated1 = "170688-935N";
final String manuallyCreated2 = "121094-917M";
```

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
- [x] Testattu docker-compose:lla
