### PR TITLE
AKR(Frontend): OPHAKRKEH-407 auktorisointien toastit

### DIFF
--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -92,6 +92,11 @@
           },
           "header": "Auktorisoinnit",
           "noAuthorisations": "Valituille kriteereille ei löytynyt auktorisointeja",
+          "toasts": {
+            "addingSucceeded": "Auktorisointi lisätty onnistuneesti",
+            "removingSucceeded": "Valittu auktorisointi poistettu",
+            "updatingPublishPermissionSucceeded": "Auktorisoinnin julkaisulupaa muutettu"
+          },
           "toggleFilters": {
             "effectives": "Voimassa olevat",
             "expired": "Umpeutuneet",
@@ -279,11 +284,7 @@
           "to": "Mihin"
         },
         "switch": {
-          "inEffect": "Voimassa",
           "permissionToPublish": "Julkaisulupa"
-        },
-        "toasts": {
-          "success": "Auktorisointi lisätty onnistuneesti"
         }
       },
       "publicTranslatorFilters": {

--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -283,7 +283,6 @@
           "permissionToPublish": "Julkaisulupa"
         },
         "toasts": {
-          "error": "Auktorisoinnin lisäys ei onnistunut, yritä myöhemmin uudelleen",
           "success": "Auktorisointi lisätty onnistuneesti"
         }
       },

--- a/frontend/packages/akr/src/components/clerkTranslator/add/AddAuthorisation.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/add/AddAuthorisation.tsx
@@ -14,7 +14,7 @@ import {
 } from 'shared/components';
 import { Color, TextFieldVariant, Variant } from 'shared/enums';
 import { ComboBoxOption } from 'shared/interfaces';
-import { CommonUtils, DateUtils, StringUtils } from 'shared/utils';
+import { CommonUtils, DateUtils } from 'shared/utils';
 
 import {
   useAppTranslation,
@@ -154,28 +154,28 @@ export const AddAuthorisation = ({
     language ? languageToComboBoxOption(translateLanguage, language) : null;
 
   const isAddButtonDisabled = () => {
-    const { languagePair, diaryNumber, examinationDate, ...otherProps } =
-      authorisation;
-
-    const isOtherPropsNotDefined = Object.values(otherProps).some((p) =>
-      StringUtils.isBlankString(p)
-    );
-    const isLangPropsNotDefined =
-      StringUtils.isBlankString(languagePair.from) ||
-      StringUtils.isBlankString(languagePair.to);
-
-    const isDiaryNumberBlank = StringUtils.isBlankString(diaryNumber);
+    const {
+      languagePair: { from: fromLang, to: toLang },
+      examinationDate,
+      permissionToPublish: _unused,
+      ...otherProps
+    } = authorisation;
 
     const isExaminationDateNotDefinedOrInvalid =
       otherProps.basis === AuthorisationBasisEnum.AUT &&
       (!examinationDate || !dayjs(examinationDate).isValid());
 
+    // If permissionToPublish wasn't marked `_unused`, this would consider false value there being incorrect
+    const isOtherPropsNotDefined = Object.values({
+      fromLang,
+      toLang,
+      ...otherProps,
+    }).some((p) => !p);
+
     return (
       isLoading ||
-      isOtherPropsNotDefined ||
-      isLangPropsNotDefined ||
-      isDiaryNumberBlank ||
-      isExaminationDateNotDefinedOrInvalid
+      isExaminationDateNotDefinedOrInvalid ||
+      isOtherPropsNotDefined
     );
   };
 

--- a/frontend/packages/akr/src/components/clerkTranslator/overview/AuthorisationListing.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/overview/AuthorisationListing.tsx
@@ -28,7 +28,7 @@ import {
 import { useAppSelector } from 'configs/redux';
 import { AuthorisationBasisEnum } from 'enums/clerkTranslator';
 import { Authorisation } from 'interfaces/authorisation';
-import { clerkTranslatorOverviewSelector } from 'redux/selectors/clerkTranslatorOverview';
+import { authorisationSelector } from 'redux/selectors/authorisation';
 import { AuthorisationUtils } from 'utils/authorisation';
 
 export const AuthorisationListing = ({
@@ -48,11 +48,15 @@ export const AuthorisationListing = ({
     keyPrefix: 'akr.component.clerkTranslatorOverview.authorisations',
   });
 
-  const status = useAppSelector(
-    clerkTranslatorOverviewSelector
-  ).authorisationDetailsStatus;
+  const { addStatus, removeStatus, updatePublishPermissionStatus } =
+    useAppSelector(authorisationSelector);
 
-  const isLoading = status === APIResponseStatus.InProgress;
+  const isLoading = [
+    addStatus,
+    removeStatus,
+    updatePublishPermissionStatus,
+  ].includes(APIResponseStatus.InProgress);
+
   const currentDate = dayjs();
 
   const defaultClassName = 'clerk-translator-details__authorisations-table';

--- a/frontend/packages/akr/src/pages/clerk/ClerkNewTranslatorPage.tsx
+++ b/frontend/packages/akr/src/pages/clerk/ClerkNewTranslatorPage.tsx
@@ -3,13 +3,7 @@ import { Box, Paper } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { CustomButton, CustomModal, H1, H2 } from 'shared/components';
-import {
-  APIResponseStatus,
-  Color,
-  Duration,
-  Severity,
-  Variant,
-} from 'shared/enums';
+import { APIResponseStatus, Color, Severity, Variant } from 'shared/enums';
 import { useDialog, useToast } from 'shared/hooks';
 
 import { AddAuthorisation } from 'components/clerkTranslator/add/AddAuthorisation';
@@ -131,9 +125,7 @@ export const ClerkNewTranslatorPage = () => {
       showToast({
         severity: Severity.Success,
         description: t('toasts.success'),
-        timeOut: Duration.Medium,
       });
-      dispatch(resetClerkNewTranslator());
       navigate(
         AppRoutes.ClerkTranslatorOverviewPage.replace(/:translatorId$/, `${id}`)
       );

--- a/frontend/packages/akr/src/pages/clerk/ClerkTranslatorOverviewPage.tsx
+++ b/frontend/packages/akr/src/pages/clerk/ClerkTranslatorOverviewPage.tsx
@@ -12,7 +12,6 @@ import { ClerkTranslatorOverviewPageSkeleton } from 'components/skeletons/ClerkT
 import { useAppTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
-import { resetAuthorisationState } from 'redux/reducers/authorisation';
 import {
   loadClerkTranslatorOverview,
   resetClerkTranslatorOverview,
@@ -69,7 +68,6 @@ export const ClerkTranslatorOverviewPage = () => {
   useEffect(() => {
     return () => {
       dispatch(resetClerkTranslatorOverview());
-      dispatch(resetAuthorisationState());
     };
   }, [dispatch]);
 

--- a/frontend/packages/akr/src/pages/clerk/ClerkTranslatorOverviewPage.tsx
+++ b/frontend/packages/akr/src/pages/clerk/ClerkTranslatorOverviewPage.tsx
@@ -12,6 +12,7 @@ import { ClerkTranslatorOverviewPageSkeleton } from 'components/skeletons/ClerkT
 import { useAppTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
+import { resetAuthorisationState } from 'redux/reducers/authorisation';
 import {
   loadClerkTranslatorOverview,
   resetClerkTranslatorOverview,
@@ -68,6 +69,7 @@ export const ClerkTranslatorOverviewPage = () => {
   useEffect(() => {
     return () => {
       dispatch(resetClerkTranslatorOverview());
+      dispatch(resetAuthorisationState());
     };
   }, [dispatch]);
 

--- a/frontend/packages/akr/src/redux/reducers/authorisation.ts
+++ b/frontend/packages/akr/src/redux/reducers/authorisation.ts
@@ -4,11 +4,15 @@ import { APIResponseStatus } from 'shared/enums';
 import { Authorisation } from 'interfaces/authorisation';
 
 interface AuthorisationState {
-  status: APIResponseStatus;
+  addStatus: APIResponseStatus;
+  removeStatus: APIResponseStatus;
+  updatePublishPermissionStatus: APIResponseStatus;
 }
 
 const initialState: AuthorisationState = {
-  status: APIResponseStatus.NotStarted,
+  addStatus: APIResponseStatus.NotStarted,
+  removeStatus: APIResponseStatus.NotStarted,
+  updatePublishPermissionStatus: APIResponseStatus.NotStarted,
 };
 
 const authorisationSlice = createSlice({
@@ -16,16 +20,40 @@ const authorisationSlice = createSlice({
   initialState,
   reducers: {
     addAuthorisation(state, _action: PayloadAction<Authorisation>) {
-      state.status = APIResponseStatus.InProgress;
+      state.addStatus = APIResponseStatus.InProgress;
     },
     addingAuthorisationSucceeded(state) {
-      state.status = APIResponseStatus.Success;
+      state.addStatus = APIResponseStatus.Success;
     },
-    rejectAuthorisation(state) {
-      state.status = APIResponseStatus.Error;
+    rejectAuthorisationAdd(state) {
+      state.addStatus = APIResponseStatus.Error;
     },
-    resetAuthorisation(state) {
-      state.status = initialState.status;
+    rejectAuthorisationPublishPermissionUpdate(state) {
+      state.updatePublishPermissionStatus = APIResponseStatus.Error;
+    },
+    rejectAuthorisationRemove(state) {
+      state.removeStatus = APIResponseStatus.Error;
+    },
+    removeAuthorisation(state, _action: PayloadAction<number>) {
+      state.removeStatus = APIResponseStatus.InProgress;
+    },
+    removingAuthorisationSucceeded(state) {
+      state.removeStatus = APIResponseStatus.Success;
+    },
+    resetAuthorisationState(state) {
+      state.addStatus = initialState.addStatus;
+      state.removeStatus = initialState.removeStatus;
+      state.updatePublishPermissionStatus =
+        initialState.updatePublishPermissionStatus;
+    },
+    updateAuthorisationPublishPermission(
+      state,
+      _action: PayloadAction<Authorisation>
+    ) {
+      state.updatePublishPermissionStatus = APIResponseStatus.InProgress;
+    },
+    updatingAuthorisationPublishPermissionSucceeded(state) {
+      state.updatePublishPermissionStatus = APIResponseStatus.Success;
     },
   },
 });
@@ -34,6 +62,12 @@ export const authorisationReducer = authorisationSlice.reducer;
 export const {
   addAuthorisation,
   addingAuthorisationSucceeded,
-  rejectAuthorisation,
-  resetAuthorisation,
+  rejectAuthorisationAdd,
+  rejectAuthorisationPublishPermissionUpdate,
+  rejectAuthorisationRemove,
+  removeAuthorisation,
+  removingAuthorisationSucceeded,
+  resetAuthorisationState,
+  updateAuthorisationPublishPermission,
+  updatingAuthorisationPublishPermissionSucceeded,
 } = authorisationSlice.actions;

--- a/frontend/packages/akr/src/redux/reducers/authorisation.ts
+++ b/frontend/packages/akr/src/redux/reducers/authorisation.ts
@@ -40,11 +40,15 @@ const authorisationSlice = createSlice({
     removingAuthorisationSucceeded(state) {
       state.removeStatus = APIResponseStatus.Success;
     },
-    resetAuthorisationState(state) {
+    resetAuthorisationAdd(state) {
       state.addStatus = initialState.addStatus;
-      state.removeStatus = initialState.removeStatus;
+    },
+    resetAuthorisationPublishPermissionUpdate(state) {
       state.updatePublishPermissionStatus =
         initialState.updatePublishPermissionStatus;
+    },
+    resetAuthorisationRemove(state) {
+      state.removeStatus = initialState.removeStatus;
     },
     updateAuthorisationPublishPermission(
       state,
@@ -67,7 +71,9 @@ export const {
   rejectAuthorisationRemove,
   removeAuthorisation,
   removingAuthorisationSucceeded,
-  resetAuthorisationState,
+  resetAuthorisationAdd,
+  resetAuthorisationPublishPermissionUpdate,
+  resetAuthorisationRemove,
   updateAuthorisationPublishPermission,
   updatingAuthorisationPublishPermissionSucceeded,
 } = authorisationSlice.actions;

--- a/frontend/packages/akr/src/redux/reducers/clerkTranslator.ts
+++ b/frontend/packages/akr/src/redux/reducers/clerkTranslator.ts
@@ -71,6 +71,17 @@ const clerkTranslatorSlice = createSlice({
       state.translators = action.payload.translators;
       state.langs = action.payload.langs;
     },
+    upsertClerkTranslator(state, action: PayloadAction<ClerkTranslator>) {
+      const updatedTranslators = [...state.translators];
+      const translator = action.payload;
+      const idx = updatedTranslators.findIndex(
+        (t: ClerkTranslator) => t.id === translator.id
+      );
+      const spliceIndex = idx >= 0 ? idx : updatedTranslators.length;
+
+      updatedTranslators.splice(spliceIndex, 1, translator);
+      state.translators = updatedTranslators;
+    },
   },
 });
 
@@ -85,4 +96,5 @@ export const {
   selectAllFilteredClerkTranslators,
   selectClerkTranslator,
   storeClerkTranslators,
+  upsertClerkTranslator,
 } = clerkTranslatorSlice.actions;

--- a/frontend/packages/akr/src/redux/reducers/clerkTranslatorOverview.ts
+++ b/frontend/packages/akr/src/redux/reducers/clerkTranslatorOverview.ts
@@ -34,10 +34,8 @@ const clerkTranslatorOverviewSlice = createSlice({
     resetClerkTranslatorDetailsUpdate(state) {
       state.translatorDetailsStatus = initialState.translatorDetailsStatus;
     },
-    resetClerkTranslatorOverview(state) {
-      state.overviewStatus = initialState.overviewStatus;
-      state.translatorDetailsStatus = initialState.translatorDetailsStatus;
-      state.selectedTranslator = initialState.selectedTranslator;
+    resetClerkTranslatorOverview(_state) {
+      return initialState;
     },
     setClerkTranslatorOverview(state, action: PayloadAction<ClerkTranslator>) {
       state.overviewStatus = APIResponseStatus.NotStarted;

--- a/frontend/packages/akr/src/redux/reducers/clerkTranslatorOverview.ts
+++ b/frontend/packages/akr/src/redux/reducers/clerkTranslatorOverview.ts
@@ -1,20 +1,17 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { APIResponseStatus } from 'shared/enums';
 
-import { Authorisation } from 'interfaces/authorisation';
 import { ClerkTranslator } from 'interfaces/clerkTranslator';
 
 interface ClerkTranslatorOverviewState {
   overviewStatus: APIResponseStatus;
   translatorDetailsStatus: APIResponseStatus;
-  authorisationDetailsStatus: APIResponseStatus;
   selectedTranslator?: ClerkTranslator;
 }
 
 const initialState: ClerkTranslatorOverviewState = {
   overviewStatus: APIResponseStatus.NotStarted,
   translatorDetailsStatus: APIResponseStatus.NotStarted,
-  authorisationDetailsStatus: APIResponseStatus.NotStarted,
   selectedTranslator: undefined,
 };
 
@@ -25,40 +22,29 @@ const clerkTranslatorOverviewSlice = createSlice({
     cancelClerkTranslatorDetailsUpdate(state) {
       state.translatorDetailsStatus = APIResponseStatus.Cancelled;
     },
-    removeAuthorisation(state, _action: PayloadAction<number>) {
-      state.authorisationDetailsStatus = APIResponseStatus.InProgress;
-    },
-    removingAuthorisationSucceeded(
-      state,
-      action: PayloadAction<ClerkTranslator>
-    ) {
-      state.authorisationDetailsStatus = APIResponseStatus.Success;
-      state.selectedTranslator = action.payload;
-    },
     loadClerkTranslatorOverview(state, _action: PayloadAction<number>) {
       state.overviewStatus = APIResponseStatus.InProgress;
-    },
-    rejectClerkTranslatorOverview(state) {
-      state.overviewStatus = APIResponseStatus.Error;
     },
     rejectClerkTranslatorDetailsUpdate(state) {
       state.translatorDetailsStatus = APIResponseStatus.Error;
     },
-    rejectAuthorisationPublishPermissionUpdate(state) {
-      state.authorisationDetailsStatus = APIResponseStatus.Error;
-    },
-    rejectAuthorisationRemove(state) {
-      state.authorisationDetailsStatus = APIResponseStatus.Error;
+    rejectClerkTranslatorOverview(state) {
+      state.overviewStatus = APIResponseStatus.Error;
     },
     resetClerkTranslatorDetailsUpdate(state) {
       state.translatorDetailsStatus = initialState.translatorDetailsStatus;
     },
     resetClerkTranslatorOverview(state) {
-      return state;
+      state.overviewStatus = initialState.overviewStatus;
+      state.translatorDetailsStatus = initialState.translatorDetailsStatus;
+      state.selectedTranslator = initialState.selectedTranslator;
     },
     setClerkTranslatorOverview(state, action: PayloadAction<ClerkTranslator>) {
-      state.selectedTranslator = action.payload;
       state.overviewStatus = APIResponseStatus.NotStarted;
+      state.selectedTranslator = action.payload;
+    },
+    setSelectedTranslator(state, action: PayloadAction<ClerkTranslator>) {
+      state.selectedTranslator = action.payload;
     },
     storeClerkTranslatorOverview(
       state,
@@ -72,19 +58,6 @@ const clerkTranslatorOverviewSlice = createSlice({
       _action: PayloadAction<ClerkTranslator>
     ) {
       state.translatorDetailsStatus = APIResponseStatus.InProgress;
-    },
-    updateAuthorisationPublishPermission(
-      state,
-      _action: PayloadAction<Authorisation>
-    ) {
-      state.authorisationDetailsStatus = APIResponseStatus.InProgress;
-    },
-    updatingAuthorisationPublishPermissionSucceeded(
-      state,
-      action: PayloadAction<ClerkTranslator>
-    ) {
-      state.authorisationDetailsStatus = APIResponseStatus.Success;
-      state.selectedTranslator = action.payload;
     },
     updatingClerkTranslatorDetailsSucceeded(
       state,
@@ -101,19 +74,14 @@ export const clerkTranslatorOverviewReducer =
   clerkTranslatorOverviewSlice.reducer;
 export const {
   cancelClerkTranslatorDetailsUpdate,
-  removeAuthorisation,
-  removingAuthorisationSucceeded,
   loadClerkTranslatorOverview,
-  rejectAuthorisationRemove,
-  rejectClerkTranslatorOverview,
   rejectClerkTranslatorDetailsUpdate,
-  rejectAuthorisationPublishPermissionUpdate,
+  rejectClerkTranslatorOverview,
   resetClerkTranslatorDetailsUpdate,
   resetClerkTranslatorOverview,
   setClerkTranslatorOverview,
+  setSelectedTranslator,
   storeClerkTranslatorOverview,
   updateClerkTranslatorDetails,
-  updateAuthorisationPublishPermission,
-  updatingAuthorisationPublishPermissionSucceeded,
   updatingClerkTranslatorDetailsSucceeded,
 } = clerkTranslatorOverviewSlice.actions;

--- a/frontend/packages/akr/src/redux/sagas/authorisation.ts
+++ b/frontend/packages/akr/src/redux/sagas/authorisation.ts
@@ -1,36 +1,115 @@
 import { PayloadAction } from '@reduxjs/toolkit';
-import { call, put, takeLatest } from 'redux-saga/effects';
+import { AxiosError, AxiosResponse } from 'axios';
+import { call, put, select, takeLatest } from 'redux-saga/effects';
 
 import axiosInstance from 'configs/axios';
-import { translateOutsideComponent } from 'configs/i18n';
 import { APIEndpoints } from 'enums/api';
 import { Authorisation } from 'interfaces/authorisation';
+import { ClerkTranslatorResponse } from 'interfaces/clerkTranslator';
 import { setAPIError } from 'redux/reducers/APIError';
 import {
   addAuthorisation,
   addingAuthorisationSucceeded,
-  rejectAuthorisation,
+  rejectAuthorisationAdd,
+  rejectAuthorisationPublishPermissionUpdate,
+  rejectAuthorisationRemove,
+  removeAuthorisation,
+  removingAuthorisationSucceeded,
+  updateAuthorisationPublishPermission,
+  updatingAuthorisationPublishPermissionSucceeded,
 } from 'redux/reducers/authorisation';
-import { loadClerkTranslatorOverview } from 'redux/reducers/clerkTranslatorOverview';
+import { setSelectedTranslator } from 'redux/reducers/clerkTranslatorOverview';
+import {
+  updateClerkTranslators,
+  updateClerkTranslatorsState,
+} from 'redux/sagas/clerkTranslator';
+import { clerkTranslatorsSelector } from 'redux/selectors/clerkTranslator';
+import { NotifierUtils } from 'utils/notifier';
 import { SerializationUtils } from 'utils/serialization';
 
 function* addAuthorisationSaga(action: PayloadAction<Authorisation>) {
   try {
     const { translatorId } = action.payload;
-    yield call(
+    const apiResponse: AxiosResponse<ClerkTranslatorResponse> = yield call(
       axiosInstance.post,
       `${APIEndpoints.ClerkTranslator}/${translatorId}/authorisation`,
       SerializationUtils.serializeAuthorisation(action.payload)
     );
+    const { translators } = yield select(clerkTranslatorsSelector);
+    const translator = SerializationUtils.deserializeClerkTranslator(
+      apiResponse.data
+    );
+    const updatedTranslators = updateClerkTranslators(translators, translator);
+    yield updateClerkTranslatorsState(updatedTranslators);
+
+    yield put(setSelectedTranslator(translator));
     yield put(addingAuthorisationSucceeded());
-    yield put(loadClerkTranslatorOverview(translatorId as number));
   } catch (error) {
-    const t = translateOutsideComponent();
-    yield put(setAPIError(t('akr.component.newAuthorisation.toasts.error')));
-    yield put(rejectAuthorisation());
+    const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
+    yield put(setAPIError(errorMessage));
+    yield put(rejectAuthorisationAdd());
   }
 }
 
-export function* watchAddAuthorisation() {
-  yield takeLatest(addAuthorisation.type, addAuthorisationSaga);
+function* updateAuthorisationPublishPermissionSaga(
+  action: PayloadAction<Authorisation>
+) {
+  const { id, version, permissionToPublish } = action.payload;
+  const requestBody = {
+    id,
+    version,
+    permissionToPublish,
+  };
+
+  try {
+    const apiResponse: AxiosResponse<ClerkTranslatorResponse> = yield call(
+      axiosInstance.put,
+      APIEndpoints.AuthorisationPublishPermission,
+      requestBody
+    );
+    const { translators } = yield select(clerkTranslatorsSelector);
+    const translator = SerializationUtils.deserializeClerkTranslator(
+      apiResponse.data
+    );
+    const updatedTranslators = updateClerkTranslators(translators, translator);
+    yield updateClerkTranslatorsState(updatedTranslators);
+
+    yield put(setSelectedTranslator(translator));
+    yield put(updatingAuthorisationPublishPermissionSucceeded());
+  } catch (error) {
+    const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
+    yield put(setAPIError(errorMessage));
+    yield put(rejectAuthorisationPublishPermissionUpdate());
+  }
+}
+
+function* removeAuthorisationSaga(action: PayloadAction<number>) {
+  try {
+    const apiResponse: AxiosResponse<ClerkTranslatorResponse> = yield call(
+      axiosInstance.delete,
+      `${APIEndpoints.Authorisation}/${action.payload}`
+    );
+    const { translators } = yield select(clerkTranslatorsSelector);
+    const translator = SerializationUtils.deserializeClerkTranslator(
+      apiResponse.data
+    );
+    const updatedTranslators = updateClerkTranslators(translators, translator);
+    yield updateClerkTranslatorsState(updatedTranslators);
+
+    yield put(setSelectedTranslator(translator));
+    yield put(removingAuthorisationSucceeded());
+  } catch (error) {
+    const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
+    yield put(setAPIError(errorMessage));
+    yield put(rejectAuthorisationRemove());
+  }
+}
+
+export function* watchAuthorisations() {
+  yield takeLatest(addAuthorisation, addAuthorisationSaga);
+  yield takeLatest(
+    updateAuthorisationPublishPermission,
+    updateAuthorisationPublishPermissionSaga
+  );
+  yield takeLatest(removeAuthorisation, removeAuthorisationSaga);
 }

--- a/frontend/packages/akr/src/redux/sagas/authorisation.ts
+++ b/frontend/packages/akr/src/redux/sagas/authorisation.ts
@@ -1,6 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import { AxiosError, AxiosResponse } from 'axios';
-import { call, put, select, takeLatest } from 'redux-saga/effects';
+import { call, put, takeLatest } from 'redux-saga/effects';
 
 import axiosInstance from 'configs/axios';
 import { APIEndpoints } from 'enums/api';
@@ -18,12 +18,8 @@ import {
   updateAuthorisationPublishPermission,
   updatingAuthorisationPublishPermissionSucceeded,
 } from 'redux/reducers/authorisation';
+import { upsertClerkTranslator } from 'redux/reducers/clerkTranslator';
 import { setSelectedTranslator } from 'redux/reducers/clerkTranslatorOverview';
-import {
-  updateClerkTranslators,
-  updateClerkTranslatorsState,
-} from 'redux/sagas/clerkTranslator';
-import { clerkTranslatorsSelector } from 'redux/selectors/clerkTranslator';
 import { NotifierUtils } from 'utils/notifier';
 import { SerializationUtils } from 'utils/serialization';
 
@@ -35,13 +31,10 @@ function* addAuthorisationSaga(action: PayloadAction<Authorisation>) {
       `${APIEndpoints.ClerkTranslator}/${translatorId}/authorisation`,
       SerializationUtils.serializeAuthorisation(action.payload)
     );
-    const { translators } = yield select(clerkTranslatorsSelector);
     const translator = SerializationUtils.deserializeClerkTranslator(
       apiResponse.data
     );
-    const updatedTranslators = updateClerkTranslators(translators, translator);
-    yield updateClerkTranslatorsState(updatedTranslators);
-
+    yield put(upsertClerkTranslator(translator));
     yield put(setSelectedTranslator(translator));
     yield put(addingAuthorisationSucceeded());
   } catch (error) {
@@ -67,13 +60,10 @@ function* updateAuthorisationPublishPermissionSaga(
       APIEndpoints.AuthorisationPublishPermission,
       requestBody
     );
-    const { translators } = yield select(clerkTranslatorsSelector);
     const translator = SerializationUtils.deserializeClerkTranslator(
       apiResponse.data
     );
-    const updatedTranslators = updateClerkTranslators(translators, translator);
-    yield updateClerkTranslatorsState(updatedTranslators);
-
+    yield put(upsertClerkTranslator(translator));
     yield put(setSelectedTranslator(translator));
     yield put(updatingAuthorisationPublishPermissionSucceeded());
   } catch (error) {
@@ -89,13 +79,10 @@ function* removeAuthorisationSaga(action: PayloadAction<number>) {
       axiosInstance.delete,
       `${APIEndpoints.Authorisation}/${action.payload}`
     );
-    const { translators } = yield select(clerkTranslatorsSelector);
     const translator = SerializationUtils.deserializeClerkTranslator(
       apiResponse.data
     );
-    const updatedTranslators = updateClerkTranslators(translators, translator);
-    yield updateClerkTranslatorsState(updatedTranslators);
-
+    yield put(upsertClerkTranslator(translator));
     yield put(setSelectedTranslator(translator));
     yield put(removingAuthorisationSucceeded());
   } catch (error) {

--- a/frontend/packages/akr/src/redux/sagas/clerkNewTranslator.ts
+++ b/frontend/packages/akr/src/redux/sagas/clerkNewTranslator.ts
@@ -1,4 +1,4 @@
-import { call, put, select, takeLatest } from '@redux-saga/core/effects';
+import { call, put, takeLatest } from '@redux-saga/core/effects';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { AxiosError, AxiosResponse } from 'axios';
 
@@ -12,8 +12,8 @@ import {
   saveClerkNewTranslator,
   storeClerkNewTranslator,
 } from 'redux/reducers/clerkNewTranslator';
-import { updateClerkTranslatorsState } from 'redux/sagas/clerkTranslator';
-import { clerkTranslatorsSelector } from 'redux/selectors/clerkTranslator';
+import { upsertClerkTranslator } from 'redux/reducers/clerkTranslator';
+import { setClerkTranslatorOverview } from 'redux/reducers/clerkTranslatorOverview';
 import { NotifierUtils } from 'utils/notifier';
 import { SerializationUtils } from 'utils/serialization';
 
@@ -29,11 +29,9 @@ function* saveClerkNewTranslatorSaga(
     const translator = SerializationUtils.deserializeClerkTranslator(
       apiResponse.data
     );
-    const { translators } = yield select(clerkTranslatorsSelector);
-    const updatedClerkTranslators = [...translators, translator];
-    yield updateClerkTranslatorsState(updatedClerkTranslators);
-
+    yield put(upsertClerkTranslator(translator));
     yield put(storeClerkNewTranslator(translator.id));
+    yield put(setClerkTranslatorOverview(translator));
   } catch (error) {
     const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
     yield put(setAPIError(errorMessage));

--- a/frontend/packages/akr/src/redux/sagas/clerkTranslator.ts
+++ b/frontend/packages/akr/src/redux/sagas/clerkTranslator.ts
@@ -1,10 +1,9 @@
 import { AxiosResponse } from 'axios';
-import { call, put, select, takeLatest } from 'redux-saga/effects';
+import { call, put, takeLatest } from 'redux-saga/effects';
 
 import axiosInstance from 'configs/axios';
 import { APIEndpoints } from 'enums/api';
 import { ClerkStateResponse } from 'interfaces/clerkState';
-import { ClerkTranslator } from 'interfaces/clerkTranslator';
 import {
   loadClerkTranslators,
   rejectClerkTranslators,
@@ -12,7 +11,6 @@ import {
 } from 'redux/reducers/clerkTranslator';
 import { storeExaminationDates } from 'redux/reducers/examinationDate';
 import { storeMeetingDates } from 'redux/reducers/meetingDate';
-import { clerkTranslatorsSelector } from 'redux/selectors/clerkTranslator';
 import { SerializationUtils } from 'utils/serialization';
 
 function* loadClerkTranslatorsSaga() {
@@ -30,37 +28,6 @@ function* loadClerkTranslatorsSaga() {
   } catch (error) {
     yield put(rejectClerkTranslators());
   }
-}
-
-export function updateClerkTranslators(
-  translators: Array<ClerkTranslator>,
-  translator: ClerkTranslator
-) {
-  const updatedTranslators = [...translators];
-  const translatorIdx = updatedTranslators.findIndex(
-    (t: ClerkTranslator) => t.id === translator.id
-  );
-
-  updatedTranslators.splice(translatorIdx, 1, translator);
-
-  return updatedTranslators;
-}
-
-export function* updateClerkTranslatorsState(
-  updatedTranslators: Array<ClerkTranslator>
-) {
-  const { translators, langs } = yield select(clerkTranslatorsSelector);
-
-  if (translators.length <= 0) {
-    yield put(loadClerkTranslators());
-  }
-
-  yield put(
-    storeClerkTranslators({
-      translators: updatedTranslators,
-      langs,
-    })
-  );
 }
 
 export function* watchClerkTranslators() {

--- a/frontend/packages/akr/src/redux/sagas/clerkTranslator.ts
+++ b/frontend/packages/akr/src/redux/sagas/clerkTranslator.ts
@@ -32,6 +32,20 @@ function* loadClerkTranslatorsSaga() {
   }
 }
 
+export function updateClerkTranslators(
+  translators: Array<ClerkTranslator>,
+  translator: ClerkTranslator
+) {
+  const updatedTranslators = [...translators];
+  const translatorIdx = updatedTranslators.findIndex(
+    (t: ClerkTranslator) => t.id === translator.id
+  );
+
+  updatedTranslators.splice(translatorIdx, 1, translator);
+
+  return updatedTranslators;
+}
+
 export function* updateClerkTranslatorsState(
   updatedTranslators: Array<ClerkTranslator>
 ) {

--- a/frontend/packages/akr/src/redux/sagas/clerkTranslatorOverview.ts
+++ b/frontend/packages/akr/src/redux/sagas/clerkTranslatorOverview.ts
@@ -5,7 +5,6 @@ import { call, put, select, takeLatest } from 'redux-saga/effects';
 import axiosInstance from 'configs/axios';
 import { translateOutsideComponent } from 'configs/i18n';
 import { APIEndpoints } from 'enums/api';
-import { Authorisation } from 'interfaces/authorisation';
 import {
   ClerkTranslator,
   ClerkTranslatorResponse,
@@ -13,19 +12,16 @@ import {
 import { setAPIError } from 'redux/reducers/APIError';
 import {
   loadClerkTranslatorOverview,
-  rejectAuthorisationPublishPermissionUpdate,
-  rejectAuthorisationRemove,
   rejectClerkTranslatorDetailsUpdate,
   rejectClerkTranslatorOverview,
-  removeAuthorisation,
-  removingAuthorisationSucceeded,
   storeClerkTranslatorOverview,
-  updateAuthorisationPublishPermission,
   updateClerkTranslatorDetails,
-  updatingAuthorisationPublishPermissionSucceeded,
   updatingClerkTranslatorDetailsSucceeded,
 } from 'redux/reducers/clerkTranslatorOverview';
-import { updateClerkTranslatorsState } from 'redux/sagas/clerkTranslator';
+import {
+  updateClerkTranslators,
+  updateClerkTranslatorsState,
+} from 'redux/sagas/clerkTranslator';
 import { clerkTranslatorsSelector } from 'redux/selectors/clerkTranslator';
 import { NotifierUtils } from 'utils/notifier';
 import { SerializationUtils } from 'utils/serialization';
@@ -50,20 +46,6 @@ function* loadClerkTranslatorOverviewSaga(action: PayloadAction<number>) {
   }
 }
 
-function updateClerkTranslators(
-  translators: Array<ClerkTranslator>,
-  translator: ClerkTranslator
-) {
-  const updatedTranslators = [...translators];
-  const translatorIdx = updatedTranslators.findIndex(
-    (t: ClerkTranslator) => t.id === translator.id
-  );
-
-  updatedTranslators.splice(translatorIdx, 1, translator);
-
-  return updatedTranslators;
-}
-
 function* updateTranslatorDetails(action: PayloadAction<ClerkTranslator>) {
   try {
     const apiResponse: AxiosResponse<ClerkTranslatorResponse> = yield call(
@@ -86,67 +68,10 @@ function* updateTranslatorDetails(action: PayloadAction<ClerkTranslator>) {
   }
 }
 
-function* updateAuthorisationPublishPermissionSaga(
-  action: PayloadAction<Authorisation>
-) {
-  const { id, version, permissionToPublish } = action.payload;
-  const requestBody = {
-    id,
-    version,
-    permissionToPublish,
-  };
-
-  try {
-    const apiResponse: AxiosResponse<ClerkTranslatorResponse> = yield call(
-      axiosInstance.put,
-      APIEndpoints.AuthorisationPublishPermission,
-      requestBody
-    );
-    const { translators } = yield select(clerkTranslatorsSelector);
-    const translator = SerializationUtils.deserializeClerkTranslator(
-      apiResponse.data
-    );
-    const updatedTranslators = updateClerkTranslators(translators, translator);
-    yield updateClerkTranslatorsState(updatedTranslators);
-
-    yield put(updatingAuthorisationPublishPermissionSucceeded(translator));
-  } catch (error) {
-    const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
-    yield put(setAPIError(errorMessage));
-    yield put(rejectAuthorisationPublishPermissionUpdate());
-  }
-}
-
-function* removeAuthorisationSaga(action: PayloadAction<number>) {
-  try {
-    const apiResponse: AxiosResponse<ClerkTranslatorResponse> = yield call(
-      axiosInstance.delete,
-      `${APIEndpoints.Authorisation}/${action.payload}`
-    );
-    const { translators } = yield select(clerkTranslatorsSelector);
-    const translator = SerializationUtils.deserializeClerkTranslator(
-      apiResponse.data
-    );
-    const updatedTranslators = updateClerkTranslators(translators, translator);
-    yield updateClerkTranslatorsState(updatedTranslators);
-
-    yield put(removingAuthorisationSucceeded(translator));
-  } catch (error) {
-    const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
-    yield put(setAPIError(errorMessage));
-    yield put(rejectAuthorisationRemove());
-  }
-}
-
 export function* watchClerkTranslatorOverview() {
-  yield takeLatest(updateClerkTranslatorDetails.type, updateTranslatorDetails);
   yield takeLatest(
     loadClerkTranslatorOverview.type,
     loadClerkTranslatorOverviewSaga
   );
-  yield takeLatest(
-    updateAuthorisationPublishPermission.type,
-    updateAuthorisationPublishPermissionSaga
-  );
-  yield takeLatest(removeAuthorisation.type, removeAuthorisationSaga);
+  yield takeLatest(updateClerkTranslatorDetails.type, updateTranslatorDetails);
 }

--- a/frontend/packages/akr/src/redux/sagas/index.ts
+++ b/frontend/packages/akr/src/redux/sagas/index.ts
@@ -1,6 +1,6 @@
 import { all } from 'redux-saga/effects';
 
-import { watchAddAuthorisation } from 'redux/sagas/authorisation';
+import { watchAuthorisations } from 'redux/sagas/authorisation';
 import { watchClerkNewTranslatorSave } from 'redux/sagas/clerkNewTranslator';
 import { watchClerkTranslators } from 'redux/sagas/clerkTranslator';
 import { watchClerkTranslatorEmail } from 'redux/sagas/clerkTranslatorEmail';
@@ -22,6 +22,6 @@ export default function* rootSaga() {
     watchClerkUser(),
     watchMeetingDates(),
     watchExaminationDates(),
-    watchAddAuthorisation(),
+    watchAuthorisations(),
   ]);
 }

--- a/frontend/packages/akr/src/tests/cypress/integration/clerk/translatorOverview/authorisation_details.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/clerk/translatorOverview/authorisation_details.spec.ts
@@ -8,6 +8,7 @@ import {
 } from 'tests/cypress/support/page-objects/authorisationDetails';
 import { onClerkTranslatorOverviewPage } from 'tests/cypress/support/page-objects/clerkTranslatorOverviewPage';
 import { onDialog } from 'tests/cypress/support/page-objects/dialog';
+import { onToast } from 'tests/cypress/support/page-objects/toast';
 
 const effectiveAuthorisationId = 10001;
 
@@ -82,6 +83,7 @@ describe('ClerkTranslatorOverview:AuthorisationDetails', () => {
       effectiveAuthorisationId,
       false
     );
+    onToast.expectText('Auktorisoinnin julkaisulupaa muutettu');
   });
 
   it('should open a confirmation dialog when a delete icon is clicked, and do no changes if user backs out', () => {
@@ -108,5 +110,6 @@ describe('ClerkTranslatorOverview:AuthorisationDetails', () => {
     cy.wait('@deleteAuthorisation');
 
     onAuthorisationDetails.assertRowDoesNotExist(effectiveAuthorisationId);
+    onToast.expectText('Valittu auktorisointi poistettu');
   });
 });


### PR DESCRIPTION
## Yhteenveto

Koodin refaktorointia ja lisätty ilmoitukset auktorisointien poistoista ja julkaisulupien päivittämisistä

## Lisätiedot

Koodin refaktorointia siltä osin, että auktorisointien poistoon sekä julkaisuluvan muokkaamiseen liittyvä toimintalogiikka (reducer actionit + saga funktiot) siirretty ulos `clerkTranslatorOverview`:stä `authorisation` vastaavien yhteyteen, jossa oli jo luontiin liittyvät actionit + saga. Tämän jälkeen lisätty ilmoitukset poistoihin ja julkaisuluvan muokkaukseen liittyen. Ilmoitus luonnin osalta siirretty ulos sagasta `AuthorisationDetails`:n alle muiden ilmoitusten näyttämisten kanssa.

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
- [x] Testattu docker-compose:lla
