### PR TITLE
OTR(Frontend): OPHOTRKEH-84 henkilötietoja ei voi muokata jos tulkki VTJ-yksilöity

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/onr/mock/PersonalDataFactory.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/mock/PersonalDataFactory.java
@@ -21,7 +21,7 @@ public class PersonalDataFactory {
     return PersonalData
       .builder()
       .onrId(onrId)
-      .individualised(counterValue % 11 != 0)
+      .individualised(counterValue % 3 != 0)
       .lastName(lastName)
       .firstName(nickName + " " + secondName)
       .nickName(nickName)

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -257,6 +257,7 @@
     "errors": {
       "api": {
         "generic": "Toiminto epäonnistui, yritä myöhemmin uudelleen",
+        "interpreterInvalidNickName": "Kutsumanimen tulee olla jokin etunimistä",
         "meetingDateCreateDuplicateDate": "Kokouspäivän lisäys epäonnistui, koska valitulla päivämäärällä on jo kokouspäivä",
         "meetingDateDeleteHasQualifications": "Kokouspäivän poisto epäonnistui, koska sille on kirjattu rekisteröintejä",
         "meetingDateUpdateDuplicateDate": "Kokouspäivän muokkaus epäonnistui, koska valitulla päivämäärällä on jo kokouspäivä",

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
@@ -137,7 +137,8 @@ export const ClerkInterpreterDetails = () => {
       onFieldChange={(field: keyof ClerkInterpreter) =>
         handleInterpreterDetailsChange(field)
       }
-      editDisabled={isViewMode}
+      isViewMode={isViewMode}
+      isIndividualisedInterpreter={interpreter?.isIndividualised}
       topControlButtons={
         <ControlButtons
           onCancel={onCancel}

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetailsFields.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetailsFields.tsx
@@ -186,7 +186,8 @@ export const ClerkInterpreterDetailsFields = ({
   areaOfOperation,
   setAreaOfOperation,
   onFieldChange,
-  editDisabled,
+  isViewMode,
+  isIndividualisedInterpreter = false,
   topControlButtons,
   displayFieldErrorBeforeChange,
 }: {
@@ -200,7 +201,8 @@ export const ClerkInterpreterDetailsFields = ({
   ) => void;
   areaOfOperation: AreaOfOperation;
   setAreaOfOperation: React.Dispatch<React.SetStateAction<AreaOfOperation>>;
-  editDisabled: boolean;
+  isViewMode: boolean;
+  isIndividualisedInterpreter?: boolean;
   topControlButtons?: JSX.Element;
   displayFieldErrorBeforeChange: boolean;
 }) => {
@@ -221,10 +223,25 @@ export const ClerkInterpreterDetailsFields = ({
       setDisplayFieldError({ ...displayFieldError, [field]: true });
     };
 
+  const isIndividualisedValue = (field: ClerkInterpreterTextFieldEnum) => {
+    if (field === ClerkInterpreterTextFieldEnum.IdentityNumber) {
+      return true;
+    }
+
+    return (
+      isIndividualisedInterpreter &&
+      [
+        ClerkInterpreterTextFieldEnum.LastName,
+        ClerkInterpreterTextFieldEnum.FirstName,
+        ClerkInterpreterTextFieldEnum.NickName,
+      ].includes(field)
+    );
+  };
+
   const getCommonTextFieldProps = (field: ClerkInterpreterTextFieldEnum) => ({
     field,
     interpreter,
-    disabled: editDisabled,
+    disabled: isViewMode || isIndividualisedValue(field),
     onChange: onFieldChange(field),
     onBlur: displayFieldErrorOnBlur(field),
     displayError: displayFieldError[field],
@@ -295,7 +312,7 @@ export const ClerkInterpreterDetailsFields = ({
         areaOfOperation={areaOfOperation}
         setAreaOfOperation={setAreaOfOperation}
         onChange={onFieldChange('regions')}
-        disabled={editDisabled}
+        disabled={isViewMode}
       />
     </>
   );

--- a/frontend/packages/otr/src/enums/api.ts
+++ b/frontend/packages/otr/src/enums/api.ts
@@ -11,6 +11,7 @@ export enum APIEndpoints {
  * The respective backend enum is `APIExceptionType`.
  */
 export enum APIError {
+  InterpreterInvalidNickName = 'interpreterInvalidNickName',
   MeetingDateCreateDuplicateDate = 'meetingDateCreateDuplicateDate',
   MeetingDateDeleteHasQualifications = 'meetingDateDeleteHasQualifications',
   MeetingDateUpdateDuplicateDate = 'meetingDateUpdateDuplicateDate',


### PR DESCRIPTION
## Yhteenveto

VTJ-yksilöityjen tulkkien henkilötietoja (= nimet + hetu) ei voi muokata. Myöskään ei VTJ-yksilöidyn tulkin hetua pysty enää muuttamaan.

## Huomautukset

- Kimmo kirjoittaa testejä tulkin editointinäkyään taskissa OPHOTRKEH-109. Ottaa myös nämä muutokset huomioon niissä.
- Joka kolmas tulkki on testidatassa nyt ei-yksilöity, aiemmin oli näin vain joka 11. osalta.

## Check-lista

- [x] Testattu docker-compose:lla