### PR TITLE
Shared(Frontend): OPHOTRKEH-146 added headerTitle attribute to PaginatedTable

### DIFF
--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.3.4] - 2022-09-16
+
+### Changed
+
+- Allow passing headerTitle to PaginatedTable
+- Added `shared:format:write` command to package.json
+
 ## [1.3.3] - 2022-09-13
 
 ### Added

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",
@@ -22,6 +22,7 @@
   "scripts": {
     "shared:eslint": "yarn g:eslint --fix \"./src/**/*.{js,jsx,ts,tsx,json}\"",
     "shared:format": "yarn g:prettier --check \"./src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
+    "shared:format:write": "yarn g:prettier --write \"./src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "shared:lint": "yarn shared:eslint && yarn shared:tslint && yarn shared:stylelint",
     "shared:stylelint": "yarn g:stylelint --fix \"./src/**/*.scss\"",
     "shared:test:jest": "yarn g:jest",

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.3.4",
+  "version": "1.3.4-test",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/components/Table/Table.tsx
+++ b/frontend/packages/shared/src/components/Table/Table.tsx
@@ -6,6 +6,7 @@ import {
 } from '@mui/material';
 import { ChangeEvent, Fragment, useEffect, useState } from 'react';
 
+import { H2 } from '../../components/Text/Text';
 import { WithId } from '../../interfaces/with';
 import './Table.scss';
 
@@ -17,6 +18,7 @@ interface PaginatedTableProps<T extends WithId> {
   className: string;
   rowsPerPageLabel: string;
   header?: JSX.Element;
+  headerTitle?: string;
   stickyHeader?: boolean;
   showBottomPagination?: boolean;
 }
@@ -31,6 +33,7 @@ export function PaginatedTable<T extends WithId>({
   stickyHeader,
   showBottomPagination = true,
   rowsPerPageLabel,
+  headerTitle,
 }: PaginatedTableProps<T>): JSX.Element {
   const PaginationDisplayedRowsLabel = ({
     from,
@@ -56,8 +59,9 @@ export function PaginatedTable<T extends WithId>({
     }
   }, [data, count]);
 
-  const Pagination = () => (
+  const Pagination = ({ showHeaderTitle }: { showHeaderTitle: boolean }) => (
     <div className="table__head-box">
+      {showHeaderTitle && <H2>{headerTitle}</H2>}
       <TablePagination
         className="table__head-box__pagination"
         count={count}
@@ -75,7 +79,7 @@ export function PaginatedTable<T extends WithId>({
 
   return (
     <>
-      <Pagination />
+      <Pagination showHeaderTitle={!!headerTitle} />
       <Table className={`${className} table`} stickyHeader={stickyHeader}>
         {header}
         <TableBody>
@@ -86,7 +90,7 @@ export function PaginatedTable<T extends WithId>({
             })}
         </TableBody>
       </Table>
-      {showBottomPagination && <Pagination />}
+      {showBottomPagination && <Pagination showHeaderTitle={false} />}
     </>
   );
 }


### PR DESCRIPTION
## Yhteenveto

Lisätty mahdollisuus asettaa otsikko `PaginatedTable` elementille "Tulokset per sivu" elementin kanssa samalle riville.

## Huomautukset

- Toteutettu https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/249 päälle
- Poistetaan ainakin `-test` versionimestä ennen mergeä jos tämä ylipäätään halutaan mergetä