### PR TITLE
OTR(Frontend): OPHOTRKEH-135 bugikorjaus tulkin tallennusnapin disablointiin liittyen

### DIFF
--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { APIResponseStatus, Duration, Severity, Variant } from 'shared/enums';
 import { useDialog, useToast } from 'shared/hooks';
 import { ComboBoxOption } from 'shared/interfaces';
+import { StringUtils } from 'shared/utils';
 
 import { ControlButtons } from 'components/clerkInterpreter/overview/ClerkInterpreterDetailsControlButtons';
 import { ClerkInterpreterDetailsFields } from 'components/clerkInterpreter/overview/ClerkInterpreterDetailsFields';
@@ -166,10 +167,10 @@ export const ClerkInterpreterDetails = () => {
   useNavigationProtection(hasLocalChanges);
 
   const hasRequiredDetails =
-    !!interpreterDetails?.firstName &&
-    !!interpreterDetails.lastName &&
-    !!interpreterDetails.nickName &&
-    !!interpreterDetails.email;
+    StringUtils.isNonBlankString(interpreterDetails?.lastName) &&
+    StringUtils.isNonBlankString(interpreterDetails?.firstName) &&
+    StringUtils.isNonBlankString(interpreterDetails?.nickName) &&
+    StringUtils.isNonBlankString(interpreterDetails?.email);
 
   return (
     <ClerkInterpreterDetailsFields

--- a/frontend/packages/otr/src/tests/cypress/integration/interpreterOverview/clerk_interpreter_details.spec.ts
+++ b/frontend/packages/otr/src/tests/cypress/integration/interpreterOverview/clerk_interpreter_details.spec.ts
@@ -25,24 +25,21 @@ describe('ClerkInterpreterOverview:ClerkInterpreterDetails', () => {
   it('should disable details save button when the required fields are not filled out', () => {
     onClerkInterpreterOverviewPage.clickEditInterpreterDetailsButton();
 
-    onClerkInterpreterOverviewPage.editInterpreterField(
-      'firstName',
-      'input',
-      '{backspace}'
-    );
-    onClerkInterpreterOverviewPage.expectDisabledSaveInterpreterDetailsButton();
+    ['lastName', 'firstName', 'nickName', 'email'].forEach((fieldName) => {
+      onClerkInterpreterOverviewPage.editInterpreterField(
+        fieldName,
+        'input',
+        ' '
+      );
+      onClerkInterpreterOverviewPage.expectDisabledSaveInterpreterDetailsButton();
 
-    onClerkInterpreterOverviewPage.editInterpreterField(
-      'firstName',
-      'input',
-      'new First name'
-    );
-    onClerkInterpreterOverviewPage.editInterpreterField(
-      'lastName',
-      'input',
-      '{backspace}'
-    );
-    onClerkInterpreterOverviewPage.expectDisabledSaveInterpreterDetailsButton();
+      onClerkInterpreterOverviewPage.editInterpreterField(
+        fieldName,
+        'input',
+        'test'
+      );
+      onClerkInterpreterOverviewPage.expectEnabledSaveInterpreterDetailsButton();
+    });
   });
 
   it('should open a confirmation dialog when cancel is clicked if changes were made and stay in edit mode if user backs out', () => {

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkInterpreterOverviewPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkInterpreterOverviewPage.ts
@@ -144,6 +144,10 @@ class ClerkInterpreterOverviewPage {
       .should('be.disabled');
   }
 
+  expectEnabledSaveInterpreterDetailsButton() {
+    this.elements.saveInterpreterDetailsButton().should('be.enabled');
+  }
+
   expectMode(mode: UIMode) {
     switch (mode) {
       case UIMode.View:


### PR DESCRIPTION
Aiemmin jos ei-yksilöidyn tulkin nimikentän tyhjensi ja täytti välilyönneillä, antoi lisätiedot sivu mahdollisuuden klikata tallenna-painiketta. Nyt painike on disabloitu jos kentissä vain välilyöntejä.