### PR TITLE
OTR(Frontend): OPHOTRKEH-124 rekisteriä ei merkitä ladatuksi tulkin tietoja tallennettaessa

### DIFF
--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -113,8 +113,6 @@
           }
         },
         "toasts": {
-          "notFound": "Valittua tulkkia ei löytynyt",
-          "updateFailed": "Tietojen tallennus epäonnistui",
           "updated": "Tiedot tallennettiin"
         }
       },
@@ -285,9 +283,7 @@
       "clerkInterpreterOverviewPage": {
         "title": "Oikeustulkin tiedot",
         "toasts": {
-          "notFound": "Valittua kääntäjää ei löytynyt",
-          "updateFailed": "Tietojen tallennus epäonnistui",
-          "updated": "Tiedot tallennettiin"
+          "notFound": "Valittua tulkkia ei löytynyt"
         }
       },
       "clerkNewInterpreterPage": {

--- a/frontend/packages/otr/src/redux/reducers/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkInterpreter.ts
@@ -63,7 +63,6 @@ const clerkInterpreterSlice = createSlice({
       state.interpreters = action.payload;
       state.qualificationLanguages = getQualificationLanguages(action.payload);
     },
-    // TODO: use in interpreter update, and in all qualification operations
     upsertClerkInterpreter(state, action: PayloadAction<ClerkInterpreter>) {
       const updatedInterpreters = [...state.interpreters];
       const interpreter = action.payload;

--- a/frontend/packages/otr/src/redux/sagas/clerkInterpreterOverview.ts
+++ b/frontend/packages/otr/src/redux/sagas/clerkInterpreterOverview.ts
@@ -3,6 +3,7 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { call, put, takeLatest } from 'redux-saga/effects';
 
 import axiosInstance from 'configs/axios';
+import { translateOutsideComponent } from 'configs/i18n';
 import { APIEndpoints } from 'enums/api';
 import {
   ClerkInterpreter,
@@ -32,9 +33,10 @@ function* loadClerkInterpreterOverviewSaga(action: PayloadAction<number>) {
     );
     yield put(storeClerkInterpreterOverview(interpreter));
   } catch (error) {
-    // TODO: not found toast?
-    const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
-    yield put(setAPIError(errorMessage));
+    const t = translateOutsideComponent();
+    yield put(
+      setAPIError(t('otr.component.clerkInterpreterOverview.toasts.notFound'))
+    );
     yield put(rejectClerkInterpreterOverview());
   }
 }

--- a/frontend/packages/otr/src/redux/sagas/clerkInterpreterOverview.ts
+++ b/frontend/packages/otr/src/redux/sagas/clerkInterpreterOverview.ts
@@ -1,6 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import { AxiosError, AxiosResponse } from 'axios';
-import { call, put, select, takeLatest } from 'redux-saga/effects';
+import { call, put, takeLatest } from 'redux-saga/effects';
 
 import axiosInstance from 'configs/axios';
 import { APIEndpoints } from 'enums/api';
@@ -9,7 +9,7 @@ import {
   ClerkInterpreterResponse,
 } from 'interfaces/clerkInterpreter';
 import { setAPIError } from 'redux/reducers/APIError';
-import { storeClerkInterpreters } from 'redux/reducers/clerkInterpreter';
+import { upsertClerkInterpreter } from 'redux/reducers/clerkInterpreter';
 import {
   loadClerkInterpreterOverview,
   rejectClerkInterpreterDetailsUpdate,
@@ -18,7 +18,6 @@ import {
   updateClerkInterpreterDetails,
   updatingClerkInterpreterDetailsSucceeded,
 } from 'redux/reducers/clerkInterpreterOverview';
-import { clerkInterpretersSelector } from 'redux/selectors/clerkInterpreter';
 import { NotifierUtils } from 'utils/notifier';
 import { SerializationUtils } from 'utils/serialization';
 
@@ -28,31 +27,16 @@ function* loadClerkInterpreterOverviewSaga(action: PayloadAction<number>) {
       axiosInstance.get,
       `${APIEndpoints.ClerkInterpreter}/${action.payload}`
     );
-    yield put(
-      storeClerkInterpreterOverview(
-        SerializationUtils.deserializeClerkInterpreter(response.data)
-      )
+    const interpreter = SerializationUtils.deserializeClerkInterpreter(
+      response.data
     );
+    yield put(storeClerkInterpreterOverview(interpreter));
   } catch (error) {
+    // TODO: not found toast?
     const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
     yield put(setAPIError(errorMessage));
     yield put(rejectClerkInterpreterOverview());
   }
-}
-
-function* updateClerkInterpreterState(interpreter: ClerkInterpreter) {
-  const { interpreters } = yield select(clerkInterpretersSelector);
-  const interpreterIndex = interpreters.findIndex(
-    (i: ClerkInterpreter) => i.id === interpreter.id
-  );
-
-  yield put(
-    storeClerkInterpreters([
-      ...interpreters.slice(0, interpreterIndex),
-      interpreter,
-      ...interpreters.slice(interpreterIndex + 1),
-    ])
-  );
 }
 
 function* updateClerkInterpreterDetailsSaga(
@@ -62,15 +46,13 @@ function* updateClerkInterpreterDetailsSaga(
     const response: AxiosResponse<ClerkInterpreterResponse> = yield call(
       axiosInstance.put,
       `${APIEndpoints.ClerkInterpreter}`,
-      SerializationUtils.serializeClerkInterpreter(
-        action.payload as ClerkInterpreter
-      )
+      SerializationUtils.serializeClerkInterpreter(action.payload)
     );
 
     const interpreter = SerializationUtils.deserializeClerkInterpreter(
       response.data
     );
-    yield updateClerkInterpreterState(interpreter);
+    yield upsertClerkInterpreter(interpreter);
     yield put(updatingClerkInterpreterDetailsSucceeded(interpreter));
   } catch (error) {
     const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);

--- a/frontend/packages/otr/src/redux/sagas/clerkInterpreterOverview.ts
+++ b/frontend/packages/otr/src/redux/sagas/clerkInterpreterOverview.ts
@@ -3,7 +3,6 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { call, put, takeLatest } from 'redux-saga/effects';
 
 import axiosInstance from 'configs/axios';
-import { translateOutsideComponent } from 'configs/i18n';
 import { APIEndpoints } from 'enums/api';
 import {
   ClerkInterpreter,
@@ -33,10 +32,6 @@ function* loadClerkInterpreterOverviewSaga(action: PayloadAction<number>) {
     );
     yield put(storeClerkInterpreterOverview(interpreter));
   } catch (error) {
-    const t = translateOutsideComponent();
-    yield put(
-      setAPIError(t('otr.component.clerkInterpreterOverview.toasts.notFound'))
-    );
     yield put(rejectClerkInterpreterOverview());
   }
 }

--- a/frontend/packages/otr/src/redux/sagas/qualification.ts
+++ b/frontend/packages/otr/src/redux/sagas/qualification.ts
@@ -7,6 +7,7 @@ import { APIEndpoints } from 'enums/api';
 import { ClerkInterpreterResponse } from 'interfaces/clerkInterpreter';
 import { Qualification } from 'interfaces/qualification';
 import { setAPIError } from 'redux/reducers/APIError';
+import { upsertClerkInterpreter } from 'redux/reducers/clerkInterpreter';
 import { setClerkInterpreterOverview } from 'redux/reducers/clerkInterpreterOverview';
 import {
   addQualification,
@@ -23,8 +24,9 @@ import { NotifierUtils } from 'utils/notifier';
 import { SerializationUtils } from 'utils/serialization';
 
 function* addQualificationSaga(action: PayloadAction<Qualification>) {
+  const { interpreterId } = action.payload;
+
   try {
-    const { interpreterId } = action.payload;
     if (!interpreterId) {
       throw new Error();
     }
@@ -33,11 +35,10 @@ function* addQualificationSaga(action: PayloadAction<Qualification>) {
       `${APIEndpoints.ClerkInterpreter}/${interpreterId}/qualification`,
       SerializationUtils.serializeQualification(action.payload)
     );
-
     const interpreter = SerializationUtils.deserializeClerkInterpreter(
       apiResponse.data
     );
-
+    yield put(upsertClerkInterpreter(interpreter));
     yield put(setClerkInterpreterOverview(interpreter));
     yield put(addQualificationSucceeded());
   } catch (error) {
@@ -53,11 +54,10 @@ function* removeQualificationSaga(action: PayloadAction<number>) {
       axiosInstance.delete,
       `${APIEndpoints.Qualification}/${action.payload}`
     );
-
     const interpreter = SerializationUtils.deserializeClerkInterpreter(
       apiResponse.data
     );
-
+    yield put(upsertClerkInterpreter(interpreter));
     yield put(setClerkInterpreterOverview(interpreter));
     yield put(removeQualificationSucceeded());
   } catch (error) {
@@ -77,6 +77,7 @@ function* updateQualificationSaga(action: PayloadAction<Qualification>) {
     const interpreter = SerializationUtils.deserializeClerkInterpreter(
       apiResponse.data
     );
+    yield put(upsertClerkInterpreter(interpreter));
     yield put(setClerkInterpreterOverview(interpreter));
     yield put(updateQualificationSucceeded());
   } catch (error) {


### PR DESCRIPTION
## Yhteenveto

Korjattu bugi, joka kuvattu tiketissä:

"Jos tulkin tiedot tallentaa, merkitään rekisteri ladatuksi. Näin ollen jos siirtyy tulkin sivulle, päivittää sivun ja tallentaa tulkin tiedot ja siirtyy rekisteriin, ei rekisterissä näy muita tulkkeja."

Samalla lisätty myös bugiin liittymättömästi ei-olemassaolevaa tulkkia haettaessa printtautumaan toast `Valittua tulkkia ei löytynyt`, jonka lokalisaatio oli olemassa mutta ei käytössä.

## Check-lista

- [x] Käännösexcel päivitetty
- [x] Testattu docker-compose:lla
