### PR TITLE
SHARED: Use timeout for Cypress tests in CI

### DIFF
--- a/.github/workflows/common-frontend.yml
+++ b/.github/workflows/common-frontend.yml
@@ -66,6 +66,7 @@ jobs:
           start: yarn ${{ inputs.app-name }}:start:ci
           wait-on: ${{ inputs.cypress-base-url }}
           command: yarn ${{ inputs.app-name }}:test:cypress
+        timeout-minutes: 10
       - name: Build
         working-directory: ${{ env.FRONTEND_DIR }}
         run: yarn ${{ inputs.app-name }}:build


### PR DESCRIPTION
## Yhteenveto

Cypress testien maksimi ajoaika tulee olemaan tämän avulla 10min

