### PR TITLE
VKT(Backend): OPHVKTKEH-27 virkailijan tutkintotilaisuuksien listausrajapinta

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/api/clerk/ClerkExamEventController.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/clerk/ClerkExamEventController.java
@@ -1,0 +1,27 @@
+package fi.oph.vkt.api.clerk;
+
+import fi.oph.vkt.api.dto.clerk.ClerkExamEventListDTO;
+import fi.oph.vkt.service.ClerkExamEventService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import javax.annotation.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/v1/clerk/examEvent", produces = MediaType.APPLICATION_JSON_VALUE)
+public class ClerkExamEventController {
+
+  private static final String TAG_EXAM_EVENT = "Exam event API";
+
+  @Resource
+  private ClerkExamEventService clerkExamEventService;
+
+  @GetMapping
+  @Operation(tags = TAG_EXAM_EVENT, summary = "List all exam events")
+  public List<ClerkExamEventListDTO> list() {
+    return clerkExamEventService.list();
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/clerk/ClerkUserController.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/clerk/ClerkUserController.java
@@ -1,0 +1,19 @@
+package fi.oph.vkt.api.clerk;
+
+import fi.oph.vkt.api.dto.clerk.ClerkUserDTO;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/v1/clerk/user", produces = MediaType.APPLICATION_JSON_VALUE)
+public class ClerkUserController {
+
+  @GetMapping(path = "")
+  public ClerkUserDTO currentClerkUser() {
+    final String oid = SecurityContextHolder.getContext().getAuthentication().getName();
+    return ClerkUserDTO.builder().oid(oid).build();
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkExamEventListDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkExamEventListDTO.java
@@ -1,0 +1,19 @@
+package fi.oph.vkt.api.dto.clerk;
+
+import fi.oph.vkt.model.exam.ExamLanguage;
+import fi.oph.vkt.model.exam.ExamLevel;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+public record ClerkExamEventListDTO(
+  @NonNull Long id,
+  @NonNull ExamLanguage language,
+  @NonNull ExamLevel level,
+  @NonNull LocalDate date,
+  @NonNull LocalDate registrationCloses,
+  @NonNull Integer participants,
+  @NonNull Integer maxParticipants,
+  @NonNull Boolean isPublic
+) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkUserDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkUserDTO.java
@@ -1,0 +1,7 @@
+package fi.oph.vkt.api.dto.clerk;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+public record ClerkUserDTO(@NonNull String oid) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/audit/VktOperation.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/audit/VktOperation.java
@@ -2,4 +2,6 @@ package fi.oph.vkt.audit;
 
 import fi.vm.sade.auditlog.Operation;
 
-public enum VktOperation implements Operation {}
+public enum VktOperation implements Operation {
+  LIST_EXAM_EVENTS,
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/ClerkExamEventProjection.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/ClerkExamEventProjection.java
@@ -1,0 +1,16 @@
+package fi.oph.vkt.repository;
+
+import fi.oph.vkt.model.exam.ExamLanguage;
+import fi.oph.vkt.model.exam.ExamLevel;
+import java.time.LocalDate;
+
+public record ClerkExamEventProjection(
+  long id,
+  ExamLanguage language,
+  ExamLevel level,
+  LocalDate date,
+  LocalDate registrationCloses,
+  int participants,
+  int maxParticipants,
+  boolean isVisible
+) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/ExamEventRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/ExamEventRepository.java
@@ -19,4 +19,12 @@ public interface ExamEventRepository extends JpaRepository<ExamEvent, Long> {
     " AND e.isVisible = true"
   )
   List<PublicExamEventProjection> listPublicExamEventProjections(final ExamLevel level);
+
+  // TODO: fetch information of participants
+  @Query(
+    "SELECT new fi.oph.vkt.repository.ClerkExamEventProjection(e.id, e.language, e.level, e.date," +
+    " e.registrationCloses, 0, e.maxParticipants, e.isVisible)" +
+    " FROM ExamEvent e"
+  )
+  List<ClerkExamEventProjection> listClerkExamEventProjections();
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkExamEventService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkExamEventService.java
@@ -1,0 +1,55 @@
+package fi.oph.vkt.service;
+
+import fi.oph.vkt.api.dto.clerk.ClerkExamEventListDTO;
+import fi.oph.vkt.audit.AuditService;
+import fi.oph.vkt.audit.VktOperation;
+import fi.oph.vkt.repository.ClerkExamEventProjection;
+import fi.oph.vkt.repository.ExamEventRepository;
+import fi.oph.vkt.util.DateUtil;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import javax.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ClerkExamEventService {
+
+  @Resource
+  private final ExamEventRepository examEventRepository;
+
+  @Resource
+  private final AuditService auditService;
+
+  @Transactional(readOnly = true)
+  public List<ClerkExamEventListDTO> list() {
+    final LocalDate now = LocalDate.now();
+    final List<ClerkExamEventProjection> examEventProjections = examEventRepository.listClerkExamEventProjections();
+
+    final List<ClerkExamEventListDTO> examEventListDTOs = examEventProjections
+      .stream()
+      .map(e -> {
+        final boolean isPublic = e.isVisible() && DateUtil.isBeforeOrEqualTo(now, e.registrationCloses());
+
+        return ClerkExamEventListDTO
+          .builder()
+          .id(e.id())
+          .language(e.language())
+          .level(e.level())
+          .date(e.date())
+          .registrationCloses(e.registrationCloses())
+          .participants(e.participants())
+          .maxParticipants(e.maxParticipants())
+          .isPublic(isPublic)
+          .build();
+      })
+      .sorted(Comparator.comparing(ClerkExamEventListDTO::date).thenComparing(ClerkExamEventListDTO::language))
+      .toList();
+
+    auditService.logOperation(VktOperation.LIST_EXAM_EVENTS);
+    return examEventListDTOs;
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/DateUtil.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/DateUtil.java
@@ -1,0 +1,12 @@
+package fi.oph.vkt.util;
+
+import java.time.LocalDate;
+
+public class DateUtil {
+
+  public static boolean isBeforeOrEqualTo(final LocalDate date1, final LocalDate date2) {
+    assert date1 != null && date2 != null;
+
+    return !date1.isAfter(date2);
+  }
+}

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/ClerkExamEventServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/ClerkExamEventServiceTest.java
@@ -1,0 +1,124 @@
+package fi.oph.vkt.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import fi.oph.vkt.Factory;
+import fi.oph.vkt.api.dto.clerk.ClerkExamEventListDTO;
+import fi.oph.vkt.audit.AuditService;
+import fi.oph.vkt.audit.VktOperation;
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.exam.ExamLanguage;
+import fi.oph.vkt.repository.ExamEventRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+import javax.annotation.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WithMockUser
+@DataJpaTest
+public class ClerkExamEventServiceTest {
+
+  @Resource
+  private ExamEventRepository examEventRepository;
+
+  @MockBean
+  private AuditService auditService;
+
+  @Resource
+  private TestEntityManager entityManager;
+
+  private ClerkExamEventService clerkExamEventService;
+
+  @BeforeEach
+  public void setup() {
+    clerkExamEventService = new ClerkExamEventService(examEventRepository, auditService);
+  }
+
+  @Test
+  public void testListExamEvents() {
+    final LocalDate now = LocalDate.now();
+
+    final ExamEvent pastEvent = Factory.examEvent();
+    pastEvent.setDate(now.minusWeeks(3));
+    pastEvent.setRegistrationCloses(now.minusWeeks(4));
+
+    final ExamEvent eventToday = Factory.examEvent(ExamLanguage.FI);
+    eventToday.setDate(now);
+
+    final ExamEvent eventWithRegistrationClosed = Factory.examEvent();
+    eventWithRegistrationClosed.setDate(now.plusDays(3));
+    eventWithRegistrationClosed.setRegistrationCloses(now.minusDays(1));
+
+    final ExamEvent hiddenEvent = Factory.examEvent();
+    hiddenEvent.setVisible(false);
+    hiddenEvent.setDate(now.plusWeeks(1));
+
+    final ExamEvent upcomingEventSv = Factory.examEvent(ExamLanguage.SV);
+    final ExamEvent upcomingEventFi = Factory.examEvent(ExamLanguage.FI);
+
+    final ExamEvent futureEvent = Factory.examEvent(ExamLanguage.FI);
+    futureEvent.setDate(now.plusWeeks(3));
+    futureEvent.setRegistrationCloses(now.plusWeeks(2));
+
+    entityManager.persist(pastEvent);
+    entityManager.persist(eventToday);
+    entityManager.persist(eventWithRegistrationClosed);
+    entityManager.persist(hiddenEvent);
+    entityManager.persist(upcomingEventSv);
+    entityManager.persist(upcomingEventFi);
+    entityManager.persist(futureEvent);
+
+    final List<ClerkExamEventListDTO> examEventListDTOs = clerkExamEventService.list();
+    assertEquals(7, examEventListDTOs.size());
+
+    final List<ExamEvent> expectedExamEventsOrdered = List.of(
+      pastEvent,
+      eventToday,
+      eventWithRegistrationClosed,
+      hiddenEvent,
+      upcomingEventFi,
+      upcomingEventSv,
+      futureEvent
+    );
+    assertCorrectOrdering(expectedExamEventsOrdered, examEventListDTOs);
+
+    IntStream
+      .range(0, expectedExamEventsOrdered.size())
+      .forEach(i -> {
+        assertExamEventListDTODetails(expectedExamEventsOrdered.get(i), examEventListDTOs.get(i));
+
+        final boolean expectedIsPublic = i == 1 || i >= 4;
+        assertEquals(expectedIsPublic, examEventListDTOs.get(i).isPublic());
+      });
+
+    verify(auditService).logOperation(VktOperation.LIST_EXAM_EVENTS);
+    verifyNoMoreInteractions(auditService);
+  }
+
+  private void assertCorrectOrdering(
+    final List<ExamEvent> expectedExamEventsOrdered,
+    final List<ClerkExamEventListDTO> examEventsListDTOs
+  ) {
+    final List<Long> expectedOrdering = expectedExamEventsOrdered.stream().map(ExamEvent::getId).toList();
+    final List<Long> actualOrdering = examEventsListDTOs.stream().map(ClerkExamEventListDTO::id).toList();
+
+    assertEquals(expectedOrdering, actualOrdering);
+  }
+
+  private void assertExamEventListDTODetails(final ExamEvent expected, final ClerkExamEventListDTO examEventListDTO) {
+    assertEquals(expected.getId(), examEventListDTO.id());
+    assertEquals(expected.getLanguage(), examEventListDTO.language());
+    assertEquals(expected.getLevel(), examEventListDTO.level());
+    assertEquals(expected.getDate(), examEventListDTO.date());
+    assertEquals(expected.getRegistrationCloses(), examEventListDTO.registrationCloses());
+    assertEquals(expected.getMaxParticipants(), examEventListDTO.maxParticipants());
+  }
+}

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicExamEventServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicExamEventServiceTest.java
@@ -75,8 +75,8 @@ public class PublicExamEventServiceTest {
     entityManager.persist(futureEvent1);
     entityManager.persist(futureEvent2);
 
-    final List<PublicExamEventDTO> examEventsDTOs = publicExamEventService.listExamEvents(ExamLevel.EXCELLENT);
-    assertEquals(5, examEventsDTOs.size());
+    final List<PublicExamEventDTO> examEventDTOs = publicExamEventService.listExamEvents(ExamLevel.EXCELLENT);
+    assertEquals(5, examEventDTOs.size());
 
     final List<ExamEvent> expectedExamEventsOrdered = List.of(
       eventToday,
@@ -85,19 +85,19 @@ public class PublicExamEventServiceTest {
       futureEvent1,
       futureEvent2
     );
-    assertCorrectOrdering(expectedExamEventsOrdered, examEventsDTOs);
+    assertCorrectOrdering(expectedExamEventsOrdered, examEventDTOs);
 
     IntStream
       .range(0, expectedExamEventsOrdered.size())
-      .forEach(i -> assertExamEventDetails(expectedExamEventsOrdered.get(i), examEventsDTOs.get(i)));
+      .forEach(i -> assertExamEventDetails(expectedExamEventsOrdered.get(i), examEventDTOs.get(i)));
   }
 
   private void assertCorrectOrdering(
     final List<ExamEvent> expectedExamEventsOrdered,
-    final List<PublicExamEventDTO> examEventsDTOs
+    final List<PublicExamEventDTO> examEventDTOs
   ) {
     final List<Long> expectedOrdering = expectedExamEventsOrdered.stream().map(ExamEvent::getId).toList();
-    final List<Long> actualOrdering = examEventsDTOs.stream().map(PublicExamEventDTO::id).toList();
+    final List<Long> actualOrdering = examEventDTOs.stream().map(PublicExamEventDTO::id).toList();
 
     assertEquals(expectedOrdering, actualOrdering);
   }


### PR DESCRIPTION
## Yhteenveto

Toteutettu listausrajapinta tutkintotilaisuuksille virkailijakäyttöliittymää varten. Rajapinta ei palauta osallistujatietoja, vaan siirryttäessä tarkastelemaan yksittäisen tutkintotilaisuuden tietoja, tehdään erillinen pyyntö backendille tietojen hakemiseksi.

Lisätty myös rajapinta autentikointitarkistusta varten.

## Check-lista

- [x] Testattu docker-compose:lla