### PR TITLE
AKR(Frontend): Fix filtering by authorisation status

### DIFF
--- a/frontend/packages/akr/src/tests/cypress/fixtures/json/clerk_translators_100.json
+++ b/frontend/packages/akr/src/tests/cypress/fixtures/json/clerk_translators_100.json
@@ -174,6 +174,20 @@
           "examinationDate": "2022-03-07"
         },
         {
+          "id": 6666,
+          "version": 0,
+          "languagePair": {
+            "from": "SEIN",
+            "to": "CA"
+          },
+          "basis": "AUT",
+          "termBeginDate": "2020-11-01",
+          "termEndDate": "2022-01-01",
+          "permissionToPublish": true,
+          "diaryNumber": "added-by-hand-6666",
+          "examinationDate": "2020-10-04"
+        },
+        {
           "id": 7265,
           "version": 0,
           "languagePair": {


### PR DESCRIPTION
## Yhteenveto

Korjattu virkailijapuolella kääntäjien haku auktorisoinnin tilan perusteella.

## Huomautukset

Testatttu lokaalisti toimivan. Tämän lisäksi varmistettu testikattavuus muokkaamalla käsin fixturea `clerk_translators_100.json`.

Testidatan muokkaaminen käsin ei kenties ole täysin ideaali ratkaisu, koska nuo muokkaukset joudutaan erikseen huomioimaan mikäli tulee tarve generoida testidatat uudelleen esim. tietomallin muuttuessa.

Toinen vaihtoehto olisi muokata dev-kantaan alustuksen yhteydessä lisättävää dataa (SQL-skriptit) siten että löytyy 1) kääntäjiä joilla on sekä voimassaolevia että umpeutuneita auktorisointeja saman kieliparin osalta kuin myös 2) kääntäjiä joilla on vain umpeutuneita auktorisointeja. Tällöin voisi ottaa skripteillä generoida uuden dumpin dev-kannan datasta.
Tämän ratkaisun haittapuolena on kenties, että näiden SQL-skriptien tulkitseminen on jo tällä hetkellä jokseenkin työlästä.
