### PR TITLE
OTR(Frontend): OPHOTRKEH-140 shared-kirjaston päivitys versioon 1.3.2

### DIFF
--- a/frontend/packages/otr/package.json
+++ b/frontend/packages/otr/package.json
@@ -25,6 +25,6 @@
     "otr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.2.6"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.2"
   }
 }

--- a/frontend/packages/otr/src/components/meetingDate/AddMeetingDate.tsx
+++ b/frontend/packages/otr/src/components/meetingDate/AddMeetingDate.tsx
@@ -1,16 +1,16 @@
 import AddIcon from '@mui/icons-material/Add';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import { useState } from 'react';
 import {
   CustomButton,
-  DatePicker,
+  CustomDatePicker,
   H3,
   LoadingProgressIndicator,
   Text,
 } from 'shared/components';
 import { APIResponseStatus, Color, Variant } from 'shared/enums';
-import { DateUtils, StringUtils } from 'shared/utils';
+import { DateUtils } from 'shared/utils';
 
 import { useAppTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
@@ -19,7 +19,7 @@ import { addMeetingDate } from 'redux/reducers/meetingDate';
 import { meetingDatesSelector } from 'redux/selectors/meetingDate';
 
 export const AddMeetingDate = () => {
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState<Dayjs | null>(null);
   const { t } = useAppTranslation({
     keyPrefix: 'otr.component.addMeetingDate',
   });
@@ -35,7 +35,9 @@ export const AddMeetingDate = () => {
   const dispatch = useAppDispatch();
 
   const handleAddDate = () => {
-    value && dispatch(addMeetingDate(dayjs(value)));
+    if (value) {
+      dispatch(addMeetingDate(dayjs(value)));
+    }
   };
 
   const isSelectedDateAlreadyTaken = () => {
@@ -67,14 +69,14 @@ export const AddMeetingDate = () => {
       </>
     ) : null;
 
-  useNavigationProtection(!StringUtils.isBlankString(value));
+  useNavigationProtection(!!value);
 
   return (
     <div className="columns gapped">
       <div className="rows gapped flex-grow-3">
         <H3>{t('header')}</H3>
         <div className="columns gapped">
-          <DatePicker
+          <CustomDatePicker
             value={value}
             setValue={setValue}
             label={t('datePicker.label')}

--- a/frontend/packages/otr/src/configs/i18n.ts
+++ b/frontend/packages/otr/src/configs/i18n.ts
@@ -73,13 +73,17 @@ declare module 'react-i18next' {
 }
 
 export const initI18n = () => {
-  return use(initReactI18next).use(LanguageDetector).init({
+  const i18n = use(initReactI18next).use(LanguageDetector).init({
     resources,
     detection: detectionOptions,
     fallbackLng: langFI,
     load: 'currentOnly',
     debug: !REACT_ENV_PRODUCTION,
   });
+  const currentLanguage = getCurrentLang() as AppLanguage;
+  DateUtils.setDayjsLocale(currentLanguage);
+
+  return i18n;
 };
 
 export const useAppTranslation = (

--- a/frontend/packages/otr/src/configs/materialUI.ts
+++ b/frontend/packages/otr/src/configs/materialUI.ts
@@ -1,4 +1,5 @@
 import { createTheme } from '@mui/material/styles';
+import type {} from '@mui/x-date-pickers/themeAugmentation';
 
 // Create Material UI theme configs
 const primaryColor = '#FFFFFF';
@@ -39,7 +40,7 @@ export const theme = createTheme({
           '&.Mui-focused': {
             color: grey700Color,
           },
-          '&.MuiInputLabel-shrink': {
+          '&.Mui-disabled': {
             color: primaryHeadingColor,
           },
           color: grey700Color,
@@ -53,26 +54,11 @@ export const theme = createTheme({
         },
       },
     },
-    MuiRadio: {
+    MuiCalendarPicker: {
       styleOverrides: {
         root: {
-          color: grey700Color,
-          '&.Mui-checked': {
-            color: secondaryColor,
-          },
-          '&.Mui-disabled': {
+          '& .MuiTypography-caption': {
             color: grey700Color,
-          },
-        },
-      },
-    },
-    MuiAutocomplete: {
-      styleOverrides: {
-        tag: {
-          backgroundColor: secondaryColor,
-          color: primaryColor,
-          '.MuiChip-deleteIcon': {
-            color: primaryLightColor,
           },
         },
       },

--- a/frontend/packages/otr/src/styles/base/_base.scss
+++ b/frontend/packages/otr/src/styles/base/_base.scss
@@ -1,7 +1,3 @@
-* {
-  box-sizing: border-box;
-}
-
 html {
   overflow-y: scroll;
 }
@@ -10,8 +6,6 @@ html,
 body,
 #root {
   background-color: $color-background-root;
-  font-family: Roboto;
-  font-size: 62.5%;
   height: 100%;
 
   & h1 {
@@ -31,7 +25,7 @@ body,
   grid-template-rows: fit-content($size-header) auto fit-content($size-footer);
   height: 100%;
   margin: auto;
-  max-width: $breakpoint-xxl;
+  max-width: $breakpoint-xxxl;
 
   .header {
     grid-area: header;

--- a/frontend/packages/otr/src/tests/cypress/fixtures/utils/clerkInterpreterOverview.ts
+++ b/frontend/packages/otr/src/tests/cypress/fixtures/utils/clerkInterpreterOverview.ts
@@ -22,6 +22,6 @@ export const addQualificationFields = [
   {
     fieldName: 'beginDate',
     fieldType: 'input',
-    value: '1.1.2022',
+    value: '01.01.2022',
   },
 ];

--- a/frontend/packages/otr/src/tests/cypress/integration/meeting_dates.spec.ts
+++ b/frontend/packages/otr/src/tests/cypress/integration/meeting_dates.spec.ts
@@ -2,7 +2,7 @@ import { MeetingDateStatus } from 'enums/meetingDate';
 import { onDialog } from 'tests/cypress/support/page-objects/dialog';
 import { onMeetingDatesPage } from 'tests/cypress/support/page-objects/meetingDatesPage';
 import { onToast } from 'tests/cypress/support/page-objects/toast';
-import { meetingDate } from 'tests/msw/fixtures/meetingDate';
+import { dateForNewMeetingDate } from 'tests/msw/fixtures/newMeetingDate';
 
 describe('MeetingDatesPage', () => {
   beforeEach(() => {
@@ -26,31 +26,31 @@ describe('MeetingDatesPage', () => {
   it('should order upcoming meeting dates by ascending date', () => {
     onMeetingDatesPage.filterByStatus(MeetingDateStatus.Upcoming);
 
-    onMeetingDatesPage.expectRowToContain(0, '25.9.2022');
-    onMeetingDatesPage.expectRowToContain(1, '3.12.2022');
+    onMeetingDatesPage.expectRowToContain(0, '25.09.2022');
+    onMeetingDatesPage.expectRowToContain(1, '03.12.2022');
   });
 
   it('should order passed meeting dates by descending date', () => {
     onMeetingDatesPage.filterByStatus(MeetingDateStatus.Passed);
 
-    onMeetingDatesPage.expectRowToContain(0, '14.5.2022');
-    onMeetingDatesPage.expectRowToContain(1, '1.1.2022');
+    onMeetingDatesPage.expectRowToContain(0, '14.05.2022');
+    onMeetingDatesPage.expectRowToContain(1, '01.01.2022');
   });
 
   it('should let user to add a new, unique meeting date', () => {
-    onMeetingDatesPage.setDateForNewMeetingDate(meetingDate.date);
+    onMeetingDatesPage.setDateForNewMeetingDate(dateForNewMeetingDate);
     onMeetingDatesPage.clickAddButton();
 
-    onToast.expectText('Kokouspäivän 4.10.2030 lisäys onnistui');
+    onToast.expectText(`Kokouspäivän ${dateForNewMeetingDate} lisäys onnistui`);
   });
 
   it('should not allow adding duplicate meeting dates', () => {
-    onMeetingDatesPage.setDateForNewMeetingDate('2022-01-01');
+    onMeetingDatesPage.setDateForNewMeetingDate('01.01.2022');
     onMeetingDatesPage.expectAddButtonDisabled();
   });
 
   it('should show an error toast when trying to add a meeting date fails', () => {
-    onMeetingDatesPage.setDateForNewMeetingDate('2030-01-01');
+    onMeetingDatesPage.setDateForNewMeetingDate('01.01.2030');
     onMeetingDatesPage.clickAddButton();
 
     onToast.expectText('Toiminto epäonnistui, yritä myöhemmin uudelleen');
@@ -61,7 +61,7 @@ describe('MeetingDatesPage', () => {
     onMeetingDatesPage.clickDeleteRowIcon(1);
     onDialog.clickButtonByText('Kyllä');
 
-    onToast.expectText('Kokouspäivä 1.1.2022 poistettu');
+    onToast.expectText('Kokouspäivä 01.01.2022 poistettu');
   });
 
   it('should show an error toast if meeting date is chosen to be deleted, but an API error occurs', () => {

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/meetingDatesPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/meetingDatesPage.ts
@@ -5,7 +5,7 @@ class MeetingDatesPage {
     heading: () => cy.findByTestId('meeting-dates-page__heading'),
     statusButton: (status: MeetingDateStatus) =>
       cy.findByTestId(`meeting-dates-filters__btn--${status}`),
-    datePicker: () => cy.get('input[type=date]'),
+    datePicker: () => cy.get('.custom-date-picker'),
     addButton: () => cy.findByTestId('meeting-dates-page__add-btn'),
     tableRow: (i: number) =>
       cy.get('.meeting-dates__listing > tbody > tr').eq(i),

--- a/frontend/packages/otr/src/tests/jest/pages/__snapshots__/ClerkHomePage.test.tsx.snap
+++ b/frontend/packages/otr/src/tests/jest/pages/__snapshots__/ClerkHomePage.test.tsx.snap
@@ -187,14 +187,14 @@ Object {
                       class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
                     >
                       <div
-                        class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-12o1et4-MuiAutocomplete-root"
+                        class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-16awh2u-MuiAutocomplete-root"
                         data-testid="clerk-interpreter-filters__from-lang"
                       >
                         <div
                           class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                         >
                           <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1cp0js7-MuiFormLabel-root-MuiInputLabel-root"
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-177thb3-MuiFormLabel-root-MuiInputLabel-root"
                             data-shrink="false"
                             for=":ri:"
                             id=":ri:-label"
@@ -263,14 +263,14 @@ Object {
                       class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
                     >
                       <div
-                        class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-12o1et4-MuiAutocomplete-root"
+                        class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-16awh2u-MuiAutocomplete-root"
                         data-testid="clerk-interpreter-filters__to-lang"
                       >
                         <div
                           class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                         >
                           <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1cp0js7-MuiFormLabel-root-MuiInputLabel-root"
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-177thb3-MuiFormLabel-root-MuiInputLabel-root"
                             data-shrink="false"
                             for=":rk:"
                             id=":rk:-label"
@@ -350,7 +350,7 @@ Object {
                     data-testid="clerk-interpreter-filters__name"
                   >
                     <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1cp0js7-MuiFormLabel-root-MuiInputLabel-root"
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-177thb3-MuiFormLabel-root-MuiInputLabel-root"
                       data-shrink="false"
                       for=":rm:"
                       id=":rm:-label"
@@ -394,14 +394,14 @@ Object {
                     class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
                   >
                     <div
-                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-12o1et4-MuiAutocomplete-root"
+                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-16awh2u-MuiAutocomplete-root"
                       data-testid="clerk-interpreter-filters__examination-type"
                     >
                       <div
                         class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1cp0js7-MuiFormLabel-root-MuiInputLabel-root"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-177thb3-MuiFormLabel-root-MuiInputLabel-root"
                           data-shrink="false"
                           for=":rn:"
                           id=":rn:-label"
@@ -479,14 +479,14 @@ Object {
                     class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
                   >
                     <div
-                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-12o1et4-MuiAutocomplete-root"
+                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-16awh2u-MuiAutocomplete-root"
                       data-testid="clerk-interpreter-filters__permission-to-publish-basis"
                     >
                       <div
                         class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1cp0js7-MuiFormLabel-root-MuiInputLabel-root"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-177thb3-MuiFormLabel-root-MuiInputLabel-root"
                           data-shrink="false"
                           for=":rp:"
                           id=":rp:-label"
@@ -770,9 +770,9 @@ Object {
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2020
+                        01/01/2020
                          - 
-                        1.1.2025
+                        01/01/2025
                       </p>
                        
                     </td>
@@ -851,16 +851,16 @@ Object {
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2020
+                        01/01/2020
                          - 
-                        1.1.2025
+                        01/01/2025
                       </p>
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2017
+                        01/01/2017
                          - 
-                        1.1.2022
+                        01/01/2022
                       </p>
                        
                     </td>
@@ -932,9 +932,9 @@ Object {
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2020
+                        01/01/2020
                          - 
-                        1.1.2025
+                        01/01/2025
                       </p>
                        
                     </td>
@@ -1006,9 +1006,9 @@ Object {
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2020
+                        01/01/2020
                          - 
-                        1.1.2025
+                        01/01/2025
                       </p>
                        
                     </td>
@@ -1080,9 +1080,9 @@ Object {
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2020
+                        01/01/2020
                          - 
-                        1.1.2025
+                        01/01/2025
                       </p>
                        
                     </td>
@@ -1154,9 +1154,9 @@ Object {
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2020
+                        01/01/2020
                          - 
-                        1.1.2025
+                        01/01/2025
                       </p>
                        
                     </td>
@@ -1228,9 +1228,9 @@ Object {
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2020
+                        01/01/2020
                          - 
-                        1.1.2025
+                        01/01/2025
                       </p>
                        
                     </td>
@@ -1302,9 +1302,9 @@ Object {
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2020
+                        01/01/2020
                          - 
-                        1.1.2025
+                        01/01/2025
                       </p>
                        
                     </td>
@@ -1376,9 +1376,9 @@ Object {
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2020
+                        01/01/2020
                          - 
-                        1.1.2025
+                        01/01/2025
                       </p>
                        
                     </td>
@@ -1457,16 +1457,16 @@ Object {
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        1.1.2020
+                        01/01/2020
                          - 
-                        1.1.2025
+                        01/01/2025
                       </p>
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                       >
-                        3.10.2018
+                        10/03/2018
                          - 
-                        3.10.2023
+                        10/03/2023
                       </p>
                        
                     </td>
@@ -1803,14 +1803,14 @@ Object {
                     class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
                   >
                     <div
-                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-12o1et4-MuiAutocomplete-root"
+                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-16awh2u-MuiAutocomplete-root"
                       data-testid="clerk-interpreter-filters__from-lang"
                     >
                       <div
                         class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1cp0js7-MuiFormLabel-root-MuiInputLabel-root"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-177thb3-MuiFormLabel-root-MuiInputLabel-root"
                           data-shrink="false"
                           for=":ri:"
                           id=":ri:-label"
@@ -1879,14 +1879,14 @@ Object {
                     class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
                   >
                     <div
-                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-12o1et4-MuiAutocomplete-root"
+                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-16awh2u-MuiAutocomplete-root"
                       data-testid="clerk-interpreter-filters__to-lang"
                     >
                       <div
                         class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1cp0js7-MuiFormLabel-root-MuiInputLabel-root"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-177thb3-MuiFormLabel-root-MuiInputLabel-root"
                           data-shrink="false"
                           for=":rk:"
                           id=":rk:-label"
@@ -1966,7 +1966,7 @@ Object {
                   data-testid="clerk-interpreter-filters__name"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1cp0js7-MuiFormLabel-root-MuiInputLabel-root"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-177thb3-MuiFormLabel-root-MuiInputLabel-root"
                     data-shrink="false"
                     for=":rm:"
                     id=":rm:-label"
@@ -2010,14 +2010,14 @@ Object {
                   class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
                 >
                   <div
-                    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-12o1et4-MuiAutocomplete-root"
+                    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-16awh2u-MuiAutocomplete-root"
                     data-testid="clerk-interpreter-filters__examination-type"
                   >
                     <div
                       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1cp0js7-MuiFormLabel-root-MuiInputLabel-root"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-177thb3-MuiFormLabel-root-MuiInputLabel-root"
                         data-shrink="false"
                         for=":rn:"
                         id=":rn:-label"
@@ -2095,14 +2095,14 @@ Object {
                   class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
                 >
                   <div
-                    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-12o1et4-MuiAutocomplete-root"
+                    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-16awh2u-MuiAutocomplete-root"
                     data-testid="clerk-interpreter-filters__permission-to-publish-basis"
                   >
                     <div
                       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1cp0js7-MuiFormLabel-root-MuiInputLabel-root"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary css-177thb3-MuiFormLabel-root-MuiInputLabel-root"
                         data-shrink="false"
                         for=":rp:"
                         id=":rp:-label"
@@ -2386,9 +2386,9 @@ Object {
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2020
+                      01/01/2020
                        - 
-                      1.1.2025
+                      01/01/2025
                     </p>
                      
                   </td>
@@ -2467,16 +2467,16 @@ Object {
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2020
+                      01/01/2020
                        - 
-                      1.1.2025
+                      01/01/2025
                     </p>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2017
+                      01/01/2017
                        - 
-                      1.1.2022
+                      01/01/2022
                     </p>
                      
                   </td>
@@ -2548,9 +2548,9 @@ Object {
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2020
+                      01/01/2020
                        - 
-                      1.1.2025
+                      01/01/2025
                     </p>
                      
                   </td>
@@ -2622,9 +2622,9 @@ Object {
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2020
+                      01/01/2020
                        - 
-                      1.1.2025
+                      01/01/2025
                     </p>
                      
                   </td>
@@ -2696,9 +2696,9 @@ Object {
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2020
+                      01/01/2020
                        - 
-                      1.1.2025
+                      01/01/2025
                     </p>
                      
                   </td>
@@ -2770,9 +2770,9 @@ Object {
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2020
+                      01/01/2020
                        - 
-                      1.1.2025
+                      01/01/2025
                     </p>
                      
                   </td>
@@ -2844,9 +2844,9 @@ Object {
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2020
+                      01/01/2020
                        - 
-                      1.1.2025
+                      01/01/2025
                     </p>
                      
                   </td>
@@ -2918,9 +2918,9 @@ Object {
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2020
+                      01/01/2020
                        - 
-                      1.1.2025
+                      01/01/2025
                     </p>
                      
                   </td>
@@ -2992,9 +2992,9 @@ Object {
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2020
+                      01/01/2020
                        - 
-                      1.1.2025
+                      01/01/2025
                     </p>
                      
                   </td>
@@ -3073,16 +3073,16 @@ Object {
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      1.1.2020
+                      01/01/2020
                        - 
-                      1.1.2025
+                      01/01/2025
                     </p>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1fltv3x-MuiTypography-root"
                     >
-                      3.10.2018
+                      10/03/2018
                        - 
-                      3.10.2023
+                      10/03/2023
                     </p>
                      
                   </td>

--- a/frontend/packages/otr/src/tests/msw/fixtures/meetingDate.ts
+++ b/frontend/packages/otr/src/tests/msw/fixtures/meetingDate.ts
@@ -1,5 +1,0 @@
-export const meetingDate = {
-  id: 11,
-  version: 0,
-  date: '2030-10-04',
-};

--- a/frontend/packages/otr/src/tests/msw/fixtures/newMeetingDate.ts
+++ b/frontend/packages/otr/src/tests/msw/fixtures/newMeetingDate.ts
@@ -1,0 +1,8 @@
+// ts-unused-exports:disable-next-line
+export const dateForNewMeetingDate = '04.10.2030';
+
+export const newMeetingDate = {
+  id: 11,
+  version: 0,
+  date: '2030-10-04',
+};

--- a/frontend/packages/otr/src/tests/msw/handlers.ts
+++ b/frontend/packages/otr/src/tests/msw/handlers.ts
@@ -4,8 +4,8 @@ import { APIEndpoints } from 'enums/api';
 import { clerkInterpreter } from 'tests/msw/fixtures/clerkInterpreter';
 import { clerkInterpreterIndividualised } from 'tests/msw/fixtures/clerkInterpreterIndividualised';
 import { clerkInterpreters10 } from 'tests/msw/fixtures/clerkInterpreters10';
-import { meetingDate } from 'tests/msw/fixtures/meetingDate';
 import { meetingDates10 } from 'tests/msw/fixtures/meetingDates10';
+import { newMeetingDate } from 'tests/msw/fixtures/newMeetingDate';
 import { person1, person2 } from 'tests/msw/fixtures/person';
 import { publicInterpreters10 } from 'tests/msw/fixtures/publicInterpreters10';
 import { qualification } from 'tests/msw/fixtures/qualification';
@@ -100,13 +100,13 @@ export const handlers = [
   rest.post(APIEndpoints.MeetingDate, async (req, res, ctx) => {
     const { date } = await req.json();
 
-    if (date === meetingDate.date) {
-      return res(ctx.status(201), ctx.json(meetingDate));
+    if (date === newMeetingDate.date) {
+      return res(ctx.status(201), ctx.json(newMeetingDate));
     } else {
       return res(ctx.status(500));
     }
   }),
-  rest.delete(`${APIEndpoints.MeetingDate}/:id`,(req, res, ctx) => {
+  rest.delete(`${APIEndpoints.MeetingDate}/:id`, (req, res, ctx) => {
     const { id } = req.params;
     const deletableMeetingDateId = meetingDates10.find(
       (m) => m.date === '2022-01-01'

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2525,7 +2525,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.otr@workspace:packages/otr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.2.6"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.2"
   languageName: unknown
   linkType: soft
 
@@ -11153,13 +11153,6 @@ __metadata:
   version: 1.0.8
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.0.8%2F49b847a91241b0dd5892466233f7d6f6ddd31e50"
   checksum: 98b0da2f685bab94dce772f38eb4ab697c14fe2f9014c326b4969b66c03b154f05417a45fd4b97bfbe231dc751e0d9a55ed3a7ee1705c9f92cd8bca1ba9d6818
-  languageName: node
-  linkType: hard
-
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.2.6":
-  version: 1.2.6
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.2.6::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.2.6%2F263c8101b3852f0a2b5d8c66f7c06154a518fb3f"
-  checksum: 48609fde2a04fd9a32a900ae20b9d661d321875950f9868d5bbb00c0d2d187330d24cf05ca1974f178e1b26e5e8a8534fd5b2b8f6ae2b9b8e1aa769e40feacc5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Samalla tulee käyttöön uusi datepicker

## Huomautukset

Shared-kirjaston päivitys versioon 1.3.0 tai uudempaan muuttaa jostain syystä päivämäärien formatoinnin muodosta d.M.yyyy muotoon MM/dd/yyyy. Tuo tapahtuu teki täällä näitä `materialUI.ts` tai `_base.scss` muutoksia tai ei. En keksinyt ainakaan tähän hätään mistä tuo ongelma kumpuaa, joten tää nyt draftinä täällä jos joku muu ehtii jossain kohtaa ihmetellä.

Toteutuksessa viitattu tähän pull requestiin: https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/235/
