### PR TITLE
OTR(Backend): OPHOTRKEH-131: ONR-integraation muutokset tulkin luontia varten

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
@@ -17,7 +17,7 @@ public record ClerkInterpreterDTO(
   @NonNull @NotBlank String lastName,
   @NonNull @NotBlank String firstName,
   @NonNull @NotBlank String nickName,
-  @NonNull @NotBlank String email,
+  String email,
   @NonNull @NotNull Boolean permissionToPublishEmail,
   String phoneNumber,
   @NonNull @NotNull Boolean permissionToPublishPhone,

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
@@ -116,8 +116,7 @@ public class OnrOperationApiImpl implements OnrOperationApi {
     final Response response = onrClient.executeBlocking(request);
 
     if (response.getStatusCode() == HttpStatus.CREATED.value()) {
-      final PersonalDataDTO responseDTO = OBJECT_MAPPER.readValue(response.getResponseBody(), new TypeReference<>() {});
-      return responseDTO.getOnrId();
+      return response.getResponseBody();
     } else {
       throw new RuntimeException("ONR service returned unexpected status code: " + response.getStatusCode());
     }

--- a/backend/otr/src/main/java/fi/oph/otr/onr/mock/OnrOperationApiMock.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/mock/OnrOperationApiMock.java
@@ -35,7 +35,6 @@ public class OnrOperationApiMock implements OnrOperationApi {
           .firstName("Matti Tauno")
           .nickName("Matti")
           .identityNumber(identityNumber)
-          .email("matti.lehtinen@example.invalid")
           .street("Kajaanintie 123")
           .postalCode("93600")
           .town("Kuusamo")
@@ -49,7 +48,6 @@ public class OnrOperationApiMock implements OnrOperationApi {
           .firstName("Anna Maria")
           .nickName("Anna")
           .identityNumber(identityNumber)
-          .email("anna.mannonen@example.invalid")
           .street("Tampereentie 234")
           .postalCode("20100")
           .town("Turku")
@@ -63,7 +61,6 @@ public class OnrOperationApiMock implements OnrOperationApi {
           .firstName("Oona Inkeri")
           .nickName("Oona")
           .identityNumber(identityNumber)
-          .email("oona.oppija@example.invalid")
           .street("Ristikontie 333")
           .town("Helsinki")
           .build();
@@ -75,7 +72,6 @@ public class OnrOperationApiMock implements OnrOperationApi {
           .firstName("Olli Pekka")
           .nickName("Olli")
           .identityNumber(identityNumber)
-          .email("olli.oppija@example.invalid")
           .build();
         default -> null;
       };

--- a/backend/otr/src/main/java/fi/oph/otr/onr/model/PersonalData.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/model/PersonalData.java
@@ -28,7 +28,6 @@ public class PersonalData {
   @NonNull
   private String identityNumber;
 
-  @NonNull // FIXME email should be required when saving to ONR, optional when reading from ONR?
   private String email;
 
   private String phoneNumber;

--- a/backend/otr/src/main/java/fi/oph/otr/service/email/ClerkEmailService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/email/ClerkEmailService.java
@@ -66,6 +66,11 @@ public class ClerkEmailService {
       final String recipientAddress = personalData.getEmail();
       final String emailSubject = "Merkintäsi oikeustulkkirekisteriin on päättymässä";
 
+      if (recipientAddress == null) {
+        LOG.info("Email for interpreter with onr id {} doesn't exist", interpreter.getOnrId());
+        return;
+      }
+
       final String emailBody = getQualificationExpiryEmailBody(
         recipientName,
         qualification.getFromLang(),

--- a/backend/otr/src/test/java/fi/oph/otr/onr/OnrOperationApiImplTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/onr/OnrOperationApiImplTest.java
@@ -18,8 +18,23 @@ import org.junit.jupiter.api.Test;
 class OnrOperationApiImplTest {
 
   @Test
-  void testCreatePersonalDataDTO_IndividualisedNoPhone() {
-    final PersonalData personalData = defaultData().email("e@mail").individualised(true).build();
+  void testCreatePersonalDataDTO_IndividualisedNoOtherDetails() {
+    final PersonalData personalData = defaultData().individualised(true).build();
+
+    final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
+
+    assertDtoMatchesDefaultData(dto);
+    assertTrue(dto.getIndividualised());
+
+    final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
+    assertEquals(2, contactDetailsSet.size());
+    assertNull(findValueByType(contactDetailsSet, ContactDetailsType.EMAIL));
+    assertNull(findValueByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER));
+  }
+
+  @Test
+  void testCreatePersonalDataDTO_IndividualisedWithEmail() {
+    final PersonalData personalData = defaultData().individualised(true).email("e@mail").build();
 
     final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
 
@@ -34,7 +49,7 @@ class OnrOperationApiImplTest {
 
   @Test
   void testCreatePersonalDataDTO_IndividualisedWithPhone() {
-    final PersonalData personalData = defaultData().email("e@mail").individualised(true).phoneNumber("040404").build();
+    final PersonalData personalData = defaultData().individualised(true).phoneNumber("040404").build();
 
     final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
 
@@ -43,15 +58,15 @@ class OnrOperationApiImplTest {
 
     final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
     assertEquals(2, contactDetailsSet.size());
-    assertEquals("e@mail", findValueByType(contactDetailsSet, ContactDetailsType.EMAIL));
+    assertNull(findValueByType(contactDetailsSet, ContactDetailsType.EMAIL));
     assertEquals("040404", findValueByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER));
   }
 
   @Test
   void testCreatePersonalDataDTO_IndividualisedAllOtherDetails() {
     final PersonalData personalData = defaultData()
-      .email("e@mail")
       .individualised(true)
+      .email("e@mail")
       .phoneNumber("040404")
       .street("Katu 1")
       .postalCode("12321")
@@ -71,7 +86,7 @@ class OnrOperationApiImplTest {
 
   @Test
   void testCreatePersonalDataDTO_NotIndividualisedNoOtherDetails() {
-    final PersonalData personalData = defaultData().email("e@mail").individualised(false).build();
+    final PersonalData personalData = defaultData().individualised(false).build();
 
     final PersonalDataDTO dto = OnrOperationApiImpl.createPersonalDataDTO(personalData);
 
@@ -80,7 +95,7 @@ class OnrOperationApiImplTest {
 
     final Set<ContactDetailsDTO> contactDetailsSet = assertGroupGettingContactDetailsDTOS(dto);
     assertEquals(6, contactDetailsSet.size());
-    assertEquals("e@mail", findValueByType(contactDetailsSet, ContactDetailsType.EMAIL));
+    assertNull(findValueByType(contactDetailsSet, ContactDetailsType.EMAIL));
     assertNull(findValueByType(contactDetailsSet, ContactDetailsType.PHONE_NUMBER));
     assertNull(findValueByType(contactDetailsSet, ContactDetailsType.STREET));
     assertNull(findValueByType(contactDetailsSet, ContactDetailsType.POSTAL_CODE));
@@ -91,8 +106,8 @@ class OnrOperationApiImplTest {
   @Test
   void testCreatePersonalDataDTO_NotIndividualisedWithAllOtherDetails() {
     final PersonalData personalData = defaultData()
-      .email("e@mail")
       .individualised(false)
+      .email("e@mail")
       .phoneNumber("040404")
       .street("Katu 1")
       .postalCode("12321")

--- a/backend/otr/src/test/java/fi/oph/otr/service/PersonServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/service/PersonServiceTest.java
@@ -48,7 +48,6 @@ class PersonServiceTest {
       .firstName("Erkki Eemeli")
       .nickName("Erkki")
       .identityNumber("xxx1")
-      .email("erkki.esimerkki@invalid")
       .street("Katu 1")
       .postalCode("999")
       .town("Kaupunki")

--- a/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
@@ -9,8 +9,8 @@ export interface ClerkInterpreterTextFields {
   lastName: string;
   firstName: string;
   nickName: string;
-  email: string;
   // Optional fields
+  email?: string;
   phoneNumber?: string;
   otherContactInfo?: string;
   street?: string;


### PR DESCRIPTION
## Yhteenveto

Tarpeelliset koodimuutokset uuden tulkin luontiin potentiaalisesti olemassaolevalla hetulla haetun oppijan perusteella

## Lisätiedot

Tulkin luonti on toteutettu erillisessä taskissa OPHOTRKEH-122 ja näitä muutoksia on testattu jo sen yhteydessä. Kun uutta tulkkia lähtee luomaan, haetaan ensin hetulla olemassaolevia tietoja ONR:stä. Jos oppija hetulla löytyy, ei sillä ole oikeustulkkirekisterin yhteystietojen mukaista sähköpostiosoitetta, täten PersonalDatassa merkattu `email` nullableksi. 

Käytännössä kun meidän järjestelmään tulkki luodaan tai sitä muokataan, sähköpostiosoitteen olemassaolo pakotetaan ja jokaiselta tulkilta se pitäisi ONR:stä näin löytyä. ONR:n kantaan pystyy kuitenkin järjestelmän ulkopuoleltakin koskemaan ja esim. virkailijan opintopolun UI:sta käsin voi helposti käydä sähköpostiosoitteen tulkkia vastaavalta oppijalta poistamassa. Näin en tehnyt enää oletusta siitä, että sähköpostiosoite olemassaolevalta tulkilta aina löytyisi ja muutin sillä periaatteella modeleita (ClerkInterpreterDTO + vast. frontin model) siten, että sähköpostiosoite ei ole noissa pakollinen. Frontend ei vaatinut muita muutoksia emailin osalta. Muokkasin myös ClerkEmailServiceä hanskaamaan tilanteen, jolloin sähköpostiosoitetta ei tulkille ONR:stä löytynytkään.

## Check-lista

- [x] Testattu docker-compose:lla
