### PR TITLE
OTR(Frontend): OPHOTRKEH-122 tulkin luontisivu

### DIFF
--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -290,6 +290,16 @@
           "updated": "Tiedot tallennettiin"
         }
       },
+      "clerkNewInterpreterPage": {
+        "addedQualificationsTitle": "Lisätyt rekisteröinnit",
+        "removeQualificationDialog": {
+          "title": "Haluatko varmasti poistaa rekisteröinnin?"
+        },
+        "title": "Lisää oikeustulkki",
+        "toasts": {
+          "success": "Tulkin tiedot tallennettiin"
+        }
+      },
       "clerkPersonSearchPage": {
         "buttons": {
           "proceed": "Syötä manuaalisesti",

--- a/frontend/packages/otr/src/components/clerkInterpreter/new/BottomControls.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/new/BottomControls.tsx
@@ -1,0 +1,51 @@
+import { CustomButton, LoadingProgressIndicator } from 'shared/components';
+import { APIResponseStatus, Color, Variant } from 'shared/enums';
+import { StringUtils } from 'shared/utils';
+
+import { useCommonTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
+import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
+import { saveClerkNewInterpreter } from 'redux/reducers/clerkNewInterpreter';
+
+export const BottomControls = ({
+  interpreter,
+  status,
+}: {
+  interpreter: ClerkNewInterpreter;
+  status: APIResponseStatus;
+}) => {
+  const translateCommon = useCommonTranslation();
+  const dispatch = useAppDispatch();
+  const isLoading = status === APIResponseStatus.InProgress;
+
+  const onSave = () => {
+    dispatch(saveClerkNewInterpreter(interpreter));
+  };
+
+  const isSaveButtonDisabled = () => {
+    return (
+      isLoading ||
+      StringUtils.isBlankString(interpreter.lastName) ||
+      StringUtils.isBlankString(interpreter.firstName) ||
+      StringUtils.isBlankString(interpreter.nickName) ||
+      StringUtils.isBlankString(interpreter.email) ||
+      interpreter.qualifications.length < 1
+    );
+  };
+
+  return (
+    <div className="columns flex-end">
+      <LoadingProgressIndicator isLoading={isLoading}>
+        <CustomButton
+          data-testid="clerk-new-interpreter-page__save-button"
+          variant={Variant.Contained}
+          color={Color.Secondary}
+          onClick={onSave}
+          disabled={isSaveButtonDisabled()}
+        >
+          {translateCommon('save')}
+        </CustomButton>
+      </LoadingProgressIndicator>
+    </div>
+  );
+};

--- a/frontend/packages/otr/src/components/clerkInterpreter/new/ClerkNewInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/new/ClerkNewInterpreterDetails.tsx
@@ -1,0 +1,74 @@
+import { ChangeEvent, useState } from 'react';
+import { ComboBoxOption } from 'shared/interfaces';
+
+import { ClerkInterpreterDetailsFields } from 'components/clerkInterpreter/overview/ClerkInterpreterDetailsFields';
+import { useAppDispatch } from 'configs/redux';
+import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
+import { updateClerkNewInterpreter } from 'redux/reducers/clerkNewInterpreter';
+import { RegionUtils } from 'utils/region';
+
+export const ClerkNewInterpreterDetails = ({
+  interpreter,
+  isIndividualisedInterpreter,
+  onDetailsChange,
+}: {
+  interpreter: ClerkNewInterpreter;
+  isIndividualisedInterpreter?: boolean;
+  onDetailsChange: () => void;
+}) => {
+  // Local state
+  const [areaOfOperation, setAreaOfOperation] = useState(
+    RegionUtils.getAreaOfOperation(interpreter.regions)
+  );
+
+  const dispatch = useAppDispatch();
+
+  const handleDetailsChange =
+    (field: keyof ClerkNewInterpreter) =>
+    (
+      eventOrValue:
+        | ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+        | ComboBoxOption[]
+    ) => {
+      let fieldValue;
+      let updatedInterpreterDetails;
+
+      if (Array.isArray(eventOrValue)) {
+        // from Region ComboBox[]
+        updatedInterpreterDetails = {
+          ...interpreter,
+          [field]: eventOrValue.map((value) => value.value),
+        };
+      } else if (
+        'checked' in eventOrValue.target &&
+        eventOrValue.target.hasOwnProperty('checked')
+      ) {
+        // from Checkbox toggle
+        updatedInterpreterDetails = {
+          ...interpreter,
+          [field]: eventOrValue.target.checked,
+        };
+      } else {
+        // from TextField ChangeEvent
+        fieldValue = eventOrValue.target.value;
+        updatedInterpreterDetails = {
+          ...interpreter,
+          [field]: fieldValue,
+        };
+      }
+      onDetailsChange();
+      dispatch(updateClerkNewInterpreter(updatedInterpreterDetails));
+    };
+
+  return (
+    <ClerkInterpreterDetailsFields
+      interpreterBasicInformation={interpreter}
+      isIndividualisedInterpreter={isIndividualisedInterpreter}
+      areaOfOperation={areaOfOperation}
+      setAreaOfOperation={setAreaOfOperation}
+      onFieldChange={(field) => handleDetailsChange(field)}
+      isViewMode={false}
+      displayFieldErrorBeforeChange={false}
+    />
+  );
+};

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
@@ -9,18 +9,17 @@ import { ClerkInterpreterDetailsFields } from 'components/clerkInterpreter/overv
 import { useAppTranslation, useCommonTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { UIMode } from 'enums/app';
-import { AreaOfOperation } from 'enums/clerkInterpreter';
 import { useNavigationProtection } from 'hooks/useNavigationProtection';
-import { ClerkInterpreter } from 'interfaces/clerkInterpreter';
+import {
+  ClerkInterpreter,
+  ClerkInterpreterBasicInformation,
+} from 'interfaces/clerkInterpreter';
 import {
   resetClerkInterpreterDetailsUpdate,
   updateClerkInterpreterDetails,
 } from 'redux/reducers/clerkInterpreterOverview';
 import { clerkInterpreterOverviewSelector } from 'redux/selectors/clerkInterpreterOverview';
-
-const getAreaOfOperation = (regions: Array<string> = []) => {
-  return regions.length > 0 ? AreaOfOperation.Regions : AreaOfOperation.All;
-};
+import { RegionUtils } from 'utils/region';
 
 export const ClerkInterpreterDetails = () => {
   // Redux
@@ -34,12 +33,12 @@ export const ClerkInterpreterDetails = () => {
   const [hasLocalChanges, setHasLocalChanges] = useState(false);
   const [currentUIMode, setCurrentUIMode] = useState(UIMode.View);
   const [areaOfOperation, setAreaOfOperation] = useState(
-    getAreaOfOperation(interpreter?.regions)
+    RegionUtils.getAreaOfOperation(interpreter?.regions)
   );
   const isViewMode = currentUIMode !== UIMode.EditInterpreterDetails;
   const resetLocalInterpreterDetails = useCallback(() => {
     setInterpreterDetails(interpreter);
-    setAreaOfOperation(getAreaOfOperation(interpreter?.regions));
+    setAreaOfOperation(RegionUtils.getAreaOfOperation(interpreter?.regions));
   }, [interpreter]);
 
   // I18n
@@ -106,11 +105,11 @@ export const ClerkInterpreterDetails = () => {
   ]);
 
   useEffect(() => {
-    setAreaOfOperation(getAreaOfOperation(interpreter?.regions));
+    setAreaOfOperation(RegionUtils.getAreaOfOperation(interpreter?.regions));
   }, [interpreter?.regions]);
 
-  const handleInterpreterDetailsChange =
-    (field: keyof ClerkInterpreter) =>
+  const handleDetailsChange =
+    (field: keyof ClerkInterpreterBasicInformation) =>
     (
       eventOrValue:
         | ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
@@ -174,12 +173,11 @@ export const ClerkInterpreterDetails = () => {
 
   return (
     <ClerkInterpreterDetailsFields
-      interpreter={interpreterDetails}
+      interpreterBasicInformation={interpreterDetails}
+      isIndividualisedInterpreter={interpreter?.isIndividualised}
       areaOfOperation={areaOfOperation}
       setAreaOfOperation={setAreaOfOperation}
-      onFieldChange={(field: keyof ClerkInterpreter) =>
-        handleInterpreterDetailsChange(field)
-      }
+      onFieldChange={(field) => handleDetailsChange(field)}
       isViewMode={isViewMode}
       topControlButtons={
         <ControlButtons

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetailsFields.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetailsFields.tsx
@@ -26,13 +26,16 @@ import {
   AreaOfOperation,
   ClerkInterpreterTextFieldEnum,
 } from 'enums/clerkInterpreter';
-import { ClerkInterpreter } from 'interfaces/clerkInterpreter';
+import {
+  ClerkInterpreterBasicInformation,
+  ClerkInterpreterTextFields,
+} from 'interfaces/clerkInterpreter';
 import koodistoRegionsFI from 'public/i18n/koodisto/regions/koodisto_regions_fi-FI.json';
 import { RegionUtils } from 'utils/regions';
 
 type ClerkInterpreterTextFieldProps = {
-  interpreter?: ClerkInterpreter;
   field: ClerkInterpreterTextFieldEnum;
+  interpreterTextFields?: ClerkInterpreterTextFields;
   displayError: boolean;
   onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 } & CustomTextFieldProps;
@@ -53,12 +56,12 @@ const getTextFieldType = (field: ClerkInterpreterTextFieldEnum) => {
 };
 
 const getFieldError = (
-  interpreter: ClerkInterpreter | undefined,
-  field: ClerkInterpreterTextFieldEnum
+  field: ClerkInterpreterTextFieldEnum,
+  interpreterTextFields?: ClerkInterpreterTextFields
 ) => {
   const t = translateOutsideComponent();
   const type = getTextFieldType(field);
-  const value = (interpreter && interpreter[field]) || '';
+  const value = (interpreterTextFields && interpreterTextFields[field]) || '';
   const required = [
     ClerkInterpreterTextFieldEnum.LastName,
     ClerkInterpreterTextFieldEnum.FirstName,
@@ -77,8 +80,8 @@ const getFieldError = (
 };
 
 const ClerkInterpreterDetailsTextField = ({
-  interpreter,
   field,
+  interpreterTextFields,
   onChange,
   displayError,
   ...rest
@@ -88,11 +91,11 @@ const ClerkInterpreterDetailsTextField = ({
     keyPrefix:
       'otr.component.clerkInterpreterOverview.interpreterDetails.fields',
   });
-  const fieldError = getFieldError(interpreter, field);
+  const fieldError = getFieldError(field, interpreterTextFields);
 
   return (
     <CustomTextField
-      value={(interpreter && interpreter[field]) ?? ''}
+      value={(interpreterTextFields && interpreterTextFields[field]) ?? ''}
       label={t(field)}
       onChange={onChange}
       type={getTextFieldType(field)}
@@ -189,7 +192,8 @@ const ClerkInterpreterDetailsRegions = ({
 };
 
 export const ClerkInterpreterDetailsFields = ({
-  interpreter,
+  interpreterBasicInformation,
+  isIndividualisedInterpreter,
   areaOfOperation,
   setAreaOfOperation,
   onFieldChange,
@@ -197,9 +201,10 @@ export const ClerkInterpreterDetailsFields = ({
   topControlButtons,
   displayFieldErrorBeforeChange,
 }: {
-  interpreter: ClerkInterpreter | undefined;
+  interpreterBasicInformation: ClerkInterpreterBasicInformation | undefined;
+  isIndividualisedInterpreter?: boolean;
   onFieldChange: (
-    field: keyof ClerkInterpreter
+    field: keyof ClerkInterpreterBasicInformation
   ) => (
     eventOrValue:
       | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -236,7 +241,7 @@ export const ClerkInterpreterDetailsFields = ({
     }
 
     return (
-      interpreter?.isIndividualised &&
+      isIndividualisedInterpreter &&
       [
         ClerkInterpreterTextFieldEnum.LastName,
         ClerkInterpreterTextFieldEnum.FirstName,
@@ -247,7 +252,7 @@ export const ClerkInterpreterDetailsFields = ({
 
   const getCommonTextFieldProps = (field: ClerkInterpreterTextFieldEnum) => ({
     field,
-    interpreter,
+    interpreterTextFields: interpreterBasicInformation,
     disabled: isViewMode || isIndividualisedValue(field),
     onChange: onFieldChange(field),
     onBlur: displayFieldErrorOnBlur(field),
@@ -303,7 +308,7 @@ export const ClerkInterpreterDetailsFields = ({
           />
           <Checkbox
             color={Color.Secondary}
-            checked={interpreter?.permissionToPublishEmail}
+            checked={interpreterBasicInformation?.permissionToPublishEmail}
             onChange={onFieldChange('permissionToPublishEmail')}
             disabled={isViewMode}
           />
@@ -318,7 +323,7 @@ export const ClerkInterpreterDetailsFields = ({
           />
           <Checkbox
             color={Color.Secondary}
-            checked={interpreter?.permissionToPublishPhone}
+            checked={interpreterBasicInformation?.permissionToPublishPhone}
             onChange={onFieldChange('permissionToPublishPhone')}
             disabled={isViewMode}
           />
@@ -333,7 +338,9 @@ export const ClerkInterpreterDetailsFields = ({
           />
           <Checkbox
             color={Color.Secondary}
-            checked={interpreter?.permissionToPublishOtherContactInfo}
+            checked={
+              interpreterBasicInformation?.permissionToPublishOtherContactInfo
+            }
             onChange={onFieldChange('permissionToPublishOtherContactInfo')}
             disabled={isViewMode}
           />
@@ -350,7 +357,7 @@ export const ClerkInterpreterDetailsFields = ({
       />
       <H3>{t('header.regions')}</H3>
       <ClerkInterpreterDetailsRegions
-        regions={interpreter?.regions}
+        regions={interpreterBasicInformation?.regions}
         areaOfOperation={areaOfOperation}
         setAreaOfOperation={setAreaOfOperation}
         onChange={onFieldChange('regions')}

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationListing.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationListing.tsx
@@ -164,7 +164,7 @@ export const QualificationListing = ({
                   data-testid={
                     q.id
                       ? `qualifications-table__id-${q.id}-row__delete-button`
-                      : `qualifications-table__id-${i}-unsaved}-row__delete-button`
+                      : `qualifications-table__id-${i}-unsaved-row__delete-button`
                   }
                 >
                   <DeleteIcon color={Color.Error} />

--- a/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
@@ -19,16 +19,21 @@ export interface ClerkInterpreterTextFields {
   country?: string;
   extraInformation?: string;
 }
-export interface ClerkInterpreter
-  extends WithId,
-    WithVersion,
-    ClerkInterpreterTextFields {
-  deleted: boolean;
-  isIndividualised: boolean;
+
+export interface ClerkInterpreterBasicInformation
+  extends ClerkInterpreterTextFields {
   permissionToPublishEmail: boolean;
   permissionToPublishPhone: boolean;
   permissionToPublishOtherContactInfo: boolean;
   regions: Array<string>;
+}
+
+export interface ClerkInterpreter
+  extends WithId,
+    WithVersion,
+    ClerkInterpreterBasicInformation {
+  deleted: boolean;
+  isIndividualised: boolean;
   qualifications: Array<Qualification>;
 }
 

--- a/frontend/packages/otr/src/interfaces/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkNewInterpreter.ts
@@ -1,0 +1,10 @@
+import { ClerkInterpreter } from 'interfaces/clerkInterpreter';
+
+export interface ClerkNewInterpreter
+  extends Omit<
+    ClerkInterpreter,
+    'id' | 'version' | 'deleted' | 'isIndividualised'
+  > {
+  onrId?: string;
+  isIndividualised?: boolean;
+}

--- a/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
@@ -1,0 +1,196 @@
+import { Add as AddIcon } from '@mui/icons-material';
+import { Box, Paper } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { CustomButton, CustomModal, H1, H2 } from 'shared/components';
+import { APIResponseStatus, Color, Severity, Variant } from 'shared/enums';
+import { useDialog, useToast } from 'shared/hooks';
+
+import { AddQualification } from 'components/clerkInterpreter/add/AddQualification';
+import { BottomControls } from 'components/clerkInterpreter/new/BottomControls';
+import { ClerkNewInterpreterDetails } from 'components/clerkInterpreter/new/ClerkNewInterpreterDetails';
+import { QualificationListing } from 'components/clerkInterpreter/overview/QualificationListing';
+import { TopControls } from 'components/clerkInterpreter/overview/TopControls';
+import { useAppTranslation, useCommonTranslation } from 'configs/i18n';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { AppRoutes } from 'enums/app';
+import { useNavigationProtection } from 'hooks/useNavigationProtection';
+import { Qualification } from 'interfaces/qualification';
+import {
+  initialiseClerkNewInterpreterByIdentityNumber,
+  initialiseClerkNewInterpreterByPerson,
+  resetClerkNewInterpreter,
+  updateClerkNewInterpreter,
+} from 'redux/reducers/clerkNewInterpreter';
+import { loadMeetingDates } from 'redux/reducers/meetingDate';
+import { clerkNewInterpreterSelector } from 'redux/selectors/clerkNewInterpreter';
+import { clerkPersonSearchSelector } from 'redux/selectors/clerkPersonSearch';
+import {
+  meetingDatesSelector,
+  selectMeetingDatesByMeetingStatus,
+} from 'redux/selectors/meetingDate';
+
+export const ClerkNewInterpreterPage = () => {
+  const [open, setOpen] = useState(false);
+  const handleOpenModal = () => setOpen(true);
+  const handleCloseModal = () => setOpen(false);
+  const [hasLocalChanges, setHasLocalChanges] = useState(false);
+
+  const { showToast } = useToast();
+  const { showDialog } = useDialog();
+
+  // i18n
+  const { t } = useAppTranslation({
+    keyPrefix: 'otr.pages.clerkNewInterpreterPage',
+  });
+  const translateCommon = useCommonTranslation();
+
+  // Redux
+  const { interpreter, status, id } = useAppSelector(
+    clerkNewInterpreterSelector
+  );
+  const { identityNumber, person } = useAppSelector(clerkPersonSearchSelector);
+  const meetingDatesState = useAppSelector(meetingDatesSelector).meetingDates;
+  const passedMeetingDates = useAppSelector(
+    selectMeetingDatesByMeetingStatus
+  ).passed;
+
+  useNavigationProtection(
+    hasLocalChanges && status !== APIResponseStatus.Success
+  );
+
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  // Initialise interpreter by clerkPersonSearch
+  useEffect(() => {
+    if (person) {
+      dispatch(initialiseClerkNewInterpreterByPerson(person));
+    } else if (identityNumber) {
+      dispatch(initialiseClerkNewInterpreterByIdentityNumber(identityNumber));
+    } else {
+      navigate(AppRoutes.ClerkHomePage);
+    }
+  }, [dispatch, person, identityNumber, navigate]);
+
+  useEffect(() => {
+    if (
+      !meetingDatesState.meetingDates.length &&
+      meetingDatesState.status === APIResponseStatus.NotStarted
+    ) {
+      dispatch(loadMeetingDates());
+    }
+  }, [dispatch, meetingDatesState]);
+
+  useEffect(() => {
+    if (status === APIResponseStatus.Success) {
+      showToast({
+        severity: Severity.Success,
+        description: t('toasts.success'),
+      });
+      navigate(
+        AppRoutes.ClerkInterpreterOverviewPage.replace(
+          /:interpreterId$/,
+          `${id}`
+        )
+      );
+    }
+  }, [id, navigate, status, showToast, t]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(resetClerkNewInterpreter());
+    };
+  }, [dispatch]);
+
+  const onQualificationAdd = (qualification: Qualification) => {
+    setHasLocalChanges(true);
+    dispatch(
+      updateClerkNewInterpreter({
+        ...interpreter,
+        qualifications: [...interpreter.qualifications, qualification],
+      })
+    );
+  };
+
+  const onQualificationRemove = (qualification: Qualification) => {
+    showDialog({
+      title: t('removeQualificationDialog.title'),
+      severity: Severity.Info,
+      description: '',
+      actions: [
+        {
+          title: translateCommon('no'),
+          variant: Variant.Outlined,
+        },
+        {
+          dataTestId:
+            'clerk-new-interpreter-page__dialog-confirm-remove-button',
+          title: translateCommon('yes'),
+          variant: Variant.Contained,
+          action: () =>
+            dispatch(
+              updateClerkNewInterpreter({
+                ...interpreter,
+                qualifications: interpreter.qualifications.filter((q) => {
+                  return q.tempId !== qualification.tempId;
+                }),
+              })
+            ),
+        },
+      ],
+    });
+  };
+
+  return (
+    <Box className="clerk-new-interpreter-page">
+      <H1>{t('title')}</H1>
+      <Paper
+        elevation={3}
+        className="clerk-new-interpreter-page__content-container rows"
+      >
+        <div className="rows gapped">
+          <TopControls />
+          <ClerkNewInterpreterDetails
+            interpreter={interpreter}
+            isIndividualisedInterpreter={person?.isIndividualised}
+            onDetailsChange={() => setHasLocalChanges(true)}
+          />
+          <CustomModal
+            data-testid="qualification-details__add-qualification-modal"
+            open={open}
+            onCloseModal={handleCloseModal}
+            ariaLabelledBy="modal-title"
+            modalTitle={translateCommon('addQualification')}
+          >
+            <AddQualification
+              meetingDates={passedMeetingDates}
+              onQualificationAdd={onQualificationAdd}
+              onCancel={handleCloseModal}
+            />
+          </CustomModal>
+          <div className="columns margin-top-sm space-between">
+            <H2>{t('addedQualificationsTitle')}</H2>
+            <CustomButton
+              data-testid="clerk-new-interpreter-page__add-qualification-button"
+              variant={Variant.Contained}
+              color={Color.Secondary}
+              startIcon={<AddIcon />}
+              onClick={handleOpenModal}
+            >
+              {translateCommon('addQualification')}
+            </CustomButton>
+          </div>
+          {interpreter.qualifications.length > 0 && (
+            <QualificationListing
+              qualifications={interpreter.qualifications}
+              permissionToPublishReadOnly={true}
+              handleRemoveQualification={onQualificationRemove}
+            />
+          )}
+          <BottomControls interpreter={interpreter} status={status} />
+        </div>
+      </Paper>
+    </Box>
+  );
+};

--- a/frontend/packages/otr/src/pages/ClerkPersonSearchPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkPersonSearchPage.tsx
@@ -141,6 +141,7 @@ export const ClerkPersonSearchPage = () => {
           <div className="columns margin-top-lg">
             {personNotFound && (
               <CustomButton
+                data-testid="clerk-person-search-page__proceed-button"
                 variant={Variant.Outlined}
                 color={Color.Secondary}
                 onClick={handleProceed}

--- a/frontend/packages/otr/src/redux/reducers/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkInterpreter.ts
@@ -63,6 +63,18 @@ const clerkInterpreterSlice = createSlice({
       state.interpreters = action.payload;
       state.qualificationLanguages = getQualificationLanguages(action.payload);
     },
+    // TODO: use in interpreter update, and in all qualification operations
+    upsertClerkInterpreter(state, action: PayloadAction<ClerkInterpreter>) {
+      const updatedInterpreters = [...state.interpreters];
+      const interpreter = action.payload;
+      const idx = updatedInterpreters.findIndex(
+        (t: ClerkInterpreter) => t.id === interpreter.id
+      );
+      const spliceIndex = idx >= 0 ? idx : updatedInterpreters.length;
+
+      updatedInterpreters.splice(spliceIndex, 1, interpreter);
+      state.interpreters = updatedInterpreters;
+    },
   },
 });
 
@@ -73,4 +85,5 @@ export const {
   rejectClerkInterpreters,
   resetClerkInterpreterFilters,
   storeClerkInterpreters,
+  upsertClerkInterpreter,
 } = clerkInterpreterSlice.actions;

--- a/frontend/packages/otr/src/redux/reducers/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkNewInterpreter.ts
@@ -1,0 +1,102 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { APIResponseStatus } from 'shared/enums';
+import { WithId } from 'shared/interfaces';
+
+import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
+import { ClerkPerson } from 'interfaces/clerkPerson';
+
+interface ClerkNewInterpreterState extends Partial<WithId> {
+  status: APIResponseStatus;
+  interpreter: ClerkNewInterpreter;
+}
+
+const initialState: ClerkNewInterpreterState = {
+  interpreter: {
+    onrId: undefined,
+    isIndividualised: undefined,
+    identityNumber: '',
+    lastName: '',
+    firstName: '',
+    nickName: '',
+    email: '',
+    phoneNumber: '',
+    otherContactInfo: '',
+    street: '',
+    postalCode: '',
+    town: '',
+    country: '',
+    extraInformation: '',
+    permissionToPublishEmail: false,
+    permissionToPublishPhone: false,
+    permissionToPublishOtherContactInfo: false,
+    regions: [],
+    qualifications: [],
+  },
+  status: APIResponseStatus.NotStarted,
+  id: undefined,
+};
+
+const clerkNewInterpreterSlice = createSlice({
+  name: 'clerkNewInterpreter',
+  initialState,
+  reducers: {
+    initialiseClerkNewInterpreterByIdentityNumber(
+      state,
+      action: PayloadAction<string>
+    ) {
+      state.interpreter.identityNumber = action.payload;
+    },
+    initialiseClerkNewInterpreterByPerson(
+      state,
+      action: PayloadAction<ClerkPerson>
+    ) {
+      const person = action.payload;
+
+      state.interpreter.onrId = person.onrId;
+      state.interpreter.isIndividualised = person.isIndividualised;
+      state.interpreter.identityNumber = person.identityNumber;
+      state.interpreter.lastName = person.lastName;
+      state.interpreter.firstName = person.firstName;
+      state.interpreter.nickName = person.nickName;
+      state.interpreter.street = person.street;
+      state.interpreter.postalCode = person.postalCode;
+      state.interpreter.town = person.town;
+      state.interpreter.country = person.country;
+    },
+    rejectClerkNewInterpreter(state) {
+      state.status = APIResponseStatus.Error;
+    },
+    resetClerkNewInterpreter(state) {
+      state.interpreter = initialState.interpreter;
+      state.status = initialState.status;
+      state.id = initialState.id;
+    },
+    saveClerkNewInterpreter(
+      state,
+      _action: PayloadAction<ClerkNewInterpreter>
+    ) {
+      state.status = APIResponseStatus.InProgress;
+    },
+    storeClerkNewInterpreter(state, action: PayloadAction<number>) {
+      state.status = APIResponseStatus.Success;
+      state.id = action.payload;
+    },
+    updateClerkNewInterpreter(
+      state,
+      action: PayloadAction<ClerkNewInterpreter>
+    ) {
+      state.interpreter = action.payload;
+    },
+  },
+});
+
+export const clerkNewInterpreterReducer = clerkNewInterpreterSlice.reducer;
+export const {
+  initialiseClerkNewInterpreterByIdentityNumber,
+  initialiseClerkNewInterpreterByPerson,
+  rejectClerkNewInterpreter,
+  resetClerkNewInterpreter,
+  saveClerkNewInterpreter,
+  storeClerkNewInterpreter,
+  updateClerkNewInterpreter,
+} = clerkNewInterpreterSlice.actions;

--- a/frontend/packages/otr/src/redux/sagas/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/redux/sagas/clerkNewInterpreter.ts
@@ -1,0 +1,44 @@
+import { call, put, takeLatest } from '@redux-saga/core/effects';
+import { PayloadAction } from '@reduxjs/toolkit';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import axiosInstance from 'configs/axios';
+import { APIEndpoints } from 'enums/api';
+import { ClerkInterpreterResponse } from 'interfaces/clerkInterpreter';
+import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
+import { setAPIError } from 'redux/reducers/APIError';
+import { upsertClerkInterpreter } from 'redux/reducers/clerkInterpreter';
+import { setClerkInterpreterOverview } from 'redux/reducers/clerkInterpreterOverview';
+import {
+  rejectClerkNewInterpreter,
+  saveClerkNewInterpreter,
+  storeClerkNewInterpreter,
+} from 'redux/reducers/clerkNewInterpreter';
+import { NotifierUtils } from 'utils/notifier';
+import { SerializationUtils } from 'utils/serialization';
+
+function* saveClerkNewInterpreterSaga(
+  action: PayloadAction<ClerkNewInterpreter>
+) {
+  try {
+    const apiResponse: AxiosResponse<ClerkInterpreterResponse> = yield call(
+      axiosInstance.post,
+      APIEndpoints.ClerkInterpreter,
+      SerializationUtils.serializeClerkNewInterpreter(action.payload)
+    );
+    const interpreter = SerializationUtils.deserializeClerkInterpreter(
+      apiResponse.data
+    );
+    yield put(upsertClerkInterpreter(interpreter));
+    yield put(storeClerkNewInterpreter(interpreter.id));
+    yield put(setClerkInterpreterOverview(interpreter));
+  } catch (error) {
+    const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
+    yield put(setAPIError(errorMessage));
+    yield put(rejectClerkNewInterpreter());
+  }
+}
+
+export function* watchClerkNewInterpreterSave() {
+  yield takeLatest(saveClerkNewInterpreter, saveClerkNewInterpreterSaga);
+}

--- a/frontend/packages/otr/src/redux/sagas/index.ts
+++ b/frontend/packages/otr/src/redux/sagas/index.ts
@@ -2,6 +2,7 @@ import { all } from 'redux-saga/effects';
 
 import { watchClerkInterpreters } from 'redux/sagas/clerkInterpreter';
 import { watchClerkInterpreterOverview } from 'redux/sagas/clerkInterpreterOverview';
+import { watchClerkNewInterpreterSave } from 'redux/sagas/clerkNewInterpreter';
 import { watchClerkPersonSearch } from 'redux/sagas/clerkPersonSearch';
 import { watchClerkUser } from 'redux/sagas/clerkUser';
 import { watchMeetingDates } from 'redux/sagas/meetingDate';
@@ -13,6 +14,7 @@ export default function* rootSaga() {
     watchPublicInterpreters(),
     watchClerkInterpreters(),
     watchClerkInterpreterOverview(),
+    watchClerkNewInterpreterSave(),
     watchClerkPersonSearch(),
     watchClerkUser(),
     watchQualificationUpdates(),

--- a/frontend/packages/otr/src/redux/selectors/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/redux/selectors/clerkNewInterpreter.ts
@@ -1,0 +1,4 @@
+import { RootState } from 'configs/redux';
+
+export const clerkNewInterpreterSelector = (state: RootState) =>
+  state.clerkNewInterpreter;

--- a/frontend/packages/otr/src/redux/store/index.ts
+++ b/frontend/packages/otr/src/redux/store/index.ts
@@ -4,6 +4,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { APIErrorReducer } from 'redux/reducers/APIError';
 import { clerkInterpreterReducer } from 'redux/reducers/clerkInterpreter';
 import { clerkInterpreterOverviewReducer } from 'redux/reducers/clerkInterpreterOverview';
+import { clerkNewInterpreterReducer } from 'redux/reducers/clerkNewInterpreter';
 import { clerkPersonSearchReducer } from 'redux/reducers/clerkPersonSearch';
 import { clerkUserReducer } from 'redux/reducers/clerkUser';
 import { meetingDateReducer } from 'redux/reducers/meetingDate';
@@ -17,6 +18,7 @@ const store = configureStore({
   reducer: {
     clerkInterpreter: clerkInterpreterReducer,
     clerkInterpreterOverview: clerkInterpreterOverviewReducer,
+    clerkNewInterpreter: clerkNewInterpreterReducer,
     clerkPersonSearch: clerkPersonSearchReducer,
     publicInterpreter: publicInterpreterReducer,
     clerkUser: clerkUserReducer,

--- a/frontend/packages/otr/src/routers/AppRouter.tsx
+++ b/frontend/packages/otr/src/routers/AppRouter.tsx
@@ -8,6 +8,7 @@ import { AppRoutes } from 'enums/app';
 import { useAPIErrorToast } from 'hooks/useAPIErrorToast';
 import { ClerkHomePage } from 'pages/ClerkHomePage';
 import { ClerkInterpreterOverviewPage } from 'pages/ClerkInterpreterOverviewPage';
+import { ClerkNewInterpreterPage } from 'pages/ClerkNewInterpreterPage';
 import { ClerkPersonSearchPage } from 'pages/ClerkPersonSearchPage';
 import { MeetingDatesPage } from 'pages/MeetingDatesPage';
 import { PublicHomePage } from 'pages/PublicHomePage';
@@ -42,6 +43,10 @@ export const AppRouter: FC = () => {
               <Route
                 path={AppRoutes.ClerkPersonSearchPage}
                 element={<ClerkPersonSearchPage />}
+              />
+              <Route
+                path={AppRoutes.ClerkNewInterpreterPage}
+                element={<ClerkNewInterpreterPage />}
               />
             </Routes>
           </div>

--- a/frontend/packages/otr/src/styles/pages/_clerk-new-interpreter-page.scss
+++ b/frontend/packages/otr/src/styles/pages/_clerk-new-interpreter-page.scss
@@ -1,0 +1,11 @@
+.clerk-new-interpreter-page {
+  flex: 1;
+
+  & &__content-container {
+    padding: 3rem;
+  }
+
+  .regions {
+    flex: 1;
+  }
+}

--- a/frontend/packages/otr/src/styles/styles.scss
+++ b/frontend/packages/otr/src/styles/styles.scss
@@ -15,6 +15,7 @@
 // Pages
 @import 'pages/clerk-homepage';
 @import 'pages/clerk-interpreter-overview-page';
+@import 'pages/clerk-new-interpreter-page';
 @import 'pages/clerk-person-search-page';
 @import 'pages/meeting-dates-page';
 @import 'pages/public-homepage';

--- a/frontend/packages/otr/src/tests/cypress/integration/clerk_new_interpreter_page.spec.ts
+++ b/frontend/packages/otr/src/tests/cypress/integration/clerk_new_interpreter_page.spec.ts
@@ -1,0 +1,167 @@
+import { AppRoutes } from 'enums/app';
+import { onClerkNewInterpreterPage } from 'tests/cypress/support/page-objects/clerkNewInterpreterPage';
+import { onClerkPersonSearchPage } from 'tests/cypress/support/page-objects/clerkPersonSearchPage';
+import { onToast } from 'tests/cypress/support/page-objects/toast';
+import { clerkInterpreter } from 'tests/msw/fixtures/clerkInterpreter';
+import { person1, person2 } from 'tests/msw/fixtures/person';
+
+const NEW_PERSON_SSN = '170688-935N';
+
+describe('ClerkNewInterpreterPage', () => {
+  beforeEach(() => {
+    cy.openClerkPersonSearchPage();
+  });
+
+  describe('on creation of interpreter for a new person', () => {
+    beforeEach(() => {
+      onClerkPersonSearchPage.typeSocialSecurityNumber(NEW_PERSON_SSN);
+      onClerkPersonSearchPage.clickSearchButton();
+      onClerkPersonSearchPage.clickProceedButton();
+    });
+
+    it('only identity number field should be prefilled and disabled', () => {
+      onClerkNewInterpreterPage.expectInterpreterFieldValue(
+        'identityNumber',
+        'input',
+        NEW_PERSON_SSN
+      );
+      onClerkNewInterpreterPage.expectDisabledInterpreterField(
+        'identityNumber',
+        'input'
+      );
+
+      [
+        'lastName',
+        'firstName',
+        'nickName',
+        'street',
+        'postalCode',
+        'town',
+        'country',
+        'email',
+        'phoneNumber',
+        'otherContactInfo',
+      ].forEach((field) => {
+        onClerkNewInterpreterPage.expectInterpreterFieldValue(
+          field,
+          'input',
+          ''
+        );
+        onClerkNewInterpreterPage.expectEnabledInterpreterField(field, 'input');
+      });
+    });
+
+    it('saving should be disabled if fields are not properly set', () => {
+      const expectEmptyingToDisableSaveInterpreterButton = (
+        fieldName,
+        reset
+      ) => {
+        onClerkNewInterpreterPage.editInterpreterField(fieldName, 'input', ' ');
+        onClerkNewInterpreterPage.expectDisabledSaveInterpreterButton();
+        onClerkNewInterpreterPage.editInterpreterField(
+          fieldName,
+          'input',
+          reset
+        );
+      };
+
+      onClerkNewInterpreterPage.setNameFieldValues(
+        'Tester',
+        'Test Name',
+        'Test'
+      );
+      onClerkNewInterpreterPage.editInterpreterField(
+        'email',
+        'input',
+        'test@tester'
+      );
+      onClerkNewInterpreterPage.clickAddQualificationButton();
+      onClerkNewInterpreterPage.fillOutAddQualificationFields();
+      onClerkNewInterpreterPage.clickSaveQualificationButton();
+
+      onClerkNewInterpreterPage.expectEnabledSaveInterpreterButton();
+
+      expectEmptyingToDisableSaveInterpreterButton('lastName', 'Tester');
+      expectEmptyingToDisableSaveInterpreterButton('firstName', 'Test');
+      expectEmptyingToDisableSaveInterpreterButton('nickName', 'Test');
+      expectEmptyingToDisableSaveInterpreterButton('email', 'test@tester');
+
+      onClerkNewInterpreterPage.expectEnabledSaveInterpreterButton();
+    });
+
+    it('saving should work with fields properly set', () => {
+      onClerkNewInterpreterPage.setNameFieldValues(
+        'Tester',
+        'Test Name',
+        'Test'
+      );
+      onClerkNewInterpreterPage.editInterpreterField(
+        'email',
+        'input',
+        'test@tester'
+      );
+      onClerkNewInterpreterPage.clickAddQualificationButton();
+      onClerkNewInterpreterPage.fillOutAddQualificationFields();
+      onClerkNewInterpreterPage.clickSaveQualificationButton();
+
+      onClerkNewInterpreterPage.clickSaveInterpreterButton();
+
+      onToast.expectText('Tulkin tiedot tallennettiin');
+      const expectedInterpreterPage =
+        AppRoutes.ClerkInterpreterOverviewPage.replace(
+          /:interpreterId$/,
+          `${clerkInterpreter.id}`
+        );
+      cy.isOnPage(expectedInterpreterPage);
+    });
+  });
+
+  describe('on creation of interpreter for an existing person', () => {
+    beforeEach(() => {
+      onClerkPersonSearchPage.typeSocialSecurityNumber(person1.identityNumber);
+      onClerkPersonSearchPage.clickSearchButton();
+    });
+
+    it('personal information fields should be prefilled and disabled', () => {
+      onClerkNewInterpreterPage.expectNameFieldValues(
+        person1.lastName,
+        person1.firstName,
+        person1.nickName
+      );
+      onClerkNewInterpreterPage.expectInterpreterFieldValue(
+        'identityNumber',
+        'input',
+        person1.identityNumber
+      );
+
+      ['lastName', 'firstName', 'nickName', 'identityNumber'].forEach(
+        (field) => {
+          onClerkNewInterpreterPage.expectDisabledInterpreterField(
+            field,
+            'input'
+          );
+        }
+      );
+    });
+  });
+
+  describe('on creation of interpreter for an existing person with address', () => {
+    beforeEach(() => {
+      onClerkPersonSearchPage.typeSocialSecurityNumber(person2.identityNumber);
+      onClerkPersonSearchPage.clickSearchButton();
+    });
+
+    it('address fields should be prefilled but editable', () => {
+      onClerkNewInterpreterPage.expectAddressFieldValues(
+        person2.street,
+        person2.postalCode,
+        person2.town,
+        person2.country
+      );
+
+      ['street', 'postalCode', 'town', 'country'].forEach((field) => {
+        onClerkNewInterpreterPage.expectEnabledInterpreterField(field, 'input');
+      });
+    });
+  });
+});

--- a/frontend/packages/otr/src/tests/cypress/support/commands.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/commands.ts
@@ -28,6 +28,6 @@ Cypress.Commands.add('goForward', () => {
   cy.go(1);
 });
 
-Cypress.Commands.add('isOnPage', (page: AppRoutes) => {
+Cypress.Commands.add('isOnPage', (page: string) => {
   cy.url().should('include', page);
 });

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkNewInterpreterPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkNewInterpreterPage.ts
@@ -1,0 +1,114 @@
+import { addQualificationFields } from 'tests/cypress/fixtures/utils/clerkInterpreterOverview';
+
+class ClerkNewInterpreterPage {
+  elements = {
+    addQualificationButton: () =>
+      cy.findByTestId('clerk-new-interpreter-page__add-qualification-button'),
+    backToRegisterButton: () =>
+      cy.findByTestId('clerk-interpreter-overview-page__back-button'),
+    interpreterField: (field: string, fieldType: string) =>
+      cy
+        .findByTestId(`clerk-interpreter__basic-information__${field}`)
+        .should('be.visible')
+        .find(`div>${fieldType}`),
+    addQualificationField: (field: string, fieldType: string) =>
+      cy
+        .findByTestId(`add-qualification-field-${field}`)
+        .find(`div>${fieldType}`),
+    qualificationRow: (i: number) =>
+      cy.findByTestId(`qualifications-table__id-${i}-unsaved`),
+    saveQualificationButton: () =>
+      cy.findByTestId('add-qualification-modal__save'),
+    saveInterpreterButton: () =>
+      cy.findByTestId('clerk-new-interpreter-page__save-button'),
+  };
+
+  editInterpreterField(fieldName: string, fieldType: string, newValue) {
+    this.elements
+      .interpreterField(fieldName, fieldType)
+      .clear()
+      .should('have.text', '')
+      .type(newValue);
+  }
+
+  setNameFieldValues(lastName: string, firstName: string, nickName: string) {
+    this.editInterpreterField('lastName', 'input', lastName);
+    this.editInterpreterField('firstName', 'input', firstName);
+    this.editInterpreterField('nickName', 'input', nickName);
+  }
+
+  expectNameFieldValues(lastName: string, firstName: string, nickName: string) {
+    this.expectInterpreterFieldValue('lastName', 'input', lastName);
+    this.expectInterpreterFieldValue('firstName', 'input', firstName);
+    this.expectInterpreterFieldValue('nickName', 'input', nickName);
+  }
+
+  expectAddressFieldValues(
+    street: string,
+    postalCode: string,
+    town: string,
+    country: string
+  ) {
+    this.expectInterpreterFieldValue('street', 'input', street);
+    this.expectInterpreterFieldValue('postalCode', 'input', postalCode);
+    this.expectInterpreterFieldValue('town', 'input', town);
+    this.expectInterpreterFieldValue('country', 'input', country);
+  }
+
+  expectEnabledInterpreterField(fieldName, fieldType) {
+    this.elements
+      .interpreterField(fieldName, fieldType)
+      .should('be.enabled');
+  }
+
+  expectDisabledInterpreterField(fieldName, fieldType) {
+    this.elements
+      .interpreterField(fieldName, fieldType)
+      .should('be.disabled');
+  }
+
+  expectInterpreterFieldValue(field: string, fieldType: string, value: string) {
+    this.elements
+      .interpreterField(field, fieldType)
+      .should('have.value', value);
+  }
+
+  clickAddQualificationButton() {
+    this.elements.addQualificationButton().should('be.visible').click();
+  }
+
+  fillOutAddQualificationField(
+    fieldName: string,
+    fieldType: string,
+    newValue: string
+  ) {
+    this.elements
+      .addQualificationField(fieldName, fieldType)
+      .clear()
+      .type(`${newValue}{enter}`);
+  }
+
+  fillOutAddQualificationFields(fields = addQualificationFields) {
+    fields.forEach(({ fieldName, fieldType, value }) => {
+      this.fillOutAddQualificationField(fieldName, fieldType, value);
+    });
+  }
+
+  clickSaveQualificationButton() {
+    this.elements.saveQualificationButton().should('be.visible').click();
+  }
+
+  clickSaveInterpreterButton() {
+    this.elements.saveInterpreterButton().should('be.visible').click();
+  }
+
+  expectEnabledSaveInterpreterButton() {
+    this.elements.saveInterpreterButton().should('be.enabled');
+  }
+
+  expectDisabledSaveInterpreterButton() {
+    this.elements.saveInterpreterButton().should('be.disabled');
+  }
+}
+
+export const onClerkNewInterpreterPage = new ClerkNewInterpreterPage();

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkPersonSearchPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkPersonSearchPage.ts
@@ -6,6 +6,8 @@ class ClerkPersonSearchPage {
       cy.findByTestId('clerk-person-search-page__ssn__field'),
     socialSecurityNumberSearchButton: () =>
       cy.findByTestId('clerk-person-search-page__ssn__search-button'),
+    proceedButton: () =>
+      cy.findByTestId('clerk-person-search-page__proceed-button'),
     byLabel: (label: Matcher) =>
       cy
         .findByTestId('clerk-person-search-page__ssn__field')
@@ -24,6 +26,10 @@ class ClerkPersonSearchPage {
       .socialSecurityNumberSearchButton()
       .should('be.visible')
       .click();
+  }
+
+  clickProceedButton() {
+    this.elements.proceedButton().should('be.visible').click();
   }
 
   expectSocialSecurityNumberFieldError(fieldError: string) {

--- a/frontend/packages/otr/src/tests/cypress/support/types/index.d.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/types/index.d.ts
@@ -1,4 +1,6 @@
-import { AppRoutes } from 'enums/app';
+// Workaround for ts(2669): adding an import or export marks a file as a module,
+// which is needed to augment the global scope as done below.
+export {};
 
 declare global {
   namespace Cypress {
@@ -10,7 +12,7 @@ declare global {
       usePhoneViewport(): void;
       goBack(): void;
       goForward(): void;
-      isOnPage(page: AppRoutes): Chainable<Element>;
+      isOnPage(page: string): Chainable<Element>;
     }
   }
 }

--- a/frontend/packages/otr/src/tests/msw/fixtures/person.ts
+++ b/frontend/packages/otr/src/tests/msw/fixtures/person.ts
@@ -1,0 +1,23 @@
+import { ClerkPerson } from 'interfaces/clerkPerson';
+
+export const person1: ClerkPerson = {
+  onrId: '123',
+  isIndividualised: true,
+  identityNumber: '170378-966N',
+  lastName: 'Mannonen',
+  firstName: 'Anna Maria',
+  nickName: 'Anna',
+};
+
+export const person2: ClerkPerson = {
+  onrId: '234',
+  isIndividualised: true,
+  identityNumber: '090687-913J',
+  lastName: 'Lehtinen',
+  firstName: 'Matti Tauno',
+  nickName: 'Tauno',
+  street: 'Kajaanintie 123',
+  postalCode: '93600',
+  town: 'Kuusamo',
+  country: 'FINLAND',
+};

--- a/frontend/packages/otr/src/tests/msw/handlers.ts
+++ b/frontend/packages/otr/src/tests/msw/handlers.ts
@@ -5,6 +5,7 @@ import { clerkInterpreter } from 'tests/msw/fixtures/clerkInterpreter';
 import { clerkInterpreterIndividualised } from 'tests/msw/fixtures/clerkInterpreterIndividualised';
 import { clerkInterpreters10 } from 'tests/msw/fixtures/clerkInterpreters10';
 import { meetingDates10 } from 'tests/msw/fixtures/meetingDates10';
+import { person1, person2 } from 'tests/msw/fixtures/person';
 import { publicInterpreters10 } from 'tests/msw/fixtures/publicInterpreters10';
 import { qualification } from 'tests/msw/fixtures/qualification';
 import {
@@ -77,6 +78,20 @@ export const handlers = [
         qualificationRemoveResponse(clerkInterpreter, parseInt(id as string))
       )
     );
+  }),
+  rest.get(APIEndpoints.ClerkPersonSearch, (req, res, ctx) => {
+    const identityNumber = req.url.searchParams.get('identityNumber');
+
+    if (identityNumber === person1.identityNumber) {
+      return res(ctx.status(200), ctx.json(person1));
+    } else if (identityNumber === person2.identityNumber) {
+      return res(ctx.status(200), ctx.json(person2));
+    } else {
+      return res(ctx.status(200));
+    }
+  }),
+  rest.post(APIEndpoints.ClerkInterpreter, (req, res, ctx) => {
+    return res(ctx.status(201), ctx.json(clerkInterpreter));
   }),
   rest.get(APIEndpoints.MeetingDate, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(meetingDates10));

--- a/frontend/packages/otr/src/utils/region.ts
+++ b/frontend/packages/otr/src/utils/region.ts
@@ -1,0 +1,7 @@
+import { AreaOfOperation } from 'enums/clerkInterpreter';
+
+export class RegionUtils {
+  static getAreaOfOperation = (regions: Array<string> = []) => {
+    return regions.length > 0 ? AreaOfOperation.Regions : AreaOfOperation.All;
+  };
+}

--- a/frontend/packages/otr/src/utils/serialization.ts
+++ b/frontend/packages/otr/src/utils/serialization.ts
@@ -6,6 +6,7 @@ import {
   ClerkInterpreterResponse,
   ClerkInterpreterTextFields,
 } from 'interfaces/clerkInterpreter';
+import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
 import { MeetingDateResponse } from 'interfaces/meetingDate';
 import { Qualification, QualificationResponse } from 'interfaces/qualification';
 
@@ -18,6 +19,34 @@ export class SerializationUtils {
     );
 
     return { ...response, qualifications };
+  }
+
+  static serializeClerkNewInterpreter(interpreter: ClerkNewInterpreter) {
+    const {
+      onrId,
+      isIndividualised,
+      permissionToPublishEmail,
+      permissionToPublishPhone,
+      permissionToPublishOtherContactInfo,
+      regions,
+      qualifications,
+      ...rest
+    } = interpreter;
+    const textFields =
+      SerializationUtils.getNonBlankClerkInterpreterTextFields(rest);
+
+    return {
+      ...textFields,
+      onrId,
+      isIndividualised,
+      permissionToPublishEmail,
+      permissionToPublishPhone,
+      permissionToPublishOtherContactInfo,
+      regions,
+      qualifications: qualifications.map(
+        SerializationUtils.serializeQualification
+      ),
+    };
   }
 
   static serializeClerkInterpreter(interpreter: ClerkInterpreter) {


### PR DESCRIPTION
## Yhteenveto

Tulkin luontisivu ja luonnin toteutus henkilötunnuksella tehtyyn hakutietoon (clerkPersonSearch) perustuen. Haun yhteydessä talletettu tuohon stateen joko pelkkä henkilötunnus, tai jos haulla löytyi myös ONR:stä oppijan tiedot, nuo ovat myös staten `person` fieldin alla.

## Lisätiedot

`OnrOperationApiMock` määrittää neljä testihetua, joita voi käyttää lokaaliin testaamiseen. Niitä jokaista kohti on ko. luokassa myös ennaltamääritelty oppijanumero, joten samalla hetulla ei voi luoda toista oppijaa. Mikäli tällaisen testaus on tarpeellista, kannattaa kanta initialisoida uudelleen välissä.

`OnrCacheUpdater` päivittää cachen 5 minuutin välein generoimalla tulkkien henkilö- ja osoitetiedot `PersonalDataFactory`:n avulla. Näin ollen kun tätä testaamalla luo uuden tulkin, muutaman minuutin kuluessa tulkin tiedot (pl. oppijanumero, joka kannassa) ylikirjoitetaan cacheen tuon data factoryn avustamana.

Uuden staten `ClerkNewInterpeter` vastaa backendin `ClerkInterpreterCreateDTO`:ta jolla optionaaliset `onrId` sekä `isIndividualised`.

## Huomautukset

- Parhaillaan jos klikkaa Takaisin-painiketta luontisivulla, vie tuo rekisteriin eikä hakusivulle
- Testit puuttuvat vielä

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
- [x] Testattu docker-compose:lla
