### PR TITLE
Feature/ophotrkeh 122 interpreter creation

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
@@ -17,7 +17,7 @@ public record ClerkInterpreterDTO(
   @NonNull @NotBlank String lastName,
   @NonNull @NotBlank String firstName,
   @NonNull @NotBlank String nickName,
-  @NonNull @NotBlank String email,
+  String email,
   @NonNull @NotNull Boolean permissionToPublishEmail,
   String phoneNumber,
   @NonNull @NotNull Boolean permissionToPublishPhone,

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
@@ -116,8 +116,7 @@ public class OnrOperationApiImpl implements OnrOperationApi {
     final Response response = onrClient.executeBlocking(request);
 
     if (response.getStatusCode() == HttpStatus.CREATED.value()) {
-      final PersonalDataDTO responseDTO = OBJECT_MAPPER.readValue(response.getResponseBody(), new TypeReference<>() {});
-      return responseDTO.getOnrId();
+      return response.getResponseBody();
     } else {
       throw new RuntimeException("ONR service returned unexpected status code: " + response.getStatusCode());
     }

--- a/backend/otr/src/main/java/fi/oph/otr/onr/model/PersonalData.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/model/PersonalData.java
@@ -28,7 +28,6 @@ public class PersonalData {
   @NonNull
   private String identityNumber;
 
-  @NonNull // FIXME email should be required when saving to ONR, optional when reading from ONR?
   private String email;
 
   private String phoneNumber;

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -295,7 +295,10 @@
         "removeQualificationDialog": {
           "title": "Haluatko varmasti poistaa rekisteröinnin?"
         },
-        "title": "Lisää oikeustulkki"
+        "title": "Lisää oikeustulkki",
+        "toasts": {
+          "success": "Tulkin tiedot tallennettiin"
+        }
       },
       "clerkPersonSearchPage": {
         "buttons": {

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -290,6 +290,9 @@
           "updated": "Tiedot tallennettiin"
         }
       },
+      "clerkNewInterpreterPage": {
+        "title": "Lisää oikeustulkki"
+      },
       "clerkPersonSearchPage": {
         "buttons": {
           "proceed": "Syötä manuaalisesti",

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -291,6 +291,10 @@
         }
       },
       "clerkNewInterpreterPage": {
+        "addedQualificationsTitle": "Lisätyt rekisteröinnit",
+        "removeQualificationDialog": {
+          "title": "Haluatko varmasti poistaa rekisteröinnin?"
+        },
         "title": "Lisää oikeustulkki"
       },
       "clerkPersonSearchPage": {

--- a/frontend/packages/otr/src/components/clerkInterpreter/new/BottomControls.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/new/BottomControls.tsx
@@ -1,0 +1,50 @@
+import { CustomButton, LoadingProgressIndicator } from 'shared/components';
+import { APIResponseStatus, Color, Variant } from 'shared/enums';
+
+import { useCommonTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
+import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
+import { saveClerkNewInterpreter } from 'redux/reducers/clerkNewInterpreter';
+
+export const BottomControls = ({
+  interpreter,
+  status,
+}: {
+  interpreter: ClerkNewInterpreter;
+  status: APIResponseStatus;
+}) => {
+  const translateCommon = useCommonTranslation();
+  const dispatch = useAppDispatch();
+  const isLoading = status === APIResponseStatus.InProgress;
+
+  const onSave = () => {
+    dispatch(saveClerkNewInterpreter(interpreter));
+  };
+
+  const isSaveButtonDisabled = () => {
+    return (
+      isLoading ||
+      !interpreter.lastName ||
+      !interpreter.firstName ||
+      !interpreter.nickName ||
+      !interpreter.email ||
+      interpreter.qualifications.length < 1
+    );
+  };
+
+  return (
+    <div className="columns gapped flex-end">
+      <LoadingProgressIndicator isLoading={isLoading}>
+        <CustomButton
+          data-testid="clerk-new-interpreter-page__save-button"
+          variant={Variant.Contained}
+          color={Color.Secondary}
+          onClick={onSave}
+          disabled={isSaveButtonDisabled()}
+        >
+          {translateCommon('save')}
+        </CustomButton>
+      </LoadingProgressIndicator>
+    </div>
+  );
+};

--- a/frontend/packages/otr/src/components/clerkInterpreter/new/ClerkNewInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/new/ClerkNewInterpreterDetails.tsx
@@ -1,0 +1,74 @@
+import { ChangeEvent, useState } from 'react';
+import { ComboBoxOption } from 'shared/interfaces';
+
+import { ClerkInterpreterDetailsFields } from 'components/clerkInterpreter/overview/ClerkInterpreterDetailsFields';
+import { useAppDispatch } from 'configs/redux';
+import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
+import { updateClerkNewInterpreter } from 'redux/reducers/clerkNewInterpreter';
+import { RegionUtils } from 'utils/region';
+
+export const ClerkNewInterpreterDetails = ({
+  interpreter,
+  isIndividualisedInterpreter,
+  onDetailsChange,
+}: {
+  interpreter: ClerkNewInterpreter;
+  isIndividualisedInterpreter?: boolean;
+  onDetailsChange: () => void;
+}) => {
+  // Local state
+  const [areaOfOperation, setAreaOfOperation] = useState(
+    RegionUtils.getAreaOfOperation(interpreter.regions)
+  );
+
+  const dispatch = useAppDispatch();
+
+  const handleDetailsChange =
+    (field: keyof ClerkNewInterpreter) =>
+    (
+      eventOrValue:
+        | ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+        | ComboBoxOption[]
+    ) => {
+      let fieldValue;
+      let updatedInterpreterDetails;
+
+      if (Array.isArray(eventOrValue)) {
+        // from Region ComboBox[]
+        updatedInterpreterDetails = {
+          ...interpreter,
+          [field]: eventOrValue.map((value) => value.value),
+        };
+      } else if (
+        'checked' in eventOrValue.target &&
+        eventOrValue.target.hasOwnProperty('checked')
+      ) {
+        // from Checkbox toggle
+        updatedInterpreterDetails = {
+          ...interpreter,
+          [field]: eventOrValue.target.checked,
+        };
+      } else {
+        // from TextField ChangeEvent
+        fieldValue = eventOrValue.target.value;
+        updatedInterpreterDetails = {
+          ...interpreter,
+          [field]: fieldValue,
+        };
+      }
+      onDetailsChange();
+      dispatch(updateClerkNewInterpreter(updatedInterpreterDetails));
+    };
+
+  return (
+    <ClerkInterpreterDetailsFields
+      interpreter={interpreter}
+      isIndividualisedInterpreter={isIndividualisedInterpreter}
+      areaOfOperation={areaOfOperation}
+      setAreaOfOperation={setAreaOfOperation}
+      onFieldChange={(field) => handleDetailsChange(field)}
+      isViewMode={false}
+      displayFieldErrorBeforeChange={false}
+    />
+  );
+};

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
@@ -166,7 +166,8 @@ export const ClerkInterpreterDetails = () => {
   const hasRequiredDetails =
     !!interpreterDetails?.firstName &&
     !!interpreterDetails.lastName &&
-    !!interpreterDetails.nickName;
+    !!interpreterDetails.nickName &&
+    !!interpreterDetails.email;
 
   return (
     <ClerkInterpreterDetailsFields

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
@@ -7,9 +7,11 @@ import { ClerkInterpreterDetailsFields } from 'components/clerkInterpreter/overv
 import { useAppTranslation, useCommonTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { UIMode } from 'enums/app';
-import { AreaOfOperation } from 'enums/clerkInterpreter';
 import { useNavigationProtection } from 'hooks/useNavigationProtection';
-import { ClerkInterpreter } from 'interfaces/clerkInterpreter';
+import {
+  ClerkInterpreter,
+  ClerkInterpreterBasicInformation,
+} from 'interfaces/clerkInterpreter';
 import {
   resetClerkInterpreterDetailsUpdate,
   updateClerkInterpreterDetails,
@@ -17,10 +19,7 @@ import {
 import { showNotifierDialog, showNotifierToast } from 'redux/reducers/notifier';
 import { clerkInterpreterOverviewSelector } from 'redux/selectors/clerkInterpreterOverview';
 import { NotifierUtils } from 'utils/notifier';
-
-const getAreaOfOperation = (regions: Array<string> = []) => {
-  return regions.length > 0 ? AreaOfOperation.Regions : AreaOfOperation.All;
-};
+import { RegionUtils } from 'utils/region';
 
 export const ClerkInterpreterDetails = () => {
   // Redux
@@ -34,12 +33,12 @@ export const ClerkInterpreterDetails = () => {
   const [hasLocalChanges, setHasLocalChanges] = useState(false);
   const [currentUIMode, setCurrentUIMode] = useState(UIMode.View);
   const [areaOfOperation, setAreaOfOperation] = useState(
-    getAreaOfOperation(interpreter?.regions)
+    RegionUtils.getAreaOfOperation(interpreter?.regions)
   );
   const isViewMode = currentUIMode !== UIMode.EditInterpreterDetails;
   const resetLocalInterpreterDetails = useCallback(() => {
     setInterpreterDetails(interpreter);
-    setAreaOfOperation(getAreaOfOperation(interpreter?.regions));
+    setAreaOfOperation(RegionUtils.getAreaOfOperation(interpreter?.regions));
   }, [interpreter]);
 
   // I18n
@@ -104,11 +103,11 @@ export const ClerkInterpreterDetails = () => {
   ]);
 
   useEffect(() => {
-    setAreaOfOperation(getAreaOfOperation(interpreter?.regions));
+    setAreaOfOperation(RegionUtils.getAreaOfOperation(interpreter?.regions));
   }, [interpreter?.regions]);
 
-  const handleInterpreterDetailsChange =
-    (field: keyof ClerkInterpreter) =>
+  const handleDetailsChange =
+    (field: keyof ClerkInterpreterBasicInformation) =>
     (
       eventOrValue:
         | ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
@@ -172,11 +171,10 @@ export const ClerkInterpreterDetails = () => {
   return (
     <ClerkInterpreterDetailsFields
       interpreter={interpreterDetails}
+      isIndividualisedInterpreter={interpreter?.isIndividualised}
       areaOfOperation={areaOfOperation}
       setAreaOfOperation={setAreaOfOperation}
-      onFieldChange={(field: keyof ClerkInterpreter) =>
-        handleInterpreterDetailsChange(field)
-      }
+      onFieldChange={(field) => handleDetailsChange(field)}
       isViewMode={isViewMode}
       topControlButtons={
         <ControlButtons

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetailsFields.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetailsFields.tsx
@@ -26,12 +26,15 @@ import {
   AreaOfOperation,
   ClerkInterpreterTextFieldEnum,
 } from 'enums/clerkInterpreter';
-import { ClerkInterpreter } from 'interfaces/clerkInterpreter';
+import {
+  ClerkInterpreterBasicInformation,
+  ClerkInterpreterTextFields,
+} from 'interfaces/clerkInterpreter';
 import koodistoRegionsFI from 'public/i18n/koodisto/regions/koodisto_regions_fi-FI.json';
 import { RegionUtils } from 'utils/regions';
 
 type ClerkInterpreterTextFieldProps = {
-  interpreter?: ClerkInterpreter;
+  interpreter?: ClerkInterpreterTextFields;
   field: ClerkInterpreterTextFieldEnum;
   displayError: boolean;
   onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
@@ -53,7 +56,7 @@ const getTextFieldType = (field: ClerkInterpreterTextFieldEnum) => {
 };
 
 const getFieldError = (
-  interpreter: ClerkInterpreter | undefined,
+  interpreter: ClerkInterpreterTextFields | undefined,
   field: ClerkInterpreterTextFieldEnum
 ) => {
   const t = translateOutsideComponent();
@@ -189,6 +192,7 @@ const ClerkInterpreterDetailsRegions = ({
 
 export const ClerkInterpreterDetailsFields = ({
   interpreter,
+  isIndividualisedInterpreter,
   areaOfOperation,
   setAreaOfOperation,
   onFieldChange,
@@ -196,9 +200,10 @@ export const ClerkInterpreterDetailsFields = ({
   topControlButtons,
   displayFieldErrorBeforeChange,
 }: {
-  interpreter: ClerkInterpreter | undefined;
+  interpreter: ClerkInterpreterBasicInformation | undefined;
+  isIndividualisedInterpreter?: boolean;
   onFieldChange: (
-    field: keyof ClerkInterpreter
+    field: keyof ClerkInterpreterBasicInformation
   ) => (
     eventOrValue:
       | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -235,7 +240,7 @@ export const ClerkInterpreterDetailsFields = ({
     }
 
     return (
-      interpreter?.isIndividualised &&
+      isIndividualisedInterpreter &&
       [
         ClerkInterpreterTextFieldEnum.LastName,
         ClerkInterpreterTextFieldEnum.FirstName,

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetailsFields.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetailsFields.tsx
@@ -67,6 +67,7 @@ const getFieldError = (
     ClerkInterpreterTextFieldEnum.FirstName,
     ClerkInterpreterTextFieldEnum.NickName,
     ClerkInterpreterTextFieldEnum.IdentityNumber,
+    ClerkInterpreterTextFieldEnum.Email,
   ].includes(field);
 
   const error = InputFieldUtils.inspectCustomTextFieldErrors(

--- a/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
@@ -19,16 +19,21 @@ export interface ClerkInterpreterTextFields {
   country?: string;
   extraInformation?: string;
 }
-export interface ClerkInterpreter
-  extends WithId,
-    WithVersion,
-    ClerkInterpreterTextFields {
-  deleted: boolean;
-  isIndividualised: boolean;
+
+export interface ClerkInterpreterBasicInformation
+  extends ClerkInterpreterTextFields {
   permissionToPublishEmail: boolean;
   permissionToPublishPhone: boolean;
   permissionToPublishOtherContactInfo: boolean;
   regions: Array<string>;
+}
+
+export interface ClerkInterpreter
+  extends WithId,
+    WithVersion,
+    ClerkInterpreterBasicInformation {
+  deleted: boolean;
+  isIndividualised: boolean;
   qualifications: Array<Qualification>;
 }
 

--- a/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
@@ -9,8 +9,8 @@ export interface ClerkInterpreterTextFields {
   lastName: string;
   firstName: string;
   nickName: string;
-  email: string;
   // Optional fields
+  email?: string;
   phoneNumber?: string;
   otherContactInfo?: string;
   street?: string;

--- a/frontend/packages/otr/src/interfaces/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkNewInterpreter.ts
@@ -1,0 +1,10 @@
+import { ClerkInterpreter } from 'interfaces/clerkInterpreter';
+
+export interface ClerkNewInterpreter
+  extends Omit<
+    ClerkInterpreter,
+    'id' | 'version' | 'deleted' | 'isIndividualised'
+  > {
+  onrId?: string;
+  isIndividualised?: boolean;
+}

--- a/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
@@ -1,0 +1,59 @@
+import { Box, Paper } from '@mui/material';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import { H1 } from 'shared/components';
+import { APIResponseStatus } from 'shared/enums';
+
+import { TopControls } from 'components/clerkInterpreter/overview/TopControls';
+import { useAppTranslation } from 'configs/i18n';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { AppRoutes } from 'enums/app';
+import { loadMeetingDates } from 'redux/reducers/meetingDate';
+import { clerkPersonSearchSelector } from 'redux/selectors/clerkPersonSearch';
+import { meetingDatesSelector } from 'redux/selectors/meetingDate';
+
+export const ClerkNewInterpreterPage = () => {
+  // i18n
+  const { t } = useAppTranslation({
+    keyPrefix: 'otr.pages.clerkNewInterpreterPage',
+  });
+
+  const navigate = useNavigate();
+
+  // Redux
+  const { identityNumber, person: _person } = useAppSelector(
+    clerkPersonSearchSelector
+  );
+  const meetingDatesState = useAppSelector(meetingDatesSelector).meetingDates;
+
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (!identityNumber) {
+      navigate(AppRoutes.ClerkHomePage);
+    }
+  }, [identityNumber, navigate]);
+
+  useEffect(() => {
+    if (
+      !meetingDatesState.meetingDates.length &&
+      meetingDatesState.status === APIResponseStatus.NotStarted
+    ) {
+      dispatch(loadMeetingDates());
+    }
+  }, [dispatch, meetingDatesState]);
+
+  return (
+    <Box className="clerk-new-interpreter-page">
+      <H1>{t('title')}</H1>
+      <Paper
+        elevation={3}
+        className="clerk-new-interpreter-page__content-container rows"
+      >
+        <div className="rows gapped">
+          <TopControls />
+        </div>
+      </Paper>
+    </Box>
+  );
+};

--- a/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
@@ -1,5 +1,5 @@
 import { Box, Paper } from '@mui/material';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { H1 } from 'shared/components';
 import { APIResponseStatus } from 'shared/enums';
@@ -8,11 +8,15 @@ import { TopControls } from 'components/clerkInterpreter/overview/TopControls';
 import { useAppTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
+import { useNavigationProtection } from 'hooks/useNavigationProtection';
 import { loadMeetingDates } from 'redux/reducers/meetingDate';
+import { clerkNewInterpreterSelector } from 'redux/selectors/clerkNewInterpreter';
 import { clerkPersonSearchSelector } from 'redux/selectors/clerkPersonSearch';
 import { meetingDatesSelector } from 'redux/selectors/meetingDate';
 
 export const ClerkNewInterpreterPage = () => {
+  const [hasLocalChanges, _setHasLocalChanges] = useState(false);
+
   // i18n
   const { t } = useAppTranslation({
     keyPrefix: 'otr.pages.clerkNewInterpreterPage',
@@ -21,12 +25,21 @@ export const ClerkNewInterpreterPage = () => {
   const navigate = useNavigate();
 
   // Redux
+  const {
+    interpreter: _interpreter,
+    status,
+    id: _id,
+  } = useAppSelector(clerkNewInterpreterSelector);
   const { identityNumber, person: _person } = useAppSelector(
     clerkPersonSearchSelector
   );
   const meetingDatesState = useAppSelector(meetingDatesSelector).meetingDates;
 
   const dispatch = useAppDispatch();
+
+  useNavigationProtection(
+    hasLocalChanges && status !== APIResponseStatus.Success
+  );
 
   useEffect(() => {
     if (!identityNumber) {

--- a/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
@@ -1,27 +1,45 @@
+import { Add as AddIcon } from '@mui/icons-material';
 import { Box, Paper } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { H1 } from 'shared/components';
-import { APIResponseStatus } from 'shared/enums';
+import { CustomButton, CustomModal, H1, H2 } from 'shared/components';
+import { APIResponseStatus, Color, Severity, Variant } from 'shared/enums';
 
+import { AddQualification } from 'components/clerkInterpreter/add/AddQualification';
 import { ClerkNewInterpreterDetails } from 'components/clerkInterpreter/new/ClerkNewInterpreterDetails';
+import { QualificationListing } from 'components/clerkInterpreter/overview/QualificationListing';
 import { TopControls } from 'components/clerkInterpreter/overview/TopControls';
-import { useAppTranslation } from 'configs/i18n';
+import { useAppTranslation, useCommonTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
 import { useNavigationProtection } from 'hooks/useNavigationProtection';
+import { Qualification } from 'interfaces/qualification';
+import {
+  initialiseClerkNewInterpreterByIdentityNumber,
+  initialiseClerkNewInterpreterByPerson,
+  updateClerkNewInterpreter,
+} from 'redux/reducers/clerkNewInterpreter';
 import { loadMeetingDates } from 'redux/reducers/meetingDate';
+import { showNotifierDialog } from 'redux/reducers/notifier';
 import { clerkNewInterpreterSelector } from 'redux/selectors/clerkNewInterpreter';
 import { clerkPersonSearchSelector } from 'redux/selectors/clerkPersonSearch';
-import { meetingDatesSelector } from 'redux/selectors/meetingDate';
+import {
+  meetingDatesSelector,
+  selectMeetingDatesByMeetingStatus,
+} from 'redux/selectors/meetingDate';
+import { NotifierUtils } from 'utils/notifier';
 
 export const ClerkNewInterpreterPage = () => {
+  const [open, setOpen] = useState(false);
+  const handleOpenModal = () => setOpen(true);
+  const handleCloseModal = () => setOpen(false);
   const [hasLocalChanges, setHasLocalChanges] = useState(false);
 
   // i18n
   const { t } = useAppTranslation({
     keyPrefix: 'otr.pages.clerkNewInterpreterPage',
   });
+  const translateCommon = useCommonTranslation();
 
   const navigate = useNavigate();
 
@@ -31,20 +49,30 @@ export const ClerkNewInterpreterPage = () => {
     status,
     id: _id,
   } = useAppSelector(clerkNewInterpreterSelector);
-  const { identityNumber, person } = useAppSelector(clerkPersonSearchSelector);
-  const meetingDatesState = useAppSelector(meetingDatesSelector).meetingDates;
 
-  const dispatch = useAppDispatch();
+  const { identityNumber, person } = useAppSelector(clerkPersonSearchSelector);
+
+  const meetingDatesState = useAppSelector(meetingDatesSelector).meetingDates;
+  const passedMeetingDates = useAppSelector(
+    selectMeetingDatesByMeetingStatus
+  ).passed;
 
   useNavigationProtection(
     hasLocalChanges && status !== APIResponseStatus.Success
   );
 
+  const dispatch = useAppDispatch();
+
+  // Initialise interpreter by clerkPersonSearch
   useEffect(() => {
-    if (!identityNumber) {
+    if (person) {
+      dispatch(initialiseClerkNewInterpreterByPerson(person));
+    } else if (identityNumber) {
+      dispatch(initialiseClerkNewInterpreterByIdentityNumber(identityNumber));
+    } else {
       navigate(AppRoutes.ClerkHomePage);
     }
-  }, [identityNumber, navigate]);
+  }, [dispatch, person, identityNumber, navigate]);
 
   useEffect(() => {
     if (
@@ -54,6 +82,48 @@ export const ClerkNewInterpreterPage = () => {
       dispatch(loadMeetingDates());
     }
   }, [dispatch, meetingDatesState]);
+
+  const onQualificationAdd = (qualification: Qualification) => {
+    setHasLocalChanges(true);
+    dispatch(
+      updateClerkNewInterpreter({
+        ...interpreter,
+        qualifications: [...interpreter.qualifications, qualification],
+      })
+    );
+  };
+
+  const onQualificationRemove = (qualification: Qualification) => {
+    const notifier = NotifierUtils.createNotifierDialog(
+      t('removeQualificationDialog.title'),
+      Severity.Info,
+      '',
+      [
+        {
+          title: translateCommon('no'),
+          variant: Variant.Outlined,
+          action: () => undefined,
+        },
+        {
+          dataTestId:
+            'clerk-new-interpreter-page__dialog-confirm-remove-button',
+          title: translateCommon('yes'),
+          variant: Variant.Contained,
+          action: () =>
+            dispatch(
+              updateClerkNewInterpreter({
+                ...interpreter,
+                qualifications: interpreter.qualifications.filter((q) => {
+                  return q.tempId !== qualification.tempId;
+                }),
+              })
+            ),
+        },
+      ]
+    );
+
+    dispatch(showNotifierDialog(notifier));
+  };
 
   return (
     <Box className="clerk-new-interpreter-page">
@@ -69,6 +139,38 @@ export const ClerkNewInterpreterPage = () => {
             isIndividualisedInterpreter={person?.isIndividualised}
             onDetailsChange={() => setHasLocalChanges(true)}
           />
+          <CustomModal
+            data-testid="qualification-details__add-qualification-modal"
+            open={open}
+            onCloseModal={handleCloseModal}
+            ariaLabelledBy="modal-title"
+            modalTitle={translateCommon('addQualification')}
+          >
+            <AddQualification
+              meetingDates={passedMeetingDates}
+              onQualificationAdd={onQualificationAdd}
+              onCancel={handleCloseModal}
+            />
+          </CustomModal>
+          <div className="columns margin-top-sm space-between">
+            <H2>{t('addedQualificationsTitle')}</H2>
+            <CustomButton
+              data-testid="clerk-new-interpreter-page__add-qualification-button"
+              variant={Variant.Contained}
+              color={Color.Secondary}
+              startIcon={<AddIcon />}
+              onClick={handleOpenModal}
+            >
+              {translateCommon('addQualification')}
+            </CustomButton>
+          </div>
+          {interpreter.qualifications.length ? (
+            <QualificationListing
+              qualifications={interpreter.qualifications}
+              permissionToPublishReadOnly={true}
+              handleRemoveQualification={onQualificationRemove}
+            />
+          ) : null}
         </div>
       </Paper>
     </Box>

--- a/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router';
 import { H1 } from 'shared/components';
 import { APIResponseStatus } from 'shared/enums';
 
+import { ClerkNewInterpreterDetails } from 'components/clerkInterpreter/new/ClerkNewInterpreterDetails';
 import { TopControls } from 'components/clerkInterpreter/overview/TopControls';
 import { useAppTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
@@ -15,7 +16,7 @@ import { clerkPersonSearchSelector } from 'redux/selectors/clerkPersonSearch';
 import { meetingDatesSelector } from 'redux/selectors/meetingDate';
 
 export const ClerkNewInterpreterPage = () => {
-  const [hasLocalChanges, _setHasLocalChanges] = useState(false);
+  const [hasLocalChanges, setHasLocalChanges] = useState(false);
 
   // i18n
   const { t } = useAppTranslation({
@@ -26,13 +27,11 @@ export const ClerkNewInterpreterPage = () => {
 
   // Redux
   const {
-    interpreter: _interpreter,
+    interpreter,
     status,
     id: _id,
   } = useAppSelector(clerkNewInterpreterSelector);
-  const { identityNumber, person: _person } = useAppSelector(
-    clerkPersonSearchSelector
-  );
+  const { identityNumber, person } = useAppSelector(clerkPersonSearchSelector);
   const meetingDatesState = useAppSelector(meetingDatesSelector).meetingDates;
 
   const dispatch = useAppDispatch();
@@ -65,6 +64,11 @@ export const ClerkNewInterpreterPage = () => {
       >
         <div className="rows gapped">
           <TopControls />
+          <ClerkNewInterpreterDetails
+            interpreter={interpreter}
+            isIndividualisedInterpreter={person?.isIndividualised}
+            onDetailsChange={() => setHasLocalChanges(true)}
+          />
         </div>
       </Paper>
     </Box>

--- a/frontend/packages/otr/src/redux/reducers/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkNewInterpreter.ts
@@ -1,0 +1,76 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { APIResponseStatus } from 'shared/enums';
+import { WithId } from 'shared/interfaces';
+
+import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
+
+interface ClerkNewInterpreterState extends Partial<WithId> {
+  status: APIResponseStatus;
+  interpreter: ClerkNewInterpreter;
+}
+
+const initialState: ClerkNewInterpreterState = {
+  interpreter: {
+    onrId: undefined,
+    isIndividualised: undefined,
+    identityNumber: '',
+    lastName: '',
+    firstName: '',
+    nickName: '',
+    email: '',
+    phoneNumber: '',
+    otherContactInfo: '',
+    street: '',
+    postalCode: '',
+    town: '',
+    country: '',
+    extraInformation: '',
+    permissionToPublishEmail: false,
+    permissionToPublishPhone: false,
+    permissionToPublishOtherContactInfo: false,
+    regions: [],
+    qualifications: [],
+  },
+  status: APIResponseStatus.NotStarted,
+  id: undefined,
+};
+
+const clerkNewInterpreterSlice = createSlice({
+  name: 'clerkNewInterpreter',
+  initialState,
+  reducers: {
+    rejectClerkNewInterpreter(state) {
+      state.status = APIResponseStatus.Error;
+    },
+    resetClerkNewInterpreter(state) {
+      state.interpreter = initialState.interpreter;
+      state.status = initialState.status;
+      state.id = initialState.id;
+    },
+    saveClerkNewInterpreter(
+      state,
+      _action: PayloadAction<ClerkNewInterpreter>
+    ) {
+      state.status = APIResponseStatus.InProgress;
+    },
+    storeClerkNewInterpreter(state, action: PayloadAction<number>) {
+      state.status = APIResponseStatus.Success;
+      state.id = action.payload;
+    },
+    updateClerkNewInterpreter(
+      state,
+      action: PayloadAction<ClerkNewInterpreter>
+    ) {
+      state.interpreter = action.payload;
+    },
+  },
+});
+
+export const clerkNewInterpreterReducer = clerkNewInterpreterSlice.reducer;
+export const {
+  rejectClerkNewInterpreter,
+  resetClerkNewInterpreter,
+  saveClerkNewInterpreter,
+  storeClerkNewInterpreter,
+  updateClerkNewInterpreter,
+} = clerkNewInterpreterSlice.actions;

--- a/frontend/packages/otr/src/redux/reducers/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkNewInterpreter.ts
@@ -45,7 +45,6 @@ const clerkNewInterpreterSlice = createSlice({
       action: PayloadAction<string>
     ) {
       state.interpreter.identityNumber = action.payload;
-      state.interpreter.isIndividualised = false;
     },
     initialiseClerkNewInterpreterByPerson(
       state,

--- a/frontend/packages/otr/src/redux/reducers/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkNewInterpreter.ts
@@ -3,6 +3,7 @@ import { APIResponseStatus } from 'shared/enums';
 import { WithId } from 'shared/interfaces';
 
 import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
+import { ClerkPerson } from 'interfaces/clerkPerson';
 
 interface ClerkNewInterpreterState extends Partial<WithId> {
   status: APIResponseStatus;
@@ -39,6 +40,30 @@ const clerkNewInterpreterSlice = createSlice({
   name: 'clerkNewInterpreter',
   initialState,
   reducers: {
+    initialiseClerkNewInterpreterByIdentityNumber(
+      state,
+      action: PayloadAction<string>
+    ) {
+      state.interpreter.identityNumber = action.payload;
+      state.interpreter.isIndividualised = false;
+    },
+    initialiseClerkNewInterpreterByPerson(
+      state,
+      action: PayloadAction<ClerkPerson>
+    ) {
+      const person = action.payload;
+
+      state.interpreter.onrId = person.onrId;
+      state.interpreter.isIndividualised = person.isIndividualised;
+      state.interpreter.identityNumber = person.identityNumber;
+      state.interpreter.lastName = person.lastName;
+      state.interpreter.firstName = person.firstName;
+      state.interpreter.nickName = person.nickName;
+      state.interpreter.street = person.street;
+      state.interpreter.postalCode = person.postalCode;
+      state.interpreter.town = person.town;
+      state.interpreter.country = person.country;
+    },
     rejectClerkNewInterpreter(state) {
       state.status = APIResponseStatus.Error;
     },
@@ -68,6 +93,8 @@ const clerkNewInterpreterSlice = createSlice({
 
 export const clerkNewInterpreterReducer = clerkNewInterpreterSlice.reducer;
 export const {
+  initialiseClerkNewInterpreterByIdentityNumber,
+  initialiseClerkNewInterpreterByPerson,
   rejectClerkNewInterpreter,
   resetClerkNewInterpreter,
   saveClerkNewInterpreter,

--- a/frontend/packages/otr/src/redux/sagas/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/redux/sagas/clerkInterpreter.ts
@@ -1,14 +1,18 @@
 import { AxiosResponse } from 'axios';
-import { call, put, takeLatest } from 'redux-saga/effects';
+import { call, put, select, takeLatest } from 'redux-saga/effects';
 
 import axiosInstance from 'configs/axios';
 import { APIEndpoints } from 'enums/api';
-import { ClerkInterpreterResponse } from 'interfaces/clerkInterpreter';
+import {
+  ClerkInterpreter,
+  ClerkInterpreterResponse,
+} from 'interfaces/clerkInterpreter';
 import {
   loadClerkInterpreters,
   rejectClerkInterpreters,
   storeClerkInterpreters,
 } from 'redux/reducers/clerkInterpreter';
+import { clerkInterpretersSelector } from 'redux/selectors/clerkInterpreter';
 import { SerializationUtils } from 'utils/serialization';
 
 function* loadClerkInterpretersSaga() {
@@ -24,6 +28,18 @@ function* loadClerkInterpretersSaga() {
   } catch (error) {
     yield put(rejectClerkInterpreters());
   }
+}
+
+// TODO: use in interpreter update, and in all qualification operations
+export function* updateClerkInterpretersState(
+  updatedInterpreters: Array<ClerkInterpreter>
+) {
+  const { interpreters } = yield select(clerkInterpretersSelector);
+
+  if (interpreters.length <= 0) {
+    yield put(loadClerkInterpreters());
+  }
+  yield put(storeClerkInterpreters(updatedInterpreters));
 }
 
 export function* watchClerkInterpreters() {

--- a/frontend/packages/otr/src/redux/sagas/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/redux/sagas/clerkNewInterpreter.ts
@@ -1,0 +1,49 @@
+import { call, put, select, takeLatest } from '@redux-saga/core/effects';
+import { PayloadAction } from '@reduxjs/toolkit';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import axiosInstance from 'configs/axios';
+import { APIEndpoints } from 'enums/api';
+import { ClerkInterpreterResponse } from 'interfaces/clerkInterpreter';
+import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
+import {
+  rejectClerkNewInterpreter,
+  saveClerkNewInterpreter,
+  storeClerkNewInterpreter,
+} from 'redux/reducers/clerkNewInterpreter';
+import { showNotifierToast } from 'redux/reducers/notifier';
+import { updateClerkInterpretersState } from 'redux/sagas/clerkInterpreter';
+import { clerkInterpretersSelector } from 'redux/selectors/clerkInterpreter';
+import { NotifierUtils } from 'utils/notifier';
+import { SerializationUtils } from 'utils/serialization';
+
+function* saveClerkNewInterpreterSaga(
+  action: PayloadAction<ClerkNewInterpreter>
+) {
+  try {
+    const apiResponse: AxiosResponse<ClerkInterpreterResponse> = yield call(
+      axiosInstance.post,
+      APIEndpoints.ClerkInterpreter,
+      SerializationUtils.serializeClerkNewInterpreter(action.payload)
+    );
+    const interpreter = SerializationUtils.deserializeClerkInterpreter(
+      apiResponse.data
+    );
+    const { interpreters } = yield select(clerkInterpretersSelector);
+    const updatedClerkInterpreters = [...interpreters, interpreter];
+    yield updateClerkInterpretersState(updatedClerkInterpreters);
+
+    yield put(storeClerkNewInterpreter(interpreter.id));
+  } catch (error) {
+    yield put(rejectClerkNewInterpreter());
+    yield put(
+      showNotifierToast(
+        NotifierUtils.createAxiosErrorNotifierToast(error as AxiosError)
+      )
+    );
+  }
+}
+
+export function* watchClerkNewInterpreterSave() {
+  yield takeLatest(saveClerkNewInterpreter, saveClerkNewInterpreterSaga);
+}

--- a/frontend/packages/otr/src/redux/sagas/index.ts
+++ b/frontend/packages/otr/src/redux/sagas/index.ts
@@ -2,6 +2,7 @@ import { all } from 'redux-saga/effects';
 
 import { watchClerkInterpreters } from 'redux/sagas/clerkInterpreter';
 import { watchClerkInterpreterOverview } from 'redux/sagas/clerkInterpreterOverview';
+import { watchClerkNewInterpreterSave } from 'redux/sagas/clerkNewInterpreter';
 import { watchClerkPersonSearch } from 'redux/sagas/clerkPersonSearch';
 import { watchClerkUser } from 'redux/sagas/clerkUser';
 import { watchMeetingDates } from 'redux/sagas/meetingDate';
@@ -13,6 +14,7 @@ export default function* rootSaga() {
     watchPublicInterpreters(),
     watchClerkInterpreters(),
     watchClerkInterpreterOverview(),
+    watchClerkNewInterpreterSave(),
     watchClerkPersonSearch(),
     watchClerkUser(),
     watchQualificationUpdates(),

--- a/frontend/packages/otr/src/redux/selectors/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/redux/selectors/clerkNewInterpreter.ts
@@ -1,0 +1,4 @@
+import { RootState } from 'configs/redux';
+
+export const clerkNewInterpreterSelector = (state: RootState) =>
+  state.clerkNewInterpreter;

--- a/frontend/packages/otr/src/redux/store/index.ts
+++ b/frontend/packages/otr/src/redux/store/index.ts
@@ -3,6 +3,7 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import { clerkInterpreterReducer } from 'redux/reducers/clerkInterpreter';
 import { clerkInterpreterOverviewReducer } from 'redux/reducers/clerkInterpreterOverview';
+import { clerkNewInterpreterReducer } from 'redux/reducers/clerkNewInterpreter';
 import { clerkPersonSearchReducer } from 'redux/reducers/clerkPersonSearch';
 import { clerkUserReducer } from 'redux/reducers/clerkUser';
 import { meetingDateReducer } from 'redux/reducers/meetingDate';
@@ -17,6 +18,7 @@ const store = configureStore({
   reducer: {
     clerkInterpreter: clerkInterpreterReducer,
     clerkInterpreterOverview: clerkInterpreterOverviewReducer,
+    clerkNewInterpreter: clerkNewInterpreterReducer,
     clerkPersonSearch: clerkPersonSearchReducer,
     publicInterpreter: publicInterpreterReducer,
     clerkUser: clerkUserReducer,

--- a/frontend/packages/otr/src/routers/AppRouter.tsx
+++ b/frontend/packages/otr/src/routers/AppRouter.tsx
@@ -7,6 +7,7 @@ import { Notifier } from 'components/notification/Notifier';
 import { AppRoutes } from 'enums/app';
 import { ClerkHomePage } from 'pages/ClerkHomePage';
 import { ClerkInterpreterOverviewPage } from 'pages/ClerkInterpreterOverviewPage';
+import { ClerkNewInterpreterPage } from 'pages/ClerkNewInterpreterPage';
 import { ClerkPersonSearchPage } from 'pages/ClerkPersonSearchPage';
 import { MeetingDatesPage } from 'pages/MeetingDatesPage';
 import { PublicHomePage } from 'pages/PublicHomePage';
@@ -39,6 +40,10 @@ export const AppRouter: FC = () => {
               <Route
                 path={AppRoutes.ClerkPersonSearchPage}
                 element={<ClerkPersonSearchPage />}
+              />
+              <Route
+                path={AppRoutes.ClerkNewInterpreterPage}
+                element={<ClerkNewInterpreterPage />}
               />
             </Routes>
           </div>

--- a/frontend/packages/otr/src/styles/pages/_clerk-new-interpreter-page.scss
+++ b/frontend/packages/otr/src/styles/pages/_clerk-new-interpreter-page.scss
@@ -4,4 +4,8 @@
   & &__content-container {
     padding: 3rem;
   }
+
+  .regions {
+    flex: 1;
+  }
 }

--- a/frontend/packages/otr/src/styles/pages/_clerk-new-interpreter-page.scss
+++ b/frontend/packages/otr/src/styles/pages/_clerk-new-interpreter-page.scss
@@ -1,0 +1,7 @@
+.clerk-new-interpreter-page {
+  flex: 1;
+
+  & &__content-container {
+    padding: 3rem;
+  }
+}

--- a/frontend/packages/otr/src/styles/styles.scss
+++ b/frontend/packages/otr/src/styles/styles.scss
@@ -15,6 +15,7 @@
 // Pages
 @import 'pages/clerk-homepage';
 @import 'pages/clerk-interpreter-overview-page';
+@import 'pages/clerk-new-interpreter-page';
 @import 'pages/clerk-person-search-page';
 @import 'pages/meeting-dates-page';
 @import 'pages/public-homepage';

--- a/frontend/packages/otr/src/utils/region.ts
+++ b/frontend/packages/otr/src/utils/region.ts
@@ -1,0 +1,7 @@
+import { AreaOfOperation } from 'enums/clerkInterpreter';
+
+export class RegionUtils {
+  static getAreaOfOperation = (regions: Array<string> = []) => {
+    return regions.length > 0 ? AreaOfOperation.Regions : AreaOfOperation.All;
+  };
+}

--- a/frontend/packages/otr/src/utils/serialization.ts
+++ b/frontend/packages/otr/src/utils/serialization.ts
@@ -6,6 +6,7 @@ import {
   ClerkInterpreterResponse,
   ClerkInterpreterTextFields,
 } from 'interfaces/clerkInterpreter';
+import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
 import { MeetingDateResponse } from 'interfaces/meetingDate';
 import { Qualification, QualificationResponse } from 'interfaces/qualification';
 
@@ -18,6 +19,34 @@ export class SerializationUtils {
     );
 
     return { ...response, qualifications };
+  }
+
+  static serializeClerkNewInterpreter(interpreter: ClerkNewInterpreter) {
+    const {
+      onrId,
+      isIndividualised,
+      permissionToPublishEmail,
+      permissionToPublishPhone,
+      permissionToPublishOtherContactInfo,
+      regions,
+      qualifications,
+      ...rest
+    } = interpreter;
+    const textFields =
+      SerializationUtils.getNonBlankClerkInterpreterTextFields(rest);
+
+    return {
+      ...textFields,
+      onrId,
+      isIndividualised,
+      permissionToPublishEmail,
+      permissionToPublishPhone,
+      permissionToPublishOtherContactInfo,
+      regions,
+      qualifications: qualifications.map(
+        SerializationUtils.serializeQualification
+      ),
+    };
   }
 
   static serializeClerkInterpreter(interpreter: ClerkInterpreter) {


### PR DESCRIPTION
## Yhteenveto

Toteutus uuden tulkin lisäämiseksi OTR:n ja ONR:n kantaan. Pull requestin voisi halutessa pilkkoa pienempiin osiin ja esim. tuon valinnaisen sähköpostiosoitteen irrottaa omaksi PR:kseen. Luontisivunkin voisi halutessa toteuttaa useampana PR:nä jos se helpottaa katselmointia.

## Lisätiedot

Tämän ensimmäiset 5 committia toteuttavat vaiheittain tulkin luontisivun.

Seuraavat 3 committia liittyvät oppijanumerorekisteri-integraatioon. Testasin tulkin lisäystä untuvan ONR:ää vasten ja havaitsin, että jos esimerkiksi lähdetään luomaan uutta tulkkia olemassaolevaa henkilöä koskien, kaatui tuo siihen, että backend olettaa, että `PersonalData`:ssa on aina `email` mukana. Poistin tuon vaatimuksen ja koska teoriassa joku voi myös virkailijapaneelista käsien käydä poistamassa sähköpostiosoitteen joltain ONR:stä joltakin tulkilta, ei voitane myöskään vaatia, että tulkilla ylipäätään on sähköpostiosoitetta olemassa, vaikka frontend sen asettamisen pakottaakin. Tähän liittyen pitäisi kai koskea myös `ClerkEmailService`:en, jonka kautta lähetetään muistutusmaileja.

## Check-lista

- [ ] Käännösten Excel-tiedosto päivitetty
- [x] Testattu docker-compose:lla
