### PR TITLE
AKR(Frontend): Fix Mobile UI scrolling bug

### DIFF
--- a/frontend/packages/akr/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
+++ b/frontend/packages/akr/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
@@ -133,7 +133,6 @@ export const PublicTranslatorFilters = ({
 
   const scrollToSearch = () => {
     filtersGridRef.current?.scrollIntoView({
-      behavior: 'smooth',
       block: 'end',
       inline: 'nearest',
     });


### PR DESCRIPTION
## Yhteenveto

Loppukäyttäjän mobiilinäkymässä auto skrolli menee pieleen, kun

1. Painaa näytä tulokset
2. Sit skrollaa vähän alas 
3. Ja painaa tee uusi haku nappia

Ongelma esintyy Ios safarilla ja sen saa toistettua myös firefoxin emulaattorilla.
