### PR TITLE
AKR(Backend): Don't HTML escape subject for informal clerk emails.

### DIFF
--- a/backend/akr/src/main/java/fi/oph/akr/service/email/ClerkEmailService.java
+++ b/backend/akr/src/main/java/fi/oph/akr/service/email/ClerkEmailService.java
@@ -24,7 +24,6 @@ import javax.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.util.HtmlUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -71,7 +70,7 @@ public class ClerkEmailService {
         .ifPresent(recipientAddress -> {
           final String recipientName = translator.getFullName();
 
-          final String emailSubject = HtmlUtils.htmlEscape(emailRequestDTO.subject().trim());
+          final String emailSubject = emailRequestDTO.subject().trim();
           final String emailBody = getInformalEmailBody(emailRequestDTO.body());
           createEmail(recipientName, recipientAddress, emailSubject, emailBody, EmailType.INFORMAL);
         })

--- a/backend/akr/src/test/java/fi/oph/akr/service/email/ClerkEmailServiceTest.java
+++ b/backend/akr/src/test/java/fi/oph/akr/service/email/ClerkEmailServiceTest.java
@@ -112,7 +112,7 @@ public class ClerkEmailServiceTest {
     final InformalEmailRequestDTO emailRequestDTO = InformalEmailRequestDTO
       .builder()
       .translatorIds(translators.stream().map(Translator::getId).toList())
-      .subject("otsikko<")
+      .subject("otsikko<ääkköset>")
       .body("viesti")
       .build();
 
@@ -134,7 +134,7 @@ public class ClerkEmailServiceTest {
 
         assertEquals(translator.getFullName(), emailData.recipientName());
         assertEquals(translator.getEmail(), emailData.recipientAddress());
-        assertEquals("otsikko&lt;", emailData.subject());
+        assertEquals("otsikko<ääkköset>", emailData.subject());
         assertEquals("<p>viesti</p>", emailData.body());
       });
   }

--- a/frontend/packages/akr/src/pages/clerk/ClerkSendEmailPage.tsx
+++ b/frontend/packages/akr/src/pages/clerk/ClerkSendEmailPage.tsx
@@ -111,7 +111,7 @@ const ControlButtons = ({ submitDisabled }: { submitDisabled: boolean }) => {
 export const ClerkSendEmailPage = () => {
   // i18n
   const { t } = useAppTranslation({
-    keyPrefix: 'akr.pages.clerkSendEmailPage',
+    keyPrefix: 'akr',
   });
 
   // Redux
@@ -140,7 +140,7 @@ export const ClerkSendEmailPage = () => {
     if (status == APIResponseStatus.Success) {
       showToast({
         severity: Severity.Success,
-        description: t('toasts.success'),
+        description: t('pages.clerkSendEmailPage.toasts.success'),
       });
     }
     if (
@@ -181,22 +181,22 @@ export const ClerkSendEmailPage = () => {
 
   return (
     <Box className="clerk-send-email-page">
-      <H1>{t('title')}</H1>
+      <H1>{t('pages.clerkSendEmailPage.title')}</H1>
       <Paper className="clerk-send-email-page__form-container" elevation={3}>
         <div className="rows gapped clerk-send-email-page__form-contents">
           <div className="rows gapped">
-            <H2>{t('sections.recipients')}</H2>
+            <H2>{t('pages.clerkSendEmailPage.sections.recipients')}</H2>
             <Text>
-              {t('selectedCount', {
+              {t('pages.clerkSendEmailPage.selectedCount', {
                 count: translators.length,
               })}
             </Text>
           </div>
           <div className="rows gapped">
-            <H2>{t('sections.subject')}</H2>
+            <H2>{t('pages.clerkSendEmailPage.sections.subject')}</H2>
             <CustomTextField
               data-testid="clerk-send-email-page__subject"
-              label={t('labels.subject')}
+              label={t('pages.clerkSendEmailPage.labels.subject')}
               value={email.subject}
               onChange={handleSubjectChange}
               onBlur={handleFieldError('subject')}
@@ -206,10 +206,10 @@ export const ClerkSendEmailPage = () => {
             />
           </div>
           <div className="rows gapped">
-            <H2>{t('sections.message')}</H2>
+            <H2>{t('pages.clerkSendEmailPage.sections.message')}</H2>
             <CustomTextField
               data-testid="clerk-send-email-page__message"
-              label={t('labels.message')}
+              label={t('pages.clerkSendEmailPage.labels.message')}
               value={email.body}
               onChange={handleMessageChange}
               onBlur={handleFieldError('message')}


### PR DESCRIPTION
## Yhteenveto

Korjattu virkailijan vapaamuotoisten sähköpostien otsikkojen ääkköset poistamalla turha `htmlEscape`-kutsu.

## Huomautukset

Korjattu samalla Lähetä sähköposti -näkymän täytettävien kenttien virheviestien käännösavaimet.
Kuva korjatusta virhetilanteesta alla. 


<img width="447" alt="Screenshot 2022-09-02 at 13 43 42" src="https://user-images.githubusercontent.com/18038608/188142635-229661e9-01bb-4190-ac34-1e6a661a9d02.png">

