### PR TITLE
AKR:OTR:VKT(Frontend): OPHAKRKEH-431 sovellusten footerien päivitys

### DIFF
--- a/frontend/packages/akr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/akr/public/i18n/en-GB/translation.json
@@ -216,13 +216,13 @@
           "accessibility": {
             "text": "Accessibility statement (in Finnish)"
           },
-          "aktHomepage": {
+          "akrHomepage": {
             "ariaLabel": "Examination system of authorised translators (oph.fi), open in a new tab",
             "link": "https://www.oph.fi/en/services/briefly-about-authorised-translators-examination",
             "text": "Examination system of authorised translators (oph.fi)"
           },
           "privacy": {
-            "text": "Privacy policy"
+            "text": "Privacy policy (in Finnish)"
           }
         }
       },

--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -216,10 +216,13 @@
           "accessibility": {
             "text": "Saavutettavuusseloste"
           },
-          "aktHomepage": {
+          "akrHomepage": {
             "ariaLabel": "Auktorisoidun kääntäjän tutkintojärjestelmä (oph.fi), avaa uudessa välilehdessä",
             "link": "https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/auktorisoidun-kaantajan-tutkinto",
             "text": "Auktorisoidun kääntäjän tutkintojärjestelmä (oph.fi)"
+          },
+          "contact": {
+            "title": "Palaute ja kehitysideat"
           },
           "privacy": {
             "text": "Tietosuojaseloste"

--- a/frontend/packages/akr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/translation.json
@@ -216,7 +216,7 @@
           "accessibility": {
             "text": "Tillgänglighetsdirektiv"
           },
-          "aktHomepage": {
+          "akrHomepage": {
             "ariaLabel": "Examenssystemet för auktoriserade translatorer (oph.fi), öppnas i en ny flik",
             "link": "https://www.oph.fi/sv/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/auktorisoidun-kaantajan-tutkinto",
             "text": "Systemet med auktoriserade translatorer (oph.fi)"

--- a/frontend/packages/akr/src/components/layouts/Footer.tsx
+++ b/frontend/packages/akr/src/components/layouts/Footer.tsx
@@ -41,7 +41,7 @@ export const Footer = () => {
           />
           <Paper className="footer" elevation={3}>
             <div className="footer__info-row">
-              <div className="footer__container footer__container--links">
+              <div className="footer__container footer__container__links">
                 <CustomButtonLink
                   to={AppRoutes.AccessibilityStatementPage}
                   variant={Variant.Text}
@@ -55,18 +55,21 @@ export const Footer = () => {
                   {t('links.privacy.text')}
                 </CustomButtonLink>
                 <ExtLink
-                  text={t('links.aktHomepage.text')}
-                  href={t('links.aktHomepage.link')}
+                  text={t('links.akrHomepage.text')}
+                  href={t('links.akrHomepage.link')}
                   endIcon={<OpenInNewIcon />}
-                  aria-label={t('links.aktHomepage.ariaLabel')}
+                  aria-label={t('links.akrHomepage.ariaLabel')}
                 />
-                <ExtLink
-                  className="footer__container--links__contact-email"
-                  href={`mailto:${translateCommon('contactEmail')}`}
-                  text={translateCommon('contactEmail')}
-                ></ExtLink>
+                <div className="footer__container__links__contact">
+                  <H3>{t('links.contact.title')}:</H3>
+                  <ExtLink
+                    className="footer__container__links__contact__email"
+                    href={`mailto:${translateCommon('contactEmail')}`}
+                    text={translateCommon('contactEmail')}
+                  ></ExtLink>
+                </div>
               </div>
-              <div className="footer__container footer__container--contact-details">
+              <div className="footer__container footer__container__contact-details">
                 <H3>{t('address.name')}</H3>
                 <br />
                 <Text>{t('address.street')}</Text>
@@ -86,7 +89,7 @@ export const Footer = () => {
               </div>
               <div className="footer__container">
                 <Svg
-                  className={'footer__container__logo--akr'}
+                  className={'footer__container__logo__akr'}
                   src={AKTLogo}
                   alt={translateCommon('akrLogo')}
                 />
@@ -96,7 +99,7 @@ export const Footer = () => {
             <div className="footer__logo-row">
               <Divider className="footer__logo-row__divider">
                 <OPHLogoViewer
-                  className="footer__container__logo--oph"
+                  className="footer__container__logo__oph"
                   direction={Direction.Vertical}
                   alt={translateCommon('ophLogo')}
                   currentLang={getCurrentLang()}

--- a/frontend/packages/akr/src/styles/components/layouts/_footer.scss
+++ b/frontend/packages/akr/src/styles/components/layouts/_footer.scss
@@ -41,23 +41,27 @@
     font-size: 1rem;
     padding: 1.5rem;
 
-    &--links,
-    &--contact-details {
+    &__links,
+    &__contact-details {
       margin-top: 3rem;
 
       @include phone {
         margin-top: 0;
       }
 
-      &__contact-email {
-        &#{&} {
-          font-weight: normal;
-          margin-top: 0.5rem;
+      &__contact {
+        margin-top: 3rem;
+
+        &__email {
+          &#{&} {
+            font-weight: normal;
+            margin-top: 0.5rem;
+          }
         }
       }
     }
 
-    &__logo--akr {
+    &__logo__akr {
       height: 16rem;
 
       @include phone {
@@ -66,7 +70,7 @@
       }
     }
 
-    &__logo--oph {
+    &__logo__oph {
       height: 8rem;
       margin: 0 4rem;
 

--- a/frontend/packages/akr/src/tests/jest/components/layouts/__snapshots__/Footer.test.tsx.snap
+++ b/frontend/packages/akr/src/tests/jest/components/layouts/__snapshots__/Footer.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Footer should render Footer correctly 1`] = `
       className="footer__info-row"
     >
       <div
-        className="footer__container footer__container--links"
+        className="footer__container footer__container__links"
       >
         <a
           className="custom-button-link"
@@ -69,9 +69,9 @@ exports[`Footer should render Footer correctly 1`] = `
           </button>
         </a>
         <a
-          aria-label="links.aktHomepage.ariaLabel"
+          aria-label="links.akrHomepage.ariaLabel"
           className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-1y942vo-MuiButtonBase-root-MuiButton-root"
-          href="links.aktHomepage.link"
+          href="links.akrHomepage.link"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -88,7 +88,7 @@ exports[`Footer should render Footer correctly 1`] = `
           tabIndex={0}
           target="_blank"
         >
-          links.aktHomepage.text
+          links.akrHomepage.text
           <span
             className="MuiButton-endIcon MuiButton-iconSizeMedium css-9tj150-MuiButton-endIcon"
           >
@@ -105,30 +105,40 @@ exports[`Footer should render Footer correctly 1`] = `
             </svg>
           </span>
         </a>
-        <a
-          className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit footer__container--links__contact-email css-1y942vo-MuiButtonBase-root-MuiButton-root"
-          href="mailto:contactEmail"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          rel="noreferrer"
-          tabIndex={0}
-          target="_blank"
+        <div
+          className="footer__container__links__contact"
         >
-          contactEmail
-        </a>
+          <h3
+            className="MuiTypography-root MuiTypography-h3 css-gepadz-MuiTypography-root"
+          >
+            links.contact.title
+            :
+          </h3>
+          <a
+            className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit footer__container__links__contact__email css-1y942vo-MuiButtonBase-root-MuiButton-root"
+            href="mailto:contactEmail"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            rel="noreferrer"
+            tabIndex={0}
+            target="_blank"
+          >
+            contactEmail
+          </a>
+        </div>
       </div>
       <div
-        className="footer__container footer__container--contact-details"
+        className="footer__container footer__container__contact-details"
       >
         <h3
           className="MuiTypography-root MuiTypography-h3 css-gepadz-MuiTypography-root"
@@ -184,7 +194,7 @@ exports[`Footer should render Footer correctly 1`] = `
       >
         <img
           alt="akrLogo"
-          className="footer__container__logo--akr"
+          className="footer__container__logo__akr"
           src="test"
         />
       </div>
@@ -201,7 +211,7 @@ exports[`Footer should render Footer correctly 1`] = `
         >
           <img
             alt="ophLogo"
-            className="footer__container__logo--oph"
+            className="footer__container__logo__oph"
             src="test"
           />
         </span>

--- a/frontend/packages/otr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/otr/public/i18n/en-GB/translation.json
@@ -144,6 +144,9 @@
             "ariaLabel": "Register of legal interpreters (oph.fi), open in a new tab",
             "link": "https://www.oph.fi/fi/palvelut/oikeustulkkirekisteri",
             "text": "Information on the Register of Legal Interpreters (oph.fi)"
+          },
+          "privacy": {
+            "text": "Privacy policy (in Finnish)"
           }
         }
       },

--- a/frontend/packages/otr/public/i18n/fi-FI/common.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/common.json
@@ -5,6 +5,7 @@
       "addQualification": "Lisää rekisteröinti",
       "allRegions": "Koko Suomi",
       "appNameAbbreviation": "OTR",
+      "appTitle": "Oikeustulkkirekisteri",
       "back": "Takaisin",
       "cancel": "Peruuta",
       "clerk": "Virkailija",

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -140,10 +140,16 @@
           "accessibility": {
             "text": "Saavutettavuusseloste"
           },
+          "contact": {
+            "title": "Palaute ja kehitysideat"
+          },
           "otrHomepage": {
             "ariaLabel": "Oikeustulkkirekisteri (oph.fi), avaa uudessa välilehdessä",
             "link": "https://www.oph.fi/fi/palvelut/oikeustulkkirekisteri",
             "text": "Tietoa Oikeustulkkirekisteristä (oph.fi)"
+          },
+          "privacy": {
+            "text": "Tietosuojaseloste"
           }
         }
       },

--- a/frontend/packages/otr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/translation.json
@@ -144,6 +144,9 @@
             "ariaLabel": "Registret över rättstolkar (oph.fi), öppna i en ny flik",
             "link": "https://www.oph.fi/sv/tjanster/registret-over-rattstolkar",
             "text": "Information om Registret över rättstolkar (oph.fi)"
+          },
+          "privacy": {
+            "text": "Dataskyddsbeskrivning"
           }
         }
       },

--- a/frontend/packages/otr/src/components/layouts/Footer.tsx
+++ b/frontend/packages/otr/src/components/layouts/Footer.tsx
@@ -36,12 +36,18 @@ export const Footer = () => {
           />
           <Paper className="footer" elevation={3}>
             <div className="footer__info-row">
-              <div className="footer__container footer__container--links">
+              <div className="footer__container footer__container__links">
                 <CustomButtonLink
                   to={AppRoutes.AccessibilityStatementPage}
                   variant={Variant.Text}
                 >
                   {t('links.accessibility.text')}
+                </CustomButtonLink>
+                <CustomButtonLink
+                  to={AppRoutes.PrivacyPolicyPage}
+                  variant={Variant.Text}
+                >
+                  {t('links.privacy.text')}
                 </CustomButtonLink>
                 <ExtLink
                   text={t('links.otrHomepage.text')}
@@ -49,13 +55,16 @@ export const Footer = () => {
                   endIcon={<OpenInNewIcon />}
                   aria-label={t('links.otrHomepage.ariaLabel')}
                 />
-                <ExtLink
-                  className="footer__container--links__contact-email"
-                  href={`mailto:${translateCommon('contactEmail')}`}
-                  text={translateCommon('contactEmail')}
-                ></ExtLink>
+                <div className="footer__container__links__contact">
+                  <H3>{t('links.contact.title')}:</H3>
+                  <ExtLink
+                    className="footer__container__links__contact__email"
+                    href={`mailto:${translateCommon('contactEmail')}`}
+                    text={translateCommon('contactEmail')}
+                  ></ExtLink>
+                </div>
               </div>
-              <div className="footer__container footer__container--contact-details">
+              <div className="footer__container footer__container__contact-details">
                 <H3>{t('address.name')}</H3>
                 <br />
                 <Text>{t('address.street')}</Text>
@@ -78,10 +87,10 @@ export const Footer = () => {
             <div className="footer__logo-row">
               <Divider className="footer__logo-row__divider">
                 <OPHLogoViewer
-                  currentLang={getCurrentLang()}
-                  className="footer__container__logo--oph"
+                  className="footer__container__logo__oph"
                   direction={Direction.Vertical}
                   alt={translateCommon('ophLogo')}
+                  currentLang={getCurrentLang()}
                 />
               </Divider>
             </div>

--- a/frontend/packages/otr/src/enums/app.ts
+++ b/frontend/packages/otr/src/enums/app.ts
@@ -11,6 +11,7 @@ export enum AppRoutes {
   ClerkNewInterpreterPage = '/otr/virkailija/lisaa-tulkki',
   ClerkLocalLogoutPage = '/otr/cas/localLogout',
   AccessibilityStatementPage = '/otr/saavutettavuusseloste',
+  PrivacyPolicyPage = '/otr/tietosuojaseloste',
   NotFoundPage = '*',
 }
 

--- a/frontend/packages/otr/src/routers/AppRouter.tsx
+++ b/frontend/packages/otr/src/routers/AppRouter.tsx
@@ -1,9 +1,10 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Notifier } from 'shared/components';
 
 import { Footer } from 'components/layouts/Footer';
 import { Header } from 'components/layouts/Header';
+import { useCommonTranslation } from 'configs/i18n';
 import { AppRoutes } from 'enums/app';
 import { useAPIErrorToast } from 'hooks/useAPIErrorToast';
 import { ClerkHomePage } from 'pages/ClerkHomePage';
@@ -14,6 +15,11 @@ import { MeetingDatesPage } from 'pages/MeetingDatesPage';
 import { PublicHomePage } from 'pages/PublicHomePage';
 
 export const AppRouter: FC = () => {
+  const translateCommon = useCommonTranslation();
+
+  useEffect(() => {
+    document.title = translateCommon('appTitle');
+  }, [translateCommon]);
   useAPIErrorToast();
 
   return (

--- a/frontend/packages/otr/src/styles/components/layouts/_footer.scss
+++ b/frontend/packages/otr/src/styles/components/layouts/_footer.scss
@@ -41,23 +41,27 @@
     font-size: 1rem;
     padding: 1.5rem;
 
-    &--links,
-    &--contact-details {
+    &__links,
+    &__contact-details {
       margin-top: 3rem;
 
       @include phone {
         margin-top: 0;
       }
 
-      &__contact-email {
-        &#{&} {
-          font-weight: normal;
-          margin-top: 0.5rem;
+      &__contact {
+        margin-top: 3rem;
+
+        &__email {
+          &#{&} {
+            font-weight: normal;
+            margin-top: 0.5rem;
+          }
         }
       }
     }
 
-    &__logo--oph {
+    &__logo__oph {
       height: 8rem;
       margin: 0 4rem;
 

--- a/frontend/packages/vkt/package.json
+++ b/frontend/packages/vkt/package.json
@@ -21,6 +21,6 @@
     "vkt:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.8"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.2"
   }
 }

--- a/frontend/packages/vkt/public/i18n/fi-FI/common.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/common.json
@@ -1,6 +1,7 @@
 {
   "vkt": {
     "common": {
+      "appTitle": "Valtionhallinnon kielitutkinnot",
       "contactEmail": "kielitutkinnot@oph.fi",
       "ophLogo": "Opetushallituksen logo"
     }

--- a/frontend/packages/vkt/public/i18n/fi-FI/common.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/common.json
@@ -2,7 +2,7 @@
   "vkt": {
     "common": {
       "appTitle": "Valtionhallinnon kielitutkinnot",
-      "contactEmail": "kielitutkinnot@oph.fi",
+      "contactEmail": "vkt@oph.fi",
       "ophLogo": "Opetushallituksen logo"
     }
   }

--- a/frontend/packages/vkt/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/translation.json
@@ -20,6 +20,12 @@
           "accessibility": {
             "text": "Saavutettavuusseloste"
           },
+          "contact": {
+            "title": "Palaute ja kehitysideat"
+          },
+          "privacy": {
+            "text": "Tietosuojaseloste"
+          },
           "vktHomepage": {
             "ariaLabel": "Valtiohallinnon kielitutkinto (oph.fi), avaa uudessa välilehdessä",
             "link": "https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/valtionhallinnon-kielitutkinnot",

--- a/frontend/packages/vkt/src/components/layouts/Footer.tsx
+++ b/frontend/packages/vkt/src/components/layouts/Footer.tsx
@@ -17,71 +17,84 @@ import {
   useCommonTranslation,
 } from 'configs/i18n';
 import { AppRoutes } from 'enums/app';
-// import { useAuthentication } from 'hooks/useAuthentication';
 
 export const Footer = () => {
   const { t } = useAppTranslation({ keyPrefix: 'vkt.component.footer' });
   const translateCommon = useCommonTranslation();
-  const currentLang = getCurrentLang();
-  // const [isClerkUI] = useAuthentication();
+  const showFooter = true; // TODO: replace with authentication and current view checks
 
   return (
     <footer>
-      <Svg
-        className="footer__wave"
-        src={FooterWave}
-        alt={t('accessibility.waveAriaLabel')}
-      />
-      <Paper className="footer" elevation={3}>
-        <div className="footer__info-row">
-          <div className="footer__container footer__container--links">
-            <CustomButtonLink
-              to={AppRoutes.AccessibilityStatementPage}
-              variant={Variant.Text}
-            >
-              {t('links.accessibility.text')}
-            </CustomButtonLink>
-            <ExtLink
-              text={t('links.vktHomepage.text')}
-              href={t('links.vktHomepage.link')}
-              endIcon={<OpenInNewIcon />}
-              aria-label={t('links.vktHomepage.ariaLabel')}
-            />
-            <ExtLink
-              className="footer__container--links__contact-email"
-              href={`mailto:${translateCommon('contactEmail')}`}
-              text={translateCommon('contactEmail')}
-            ></ExtLink>
-          </div>
-          <div className="footer__container footer__container--contact-details">
-            <H3>{t('address.name')}</H3>
-            <br />
-            <Text>{t('address.street')}</Text>
-            <Text>{t('address.zipCity')}</Text>
-            <br />
-            <div className="columns gapped-xxs">
-              <Text className="inline-text">{t('address.phone.title')}</Text>
-              <ExtLink
-                className="inline-text"
-                text={t('address.phone.number')}
-                href={`tel:${t('address.phone.number')}`}
-                aria-label={t('accessibility.ophPhone')}
-              />
+      {showFooter && (
+        <>
+          <Svg
+            className="footer__wave"
+            src={FooterWave}
+            alt={t('accessibility.waveAriaLabel')}
+          />
+          <Paper className="footer" elevation={3}>
+            <div className="footer__info-row">
+              <div className="footer__container footer__container__links">
+                <CustomButtonLink
+                  to={AppRoutes.AccessibilityStatementPage}
+                  variant={Variant.Text}
+                >
+                  {t('links.accessibility.text')}
+                </CustomButtonLink>
+                <CustomButtonLink
+                  to={AppRoutes.PrivacyPolicyPage}
+                  variant={Variant.Text}
+                >
+                  {t('links.privacy.text')}
+                </CustomButtonLink>
+                <ExtLink
+                  text={t('links.vktHomepage.text')}
+                  href={t('links.vktHomepage.link')}
+                  endIcon={<OpenInNewIcon />}
+                  aria-label={t('links.vktHomepage.ariaLabel')}
+                />
+                <div className="footer__container__links__contact">
+                  <H3>{t('links.contact.title')}:</H3>
+                  <ExtLink
+                    className="footer__container__links__contact__email"
+                    href={`mailto:${translateCommon('contactEmail')}`}
+                    text={translateCommon('contactEmail')}
+                  ></ExtLink>
+                </div>
+              </div>
+              <div className="footer__container footer__container__contact-details">
+                <H3>{t('address.name')}</H3>
+                <br />
+                <Text>{t('address.street')}</Text>
+                <Text>{t('address.zipCity')}</Text>
+                <br />
+                <div className="columns gapped-xxs">
+                  <Text className="inline-text">
+                    {t('address.phone.title')}
+                  </Text>
+                  <ExtLink
+                    className="inline-text"
+                    text={t('address.phone.number')}
+                    href={`tel:${t('address.phone.number')}`}
+                    aria-label={t('accessibility.ophPhone')}
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
 
-        <div className="footer__logo-row">
-          <Divider className="footer__logo-row__divider">
-            <OPHLogoViewer
-              currentLang={currentLang}
-              className="footer__container__logo--oph"
-              direction={Direction.Vertical}
-              alt={translateCommon('ophLogo')}
-            />
-          </Divider>
-        </div>
-      </Paper>
+            <div className="footer__logo-row">
+              <Divider className="footer__logo-row__divider">
+                <OPHLogoViewer
+                  className="footer__container__logo__oph"
+                  direction={Direction.Vertical}
+                  alt={translateCommon('ophLogo')}
+                  currentLang={getCurrentLang()}
+                />
+              </Divider>
+            </div>
+          </Paper>
+        </>
+      )}
     </footer>
   );
 };

--- a/frontend/packages/vkt/src/enums/app.ts
+++ b/frontend/packages/vkt/src/enums/app.ts
@@ -5,5 +5,6 @@ export enum AppConstants {
 export enum AppRoutes {
   PublicHomePage = '/vkt/etusivu',
   AccessibilityStatementPage = '/vkt/saavutettavuusseloste',
+  PrivacyPolicyPage = '/vkt/tietosuojaseloste',
   NotFoundPage = '*',
 }

--- a/frontend/packages/vkt/src/routers/AppRouter.tsx
+++ b/frontend/packages/vkt/src/routers/AppRouter.tsx
@@ -1,18 +1,26 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { Notifier } from 'shared/components';
 
 import { Footer } from 'components/layouts/Footer';
 import { Header } from 'components/layouts/Header';
-// import { Notifier } from 'components/notification/Notifier';
+import { useCommonTranslation } from 'configs/i18n';
 import { AppRoutes } from 'enums/app';
 import { PublicHomePage } from 'pages/PublicHomePage';
 
 export const AppRouter: FC = () => {
+  const translateCommon = useCommonTranslation();
+
+  useEffect(() => {
+    document.title = translateCommon('appTitle');
+  }, [translateCommon]);
+  // TODO: useAPIErrorToast();
+
   return (
     <BrowserRouter>
       <div className="app">
         <Header />
-        {/* <Notifier /> */}
+        <Notifier />
         <main className="content" id="main-content">
           <div className="content__container">
             <Routes>

--- a/frontend/packages/vkt/src/styles/components/layouts/_footer.scss
+++ b/frontend/packages/vkt/src/styles/components/layouts/_footer.scss
@@ -41,23 +41,27 @@
     font-size: 1rem;
     padding: 1.5rem;
 
-    &--links,
-    &--contact-details {
+    &__links,
+    &__contact-details {
       margin-top: 3rem;
 
       @include phone {
         margin-top: 0;
       }
 
-      &__contact-email {
-        &#{&} {
-          font-weight: normal;
-          margin-top: 0.5rem;
+      &__contact {
+        margin-top: 3rem;
+
+        &__email {
+          &#{&} {
+            font-weight: normal;
+            margin-top: 0.5rem;
+          }
         }
       }
     }
 
-    &__logo--oph {
+    &__logo__oph {
       height: 8rem;
       margin: 0 4rem;
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2624,7 +2624,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.vkt@workspace:packages/vkt"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.8"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.2"
   languageName: unknown
   linkType: soft
 
@@ -11146,13 +11146,6 @@ __metadata:
   dependencies:
     kind-of: ^6.0.2
   checksum: 39b3dd9630a774aba288a680e7d2901f5c0eae7b8387fc5c8ea559918b29b3da144b7bdb990d7ccd9e11be05508ac9e459ce51d01fd65e583282f6ffafcba2e7
-  languageName: node
-  linkType: hard
-
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.0.8":
-  version: 1.0.8
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.0.8%2F49b847a91241b0dd5892466233f7d6f6ddd31e50"
-  checksum: 98b0da2f685bab94dce772f38eb4ab697c14fe2f9014c326b4969b66c03b154f05417a45fd4b97bfbe231dc751e0d9a55ed3a7ee1705c9f92cd8bca1ba9d6818
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Sovellusten footerin päivitetty Figman mukaisiksi. Samalla havaittu, että OTR:ssä ja VKT:ssä ei ollut kielivalintaan perustuvaa seurantaa sovelluksen nimestä ja tämä korjattu.

## Huomautukset

Jos OTR:ään ei tule tietosuojaselostetta, tuo osio footerista on helppo jälkikäteenkin poistaa.

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
