### PR TITLE
OPHOTRKEH-116: Updated documentation about i18n-json-to-xlsx-converter usage

### DIFF
--- a/docs/akr.md
+++ b/docs/akr.md
@@ -127,16 +127,16 @@ mvn spring-boot:run -Dtomcat.util.http.parser.HttpParser.requestTargetAllow=|{}
 
 ### Frontend localizations
 
-I18next is used as an internationalization framework. Localizations are stored in JSON files and committed to git.
+I18next is used as an internationalization framework. Localizations are stored in JSON files in public/i18n directory and committed to git.
 
-For inspection and modification by OPH clerks, it's possible to create an excel sheet as shown below:
+For inspection and modification by OPH clerks, it's possible to create an excel sheet in the application directory as shown below:
 
 &nbsp;
 
 #### JSON to XLSX
 
 ```sh
-npx i18n-json-to-xlsx-converter --convert common.json, translation.json
+npx i18n-json-to-xlsx-converter --convert public/i18n/fi-FI/translation.json
 ```
 
 #### XLSX to JSON

--- a/docs/otr.md
+++ b/docs/otr.md
@@ -138,16 +138,16 @@ mvn spring-boot:run -Dtomcat.util.http.parser.HttpParser.requestTargetAllow=|{}
 
 ### Frontend localizations
 
-I18next is used as an internationalization framework. Localizations are stored in JSON files and committed to git.
+I18next is used as an internationalization framework. Localizations are stored in JSON files in public/i18n directory and committed to git.
 
-For inspection and modification by OPH clerks, it's possible to create an excel sheet as shown below:
+For inspection and modification by OPH clerks, it's possible to create an excel sheet in the application directory as shown below:
 
 &nbsp;
 
 #### JSON to XLSX
 
 ```sh
-npx i18n-json-to-xlsx-converter --convert common.json, translation.json
+npx i18n-json-to-xlsx-converter --convert public/i18n/fi-FI/translation.json
 ```
 
 #### XLSX to JSON

--- a/docs/vkt.md
+++ b/docs/vkt.md
@@ -119,16 +119,16 @@ mvn spring-boot:run -Dtomcat.util.http.parser.HttpParser.requestTargetAllow=|{}
 
 ### Frontend localizations
 
-I18next is used as an internationalization framework. Localizations are stored in JSON files and committed to git.
+I18next is used as an internationalization framework. Localizations are stored in JSON files in public/i18n directory and committed to git.
 
-For inspection and modification by OPH clerks, it's possible to create an excel sheet as shown below:
+For inspection and modification by OPH clerks, it's possible to create an excel sheet in the application directory as shown below:
 
 &nbsp;
 
 #### JSON to XLSX
 
 ```sh
-npx i18n-json-to-xlsx-converter --convert common.json, translation.json
+npx i18n-json-to-xlsx-converter --convert public/i18n/fi-FI/translation.json
 ```
 
 #### XLSX to JSON


### PR DESCRIPTION
## Yhteenveto

OTR:n käännökset päivitetty ja samalla muutettu dokumentaatiota i18n-json-to-xlsx-converter käyttöön liittyen. Ainakaan itselläni tuon käyttö `public` hakemiston sisältä ei onnistu:
```
mika.huttunen@... kieli-ja-kaantajatutkinnot % cd frontend/packages/otr/public/i18n/fi-FI
mika.huttunen@... fi-FI % npx i18n-json-to-xlsx-converter --convert common.json

Processing!
Converting JSON to XLSX for the file
common.json

Error: Error: ENOENT: no such file or directory, open 'common.json'
```

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
