### PR TITLE
OTR(Frontend): OPHOTRKEH-127 käännösten lisäys

### DIFF
--- a/frontend/packages/otr/public/i18n/en-GB/common.json
+++ b/frontend/packages/otr/public/i18n/en-GB/common.json
@@ -1,1 +1,34 @@
-{}
+{
+  "otr": {
+    "common": {
+      "add": "Add",
+      "addQualification": null,
+      "allRegions": null,
+      "appNameAbbreviation": "OTR",
+      "back": "Back",
+      "cancel": "Cancel",
+      "clerk": "Clerk",
+      "contactEmail": "oikeustulkkirekisteri@oph.fi",
+      "delete": "Delete",
+      "edit": "Edit",
+      "examinationType": {
+        "degreeStudies": null,
+        "legalInterpreterExam": null
+      },
+      "loadingContent": "Downloading content",
+      "meetingDates": "Meeting days",
+      "navigationProtection": {
+        "description": "You will lose any changes you have made",
+        "header": "Are you sure you want to leave this page?"
+      },
+      "no": "No",
+      "ophLogo": "Logo of Finnish National Agency for Education",
+      "permissionToPublish": null,
+      "register": "Register",
+      "rowsPerPageLabel": null,
+      "save": "Save",
+      "searchResults": null,
+      "yes": "Yes"
+    }
+  }
+}

--- a/frontend/packages/otr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/otr/public/i18n/en-GB/translation.json
@@ -1,12 +1,337 @@
 {
   "otr": {
     "component": {
+      "addMeetingDate": {
+        "buttons": {
+          "add": "Add a meeting day"
+        },
+        "datePicker": {
+          "label": "Meeting date"
+        },
+        "header": "Add a meeting day",
+        "meetingDateAlreadyExists": "The day you have selected is an already existing meeting day."
+      },
+      "clerkInterpreterFilters": {
+        "examinationType": {
+          "placeholder": "All",
+          "title": "Completed qualification"
+        },
+        "languagePair": {
+          "fromPlaceholder": "Source language",
+          "title": "Search by language pair",
+          "toPlaceholder": "Target language"
+        },
+        "name": {
+          "placeholder": "Name",
+          "title": "Search by legal interpreter’s name"
+        },
+        "permissionToPublish": {
+          "placeholder": "All",
+          "title": "Permission to publish the language pair"
+        },
+        "qualificationStatus": {
+          "effective": "Valid",
+          "expired": "Expired",
+          "expiring": "Expiring"
+        }
+      },
+      "clerkInterpreterListing": {
+        "header": {
+          "name": "Name",
+          "languagePairs": "Language pairs",
+          "region": "Operating area",
+          "validFor": "Valid"
+        },
+        "row": {
+          "detailsButton": "Additional information"
+        }
+      },
+      "clerkInterpreterOverview": {
+        "interpreterDetails": {
+          "areaOfOperation": {
+            "all": "All of Finland",
+            "chooseRegion": "Select region",
+            "regions": "Regions"
+          },
+          "cancelUpdateDialog": {
+            "description": "You will lose the changes you have made.",
+            "title": "Do you want to exit the modification view?"
+          },
+          "fields": {
+            "country": "Country",
+            "email": "Email",
+            "extraInformation": "Additional information",
+            "firstName": "First name(s)",
+            "identityNumber": "Finnish personal identity code",
+            "lastName": "Last name",
+            "nickName": null,
+            "otherContactInfo": null,
+            "phoneNumber": "Telephone number",
+            "postalCode": "Postal code",
+            "street": "Street address",
+            "town": "City/town"
+          },
+          "header": {
+            "address": "Address",
+            "contactInformation": "Contact details",
+            "extraInformation": "Additional information",
+            "personalInformation": "Personal data",
+            "regions": null
+          }
+        },
+        "qualifications": {
+          "actions": {
+            "changePermissionToPublish": {
+              "ariaLabel": "Change the permission to publish",
+              "dialog": {
+                "description": "This will change the visibility of the language pair in the public register.",
+                "header": "Are you sure you want to change the permission to publish?"
+              }
+            },
+            "removal": {
+              "ariaLabel": "Delete the language pair",
+              "dialog": {
+                "description": "This action cannot be undone!",
+                "confirmButton": "Delete the language pair",
+                "header": "Are you sure you want to delete the language pair?"
+              }
+            }
+          },
+          "fields": {
+            "diaryNumber": "Case identifier",
+            "endDate": "End date",
+            "examinationType": "Education",
+            "languagePair": "Language pair",
+            "permissionToPublish": "Permission to publish",
+            "startDate": "Start date"
+          },
+          "header": "Language pairs",
+          "noQualifications": "No qualifications meeting the selected criteria were found",
+          "toasts": {
+            "addingSucceeded": null,
+            "removingSucceeded": null,
+            "updatingPublishPermissionSucceeded": null
+          },
+          "toggleFilters": {
+            "effective": "Valid",
+            "expired": "Expired"
+          }
+        },
+        "toasts": {
+          "updated": "The information was saved"
+        }
+      },
+      "footer": {
+        "accessibility": {
+          "continueToMain": "Continue to content",
+          "ophPhone": "Telephone number of the Finnish National Agency for Education",
+          "waveAriaLabel": "Wavy vector image"
+        },
+        "address": {
+          "name": "Finnish National Agency for Education",
+          "phone": {
+            "number": "+358 29 533 1000",
+            "title": "Telephone"
+          },
+          "street": "Hakaniemenranta 6",
+          "zipCity": "P.O. Box 380, 00531 Helsinki"
+        },
+        "links": {
+          "accessibility": {
+            "text": "Accessibility statement (in Finnish)"
+          },
+          "otrHomepage": {
+            "ariaLabel": "Register of legal interpreters (oph.fi), open in a new tab",
+            "link": "https://www.oph.fi/fi/palvelut/oikeustulkkirekisteri",
+            "text": "Information on the Register of Legal Interpreters (oph.fi)"
+          }
+        }
+      },
       "header": {
+        "accessibility": {
+          "continueToMain": "Continue to content",
+          "langSelectorAriaLabel": "Change the language of the user interface"
+        },
+        "clerk": {
+          "backToOph": "Back to Studyinfo",
+          "logOut": "Sign out",
+          "navLinks": {
+            "tabsLabel": "Official’s URLs"
+          }
+        },
         "lang": {
           "en": "In English",
           "fi": "Suomeksi",
-          "sv": "På Svenska"
+          "sv": "På svenska"
         }
+      },
+      "meetingDatesListing": {
+        "header": "Meeting day",
+        "removal": {
+          "ariaLabel": "Delete the meeting day",
+          "dialog": {
+            "description": null,
+            "header": "Are you sure you want to delete the meeting day?"
+          }
+        }
+      },
+      "meetingDatesToggleFilters": {
+        "passed": "Past",
+        "upcoming": "Forthcoming"
+      },
+      "newQualification": {
+        "cancelDialog": {
+          "header": "Are you sure you want to cancel?"
+        },
+        "fieldLabel": {
+          "beginDate": null,
+          "diaryNumber": "Case identifier",
+          "endDate": null,
+          "examination": null,
+          "from": "Language pair (source language)",
+          "to": "Language pair (target language)"
+        },
+        "fieldPlaceholders": {
+          "beginDate": "Start date",
+          "diaryNumber": "Case identifier",
+          "endDate": "End date",
+          "examination": null,
+          "from": "Source language",
+          "to": "Target language"
+        },
+        "switch": {
+          "permissionToPublish": "Permission to publish"
+        }
+      },
+      "publicInterpreterFilters": {
+        "name": {
+          "placeholder": "Name",
+          "title": "Search by legal interpreter’s name"
+        },
+        "buttons": {
+          "empty": "Clear",
+          "newSearch": "Conduct a new search",
+          "search": "Show results"
+        },
+        "languagePair": {
+          "fromAriaLabel": "Source language, mandatory for contacting",
+          "fromHelperText": "Select language",
+          "fromPlaceholder": "Source language",
+          "title": "Search by language pair",
+          "toAriaLabel": "Target language, mandatory for contacting",
+          "toHelperText": "Select language",
+          "toPlaceholder": "Target language"
+        },
+        "region": {
+          "placeholder": "Operating area",
+          "title": "Search by legal interpreter's operating area"
+        },
+        "toasts": {
+          "contactRequestNeedsLanguagePairs": "Select a language pair for contacting a translator",
+          "interpreterSelected": "You can select only one language pair for contacting",
+          "selectLanguagePair": "Select a language pair"
+        }
+      },
+      "publicInterpreterListing": {
+        "header": {
+          "name": "Name",
+          "languagePairs": "Language pairs",
+          "region": "Operating area"
+        },
+        "row": {
+          "additionalContactDetail": {
+            "email": "Email",
+            "otherContactInfo": "Other contact detail",
+            "phoneNumber": "Telephone number"
+          },
+          "ariaLabel": "Open additional information"
+        },
+        "searchResultsInfo": null
+      },
+      "table": {
+        "pagination": {
+          "rowsPerPage": null
+        }
+      }
+    },
+    "errors": {
+      "api": {
+        "generic": "The action failed, please try again later",
+        "interpreterInvalidNickName": null,
+        "meetingDateCreateDuplicateDate": "Failed to add the meeting day because the selected date is already a meeting day",
+        "meetingDateDeleteHasQualifications": null,
+        "meetingDateUpdateDuplicateDate": "Failed to modify the meeting day failed because the selected date is already a meeting day",
+        "meetingDateUpdateHasQualifications": null
+      },
+      "customTextField": {
+        "emailFormat": "The email address is incorrect",
+        "maxLength": "The text is too long",
+        "personalIdentityCodeFormat": "The form of the personal identity code was not recognised",
+        "required": "The information is mandatory",
+        "telFormat": "The telephone number is incorrect"
+      },
+      "loadingFailed": "Failed to download the information, please try again later."
+    },
+    "pages": {
+      "clerkHomepage": {
+        "addInterpreter": "Add a legal interpreter",
+        "buttons": {
+          "emptySelection": "Clear selections"
+        },
+        "register": "Register",
+        "title": "Register of Legal Interpreters"
+      },
+      "clerkInterpreterOverviewPage": {
+        "title": "Legal interpreter's details",
+        "toasts": {
+          "notFound": "The selected interpreter could not be found"
+        }
+      },
+      "clerkNewInterpreterPage": {
+        "addedQualificationsTitle": null,
+        "removeQualificationDialog": {
+          "title": null
+        },
+        "title": null,
+        "toasts": {
+          "success": null
+        }
+      },
+      "clerkPersonSearchPage": {
+        "buttons": {
+          "proceed": null,
+          "search": null
+        },
+        "noResult": {
+          "description": null,
+          "label": null
+        },
+        "placeholder": null,
+        "search": {
+          "description": null,
+          "label": null
+        },
+        "title": null
+      },
+      "homepage": {
+        "description": "The Finnish National Agency for Education maintains a register of legal interpreters, into which the legal interpreters approved by the Legal Interpreters’ Registration Board are entered. You can use the search engine to find an interpreter by name, language pair or operating area. The public register of legal interpreters contains only the details of those interpreters who have given the permission to publish their details online.",
+        "filters": {
+          "title": "Search for a legal interpreter"
+        },
+        "noSearchResults": "No search results",
+        "note": "Legal interpreters always have two-way qualifications, for example, Finnish <-> English, English <-> Finnish",
+        "title": "Register of Legal Interpreters"
+      },
+      "meetingDatesPage": {
+        "title": "Meeting days",
+        "toasts": {
+          "addingSucceeded": null,
+          "removingSucceeded": null
+        }
+      },
+      "notFoundPage": {
+        "description": "The address may be wrong or outdated. Click the button below to return to the home page",
+        "title": "Unfortunately, the page you are looking for was not found"
       }
     }
   }

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -12,10 +12,6 @@
         "meetingDateAlreadyExists": "Valitsemasi päivä on jo olemassaoleva kokouspäivä."
       },
       "clerkInterpreterFilters": {
-        "name": {
-          "placeholder": "Nimi",
-          "title": "Haku oikeustulkin nimellä"
-        },
         "examinationType": {
           "placeholder": "Kaikki",
           "title": "Suoritettu tutkinto"
@@ -24,6 +20,10 @@
           "fromPlaceholder": "Mistä",
           "title": "Haku kieliparilla",
           "toPlaceholder": "Mihin"
+        },
+        "name": {
+          "placeholder": "Nimi",
+          "title": "Haku oikeustulkin nimellä"
         },
         "permissionToPublish": {
           "placeholder": "Kaikki",
@@ -314,7 +314,7 @@
         "title": "Lisää oikeustulkki"
       },
       "homepage": {
-        "description": "Opetushallitus ylläpitää oikeustulkkirekisteriä, johon oikeustulkkirekisterilautakunnan hyväksymät oikeustulkit merkitään. Hakukoneella voit hakea tulkkia joko nimen, kieliparin tai toiminta-alueen mukaan. Julkinen oikeustulkkirekisteri sisältää tiedot vain niistä tulkeista, jotka ovat antaneet luvan tietojensa julkaisemiseen verkossa.",
+        "description": "Opetushallitus ylläpitää oikeustulkkirekisteriä, johon Oikeustulkkirekisterilautakunnan hyväksymät oikeustulkit merkitään. Hakukoneella voit hakea tulkkia joko nimen, kieliparin tai toiminta-alueen mukaan. Julkinen oikeustulkkirekisteri sisältää tiedot vain niistä tulkeista, jotka ovat antaneet luvan tietojensa julkaisemiseen verkossa.",
         "filters": {
           "title": "Etsi oikeustulkkia"
         },

--- a/frontend/packages/otr/public/i18n/sv-SE/common.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/common.json
@@ -1,1 +1,34 @@
-{}
+{
+  "otr": {
+    "common": {
+      "add": "Lägg till",
+      "addQualification": null,
+      "allRegions": null,
+      "appNameAbbreviation": "OTR",
+      "back": "Tillbaka",
+      "cancel": "Avbryt",
+      "clerk": null,
+      "contactEmail": "oikeustulkkirekisteri@oph.fi",
+      "delete": "Ta bort",
+      "edit": "Ändra",
+      "examinationType": {
+        "degreeStudies": null,
+        "legalInterpreterExam": null
+      },
+      "loadingContent": "Innehållet laddas ner",
+      "meetingDates": "Mötesdagar",
+      "navigationProtection": {
+        "description": "Du förlorar ändringar du gjort",
+        "header": "Är du säker på att du vill lämna den här sidan?"
+      },
+      "no": "Nej",
+      "ophLogo": "Utbildningsstyrelsens logo",
+      "permissionToPublish": null,
+      "register": "Register",
+      "rowsPerPageLabel": null,
+      "save": "Spara",
+      "searchResults": null,
+      "yes": "Ja"
+    }
+  }
+}

--- a/frontend/packages/otr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/translation.json
@@ -1,12 +1,337 @@
 {
   "otr": {
     "component": {
+      "addMeetingDate": {
+        "buttons": {
+          "add": "Lägg till mötesdag"
+        },
+        "datePicker": {
+          "label": "Datum för mötet"
+        },
+        "header": "Lägg till mötesdag",
+        "meetingDateAlreadyExists": "Dagen du valt är en redan befintlig mötesdag."
+      },
+      "clerkInterpreterFilters": {
+        "examinationType": {
+          "placeholder": "Alla",
+          "title": "Avlagd examen"
+        },
+        "languagePair": {
+          "fromPlaceholder": "Från",
+          "title": "Sök med språkpar",
+          "toPlaceholder": "Till"
+        },
+        "name": {
+          "placeholder": "Namn",
+          "title": "Sök med rättstolkens namn"
+        },
+        "permissionToPublish": {
+          "placeholder": "Alla",
+          "title": "Publiceringstillstånd för språkparet"
+        },
+        "qualificationStatus": {
+          "effective": "I kraft",
+          "expired": "Löpt ut",
+          "expiring": "Håller på att löpa ut"
+        }
+      },
+      "clerkInterpreterListing": {
+        "header": {
+          "name": "Namn",
+          "languagePairs": "Språkpar",
+          "region": "Verksamhetsområde",
+          "validFor": "I kraft"
+        },
+        "row": {
+          "detailsButton": "Ytterligare information"
+        }
+      },
+      "clerkInterpreterOverview": {
+        "interpreterDetails": {
+          "areaOfOperation": {
+            "all": "Hela Finland",
+            "chooseRegion": "Välj landskap",
+            "regions": "Landskap"
+          },
+          "cancelUpdateDialog": {
+            "description": "Du kommer att förlora dina ändringar.",
+            "title": "Vill du lämna redigeringsvyn?"
+          },
+          "fields": {
+            "country": "Land",
+            "email": "E-postadress",
+            "extraInformation": "Ytterligare information",
+            "firstName": "Förnamn",
+            "identityNumber": "Personbeteckning",
+            "lastName": "Efternamn",
+            "nickName": null,
+            "otherContactInfo": null,
+            "phoneNumber": "Telefonnummer",
+            "postalCode": "Postnummer",
+            "street": "Gatuadress",
+            "town": "Postanstalt"
+          },
+          "header": {
+            "address": "Adress",
+            "contactInformation": "Kontaktuppgifter",
+            "extraInformation": "Ytterligare information",
+            "personalInformation": "Personuppgifter",
+            "regions": null
+          }
+        },
+        "qualifications": {
+          "actions": {
+            "changePermissionToPublish": {
+              "ariaLabel": "Ändra publiceringstillstånd",
+              "dialog": {
+                "description": "Detta ändrar hur språkparet syns i det offentliga registret.",
+                "header": "Är du säker på att du vill byta publiceringstillstånd?"
+              }
+            },
+            "removal": {
+              "ariaLabel": "Ta bort språkpar",
+              "dialog": {
+                "description": "Denna funktion kan inte ångras!",
+                "confirmButton": "Ta bort språkpar",
+                "header": "Är du säker på att du vill ta bort språkparet?"
+              }
+            }
+          },
+          "fields": {
+            "diaryNumber": "Diarienummer",
+            "endDate": "Slutdatum",
+            "examinationType": "Utbildning",
+            "languagePair": "Språkpar",
+            "permissionToPublish": "Publiceringstillstånd",
+            "startDate": "Startdatum"
+          },
+          "header": "Språkpar",
+          "noQualifications": "Inga examina hittades för de valda kriterierna",
+          "toasts": {
+            "addingSucceeded": null,
+            "removingSucceeded": null,
+            "updatingPublishPermissionSucceeded": null
+          },
+          "toggleFilters": {
+            "effective": "I kraft",
+            "expired": "Löpt ut"
+          }
+        },
+        "toasts": {
+          "updated": "Uppgifterna sparades"
+        }
+      },
+      "footer": {
+        "accessibility": {
+          "continueToMain": "Fortsätt till innehållet",
+          "ophPhone": "Utbildningsstyrelsens telefonnummer",
+          "waveAriaLabel": "Vektordiagram med vågor"
+        },
+        "address": {
+          "name": "Utbildningsstyrelsen",
+          "phone": {
+            "number": "+358 29 533 1000",
+            "title": "Telefon"
+          },
+          "street": "Hagnäskajen 6",
+          "zipCity": "PB 380, 00531 Helsingfors"
+        },
+        "links": {
+          "accessibility": {
+            "text": "Tillgänglighetsdirektiv"
+          },
+          "otrHomepage": {
+            "ariaLabel": "Registret över rättstolkar (oph.fi), öppna i en ny flik",
+            "link": "https://www.oph.fi/sv/tjanster/registret-over-rattstolkar",
+            "text": "Information om Registret över rättstolkar (oph.fi)"
+          }
+        }
+      },
       "header": {
+        "accessibility": {
+          "continueToMain": "Fortsätt till innehållet",
+          "langSelectorAriaLabel": "Ändra språk i användargränssnittet"
+        },
+        "clerk": {
+          "backToOph": "Tillbaka till Studieinfo",
+          "logOut": "Logga ut",
+          "navLinks": {
+            "tabsLabel": "Tjänstemannens URL-adresser"
+          }
+        },
         "lang": {
           "en": "In English",
           "fi": "Suomeksi",
-          "sv": "På Svenska"
+          "sv": "På svenska"
         }
+      },
+      "meetingDatesListing": {
+        "header": "Mötesdag",
+        "removal": {
+          "ariaLabel": "Ta bort mötesdagen",
+          "dialog": {
+            "description": null,
+            "header": "Är du säker på att du vill ta bort mötesdagen?"
+          }
+        }
+      },
+      "meetingDatesToggleFilters": {
+        "passed": "Tidigare",
+        "upcoming": "Kommande"
+      },
+      "newQualification": {
+        "cancelDialog": {
+          "header": "Är du säker på att du vill ångra?"
+        },
+        "fieldLabel": {
+          "beginDate": null,
+          "diaryNumber": "Diarienummer",
+          "endDate": null,
+          "examination": null,
+          "from": "Språkpar (från)",
+          "to": "Språkpar (till)"
+        },
+        "fieldPlaceholders": {
+          "beginDate": "Startdatum",
+          "diaryNumber": "Diarienummer",
+          "endDate": "Slutdatum",
+          "examination": null,
+          "from": "Varifrån",
+          "to": "Vart"
+        },
+        "switch": {
+          "permissionToPublish": "Publiceringstillstånd"
+        }
+      },
+      "publicInterpreterFilters": {
+        "name": {
+          "placeholder": "Namn",
+          "title": "Sök med rättstolkens namn"
+        },
+        "buttons": {
+          "empty": "Töm",
+          "newSearch": "Gör en ny sökning",
+          "search": "Visa resultat"
+        },
+        "languagePair": {
+          "fromAriaLabel": "Från, obligatorisk för att ta kontakt",
+          "fromHelperText": "Välj språk",
+          "fromPlaceholder": "Från",
+          "title": "Sök med språkpar",
+          "toAriaLabel": "Till, obligatoriskt för att ta kontakt",
+          "toHelperText": "Välj språk",
+          "toPlaceholder": "Till"
+        },
+        "region": {
+          "placeholder": "Verksamhetsområde",
+          "title": "Sök med rättstolkens verksamhetsområde"
+        },
+        "toasts": {
+          "contactRequestNeedsLanguagePairs": "Välj språkpar för att kontakta en translator",
+          "interpreterSelected": "Du kan endast välja ett språkpar för att ta kontakt",
+          "selectLanguagePair": "Välj språkpar"
+        }
+      },
+      "publicInterpreterListing": {
+        "header": {
+          "name": "Namn",
+          "languagePairs": "Språkpar",
+          "region": "Verksamhetsområde"
+        },
+        "row": {
+          "additionalContactDetail": {
+            "email": "E-post",
+            "otherContactInfo": "Annan kontaktinformation",
+            "phoneNumber": "Telefonnummer"
+          },
+          "ariaLabel": "Öppna tilläggsuppgifterna"
+        },
+        "searchResultsInfo": null
+      },
+      "table": {
+        "pagination": {
+          "rowsPerPage": null
+        }
+      }
+    },
+    "errors": {
+      "api": {
+        "generic": "Funktionen misslyckades, försök på nytt senare",
+        "interpreterInvalidNickName": null,
+        "meetingDateCreateDuplicateDate": "Det gick inte lägga till mötesdagen eftersom det valda datumet redan är ett mötesdatum",
+        "meetingDateDeleteHasQualifications": null,
+        "meetingDateUpdateDuplicateDate": "Mötesdagen kunde inte redigeras eftersom det valda datumet redan är en mötesdag",
+        "meetingDateUpdateHasQualifications": null
+      },
+      "customTextField": {
+        "emailFormat": "E-postadressen är felaktig",
+        "maxLength": "Texten är för lång",
+        "personalIdentityCodeFormat": "Personbeteckningens form kunde inte identifieras",
+        "required": "Uppgiften är obligatorisk",
+        "telFormat": "Telefonnumret är felaktigt"
+      },
+      "loadingFailed": "Det gick inte att ladda uppgifterna, försök igen senare."
+    },
+    "pages": {
+      "clerkHomepage": {
+        "addInterpreter": "Lägg till rättstolk",
+        "buttons": {
+          "emptySelection": "Töm val"
+        },
+        "register": "Register",
+        "title": "Registret över rättstolkar"
+      },
+      "clerkInterpreterOverviewPage": {
+        "title": "Rättstolkens uppgifter",
+        "toasts": {
+          "notFound": "Tolken som valts kunde inte hittas"
+        }
+      },
+      "clerkNewInterpreterPage": {
+        "addedQualificationsTitle": null,
+        "removeQualificationDialog": {
+          "title": null
+        },
+        "title": null,
+        "toasts": {
+          "success": null
+        }
+      },
+      "clerkPersonSearchPage": {
+        "buttons": {
+          "proceed": null,
+          "search": null
+        },
+        "noResult": {
+          "description": null,
+          "label": null
+        },
+        "placeholder": null,
+        "search": {
+          "description": null,
+          "label": null
+        },
+        "title": null
+      },
+      "homepage": {
+        "description": "Utbildningsstyrelsen upprätthåller ett register över rättstolkar, där rättstolkar som har godkänts av Nämnden för registret över rättstolkar registreras. Med sökmotorn kan du söka en tolk på namn eller enligt språkpar eller verksamhetsområde. I det offentliga registret över rättstolkar finns endast uppgifter om de tolkar som har gett sitt samtycke till att deras uppgifter publiceras på webben.",
+        "filters": {
+          "title": "Sök en rättstolk"
+        },
+        "noSearchResults": "Inga sökresultat",
+        "note": "Rättstolkar har alltid behörighet i båda riktningarna, till exempel finska <-> engelska engelska <-> finska",
+        "title": "Registret över rättstolkar"
+      },
+      "meetingDatesPage": {
+        "title": "Mötesdagar",
+        "toasts": {
+          "addingSucceeded": null,
+          "removingSucceeded": null
+        }
+      },
+      "notFoundPage": {
+        "description": "Adressen kan vara fel eller föråldrad. Gå tillbaka till framsidan med knappen nedan",
+        "title": "Tyvärr kan sidan du sökte efter inte hittas"
       }
     }
   }


### PR DESCRIPTION
## Yhteenveto

Lisätty ruotsin- ja englanninkieliset käännökset Saaran ja Terhin toimittaman Excelin pohjalta.

## Lisätiedot

Suomenkielisiin käännöksiin oli tullut pääasiallisena muutoksena vain tuon _Oikeustulkkirekisterilautakunnan_ kirjoittaminen isolla. Tuon ohessa termi "Haku" oli tosin korvattu termillä "Hae" tietyissä tilanteissa. En mennyt ko. muutoksia tekemään täällä suomenkielisiin käännöksiin, mutta ruotsin- ja englanninkielisessä käännöksessä tuon "Haku"-sanan sijaan on nyt siis käännettynä terminä "Hae".  OneDriven versiossa on merkitty muutenkin keltaisella taustavärillä kaikki käännökset, jotka vaativat vielä jonkinmoista tsekkausta nuo Haku <-> Hae tilanteet mukaan lukien.

Toin myös AKR:n puolelta tänne sellaisia käännöksiä, joiden suomenkielinen vastine on identtinen täällä olevan kanssa. Nuo omina committeinaan muiden käännösten siirron jälkeen.

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
- [x] Testattu docker-compose:lla
