### PR TITLE
OTR(Frontend): OPHOTRKEH-147 & -157 julkisen käyttöliittymän parannuksia

### DIFF
--- a/frontend/packages/otr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/otr/public/i18n/en-GB/translation.json
@@ -217,22 +217,17 @@
           "search": "Show results"
         },
         "languagePair": {
-          "fromAriaLabel": "Source language, mandatory for contacting",
+          "fromAriaLabel": "Source language",
           "fromHelperText": "Select language",
           "fromPlaceholder": "Source language",
           "title": "Search by language pair",
-          "toAriaLabel": "Target language, mandatory for contacting",
+          "toAriaLabel": "Target language",
           "toHelperText": "Select language",
           "toPlaceholder": "Target language"
         },
         "region": {
           "placeholder": "Operating area",
           "title": "Search by legal interpreter's operating area"
-        },
-        "toasts": {
-          "contactRequestNeedsLanguagePairs": "Select a language pair for contacting a translator",
-          "interpreterSelected": "You can select only one language pair for contacting",
-          "selectLanguagePair": "Select a language pair"
         }
       },
       "publicInterpreterListing": {

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -221,22 +221,17 @@
           "search": "Näytä tulokset"
         },
         "languagePair": {
-          "fromAriaLabel": "Mistä, pakollinen yhteydenottamista varten",
+          "fromAriaLabel": "Mistä",
           "fromHelperText": "Valitse kieli",
           "fromPlaceholder": "Mistä",
           "title": "Haku kieliparilla",
-          "toAriaLabel": "Mihin, pakollinen yhteydenottamista varten",
+          "toAriaLabel": "Mihin",
           "toHelperText": "Valitse kieli",
           "toPlaceholder": "Mihin"
         },
         "region": {
           "placeholder": "Toiminta-alue",
           "title": "Haku oikeustulkin toiminta-alueella"
-        },
-        "toasts": {
-          "contactRequestNeedsLanguagePairs": "Valitse kielipari ottaaksesi yhteyttä kääntäjään",
-          "interpreterSelected": "Voit valita vain yhden kieliparin yhteydenottoon",
-          "selectLanguagePair": "Valitse kielipari"
         }
       },
       "publicInterpreterListing": {

--- a/frontend/packages/otr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/translation.json
@@ -217,22 +217,17 @@
           "search": "Visa resultat"
         },
         "languagePair": {
-          "fromAriaLabel": "Från, obligatorisk för att ta kontakt",
+          "fromAriaLabel": "Från",
           "fromHelperText": "Välj språk",
           "fromPlaceholder": "Från",
           "title": "Sök med språkpar",
-          "toAriaLabel": "Till, obligatoriskt för att ta kontakt",
+          "toAriaLabel": "Till",
           "toHelperText": "Välj språk",
           "toPlaceholder": "Till"
         },
         "region": {
           "placeholder": "Verksamhetsområde",
           "title": "Sök med rättstolkens verksamhetsområde"
-        },
-        "toasts": {
-          "contactRequestNeedsLanguagePairs": "Välj språkpar för att kontakta en translator",
-          "interpreterSelected": "Du kan endast välja ett språkpar för att ta kontakt",
-          "selectLanguagePair": "Välj språkpar"
         }
       },
       "publicInterpreterListing": {

--- a/frontend/packages/otr/src/components/publicInterpreter/listing/row/Cells.tsx
+++ b/frontend/packages/otr/src/components/publicInterpreter/listing/row/Cells.tsx
@@ -9,6 +9,11 @@ import {
 import { PublicInterpreter } from 'interfaces/publicInterpreter';
 import { RegionUtils } from 'utils/regions';
 
+const mapRegionsToTextElements = (regions: Array<string>) =>
+  RegionUtils.translateRegions(regions)
+    .sort()
+    .map((translation, k) => <Text key={k}>{translation}</Text>);
+
 export const PublicInterpreterPhoneCells = ({
   isOpen,
   interpreter,
@@ -40,7 +45,7 @@ export const PublicInterpreterPhoneCells = ({
             </div>
             <div>
               <H3>{t('header.region')}</H3>
-              <Text>{RegionUtils.translateAndConcatRegions(regions)}</Text>
+              {mapRegionsToTextElements(regions)}
             </div>
           </div>
         </div>
@@ -77,9 +82,7 @@ export const PublicInterpreterDesktopCells = ({
           </Text>
         ))}
       </TableCell>
-      <TableCell>
-        <Text>{RegionUtils.translateAndConcatRegions(regions)}</Text>
-      </TableCell>
+      <TableCell>{mapRegionsToTextElements(regions)}</TableCell>
     </>
   );
 };

--- a/frontend/packages/otr/src/components/publicInterpreter/listing/row/CollapsibleRow.tsx
+++ b/frontend/packages/otr/src/components/publicInterpreter/listing/row/CollapsibleRow.tsx
@@ -1,13 +1,10 @@
 import { Collapse, TableCell, TableRow } from '@mui/material';
-import { ExtLink, Text } from 'shared/components';
+import { Text } from 'shared/components';
 import { useWindowProperties } from 'shared/hooks';
 import { StringUtils } from 'shared/utils';
 
 import { useAppTranslation } from 'configs/i18n';
 import { PublicInterpreter } from 'interfaces/publicInterpreter';
-
-// Helpers
-const PLACEHOLDER_TEXT = '-';
 
 enum AdditionalDetailsField {
   Email = 'email',
@@ -16,32 +13,20 @@ enum AdditionalDetailsField {
 }
 
 const AdditionalContactDetail = ({
-  field,
   label,
-  contactDetail,
+  value,
 }: {
-  field: AdditionalDetailsField;
   label: string;
-  contactDetail: string;
+  value: string;
 }) => {
   const { isPhone } = useWindowProperties();
-  const linkPrefix = field === AdditionalDetailsField.Email ? 'mailto' : 'tel';
 
   return (
     <div className="public-interpreter-listing-row__additional-contact-details__box">
       <Text className="bold">{isPhone ? label : `${label}: `}</Text>
-      {field === AdditionalDetailsField.OtherContactInfo ||
-      contactDetail === PLACEHOLDER_TEXT ? (
-        <Text className="public-interpreter-listing-row__additional-contact-details__text">
-          {contactDetail}
-        </Text>
-      ) : (
-        <ExtLink
-          className="public-interpreter-listing-row__additional-contact-details__link"
-          text={contactDetail}
-          href={`${linkPrefix}:${contactDetail}`}
-        />
-      )}
+      <Text className="public-interpreter-listing-row__additional-contact-details__text">
+        {value}
+      </Text>
     </div>
   );
 };
@@ -60,9 +45,8 @@ export const CollapsibleRow = ({
   const numOfCells = isPhone ? 0 : 3;
 
   const getAdditionalContactDetailProps = (field: AdditionalDetailsField) => ({
-    field,
     label: t(`row.additionalContactDetail.${field}`),
-    contactDetail: StringUtils.getWithPlaceholder(interpreter[field]),
+    value: StringUtils.getWithPlaceholder(interpreter[field]),
   });
 
   return (

--- a/frontend/packages/otr/src/styles/components/publicInterpreter/_public-interpreter-listing.scss
+++ b/frontend/packages/otr/src/styles/components/publicInterpreter/_public-interpreter-listing.scss
@@ -49,16 +49,6 @@
         gap: 1rem;
       }
 
-      & &__link {
-        display: inline-block;
-        font-size: 1.6rem;
-        font-weight: normal;
-        justify-self: flex-start;
-        padding: 0;
-        text-transform: lowercase;
-      }
-
-      & &__link,
       & &__text {
         @include phone {
           padding-left: 0.5rem;

--- a/frontend/packages/otr/src/utils/regions.ts
+++ b/frontend/packages/otr/src/utils/regions.ts
@@ -4,6 +4,20 @@ import { ComboBoxOption } from 'shared/interfaces';
 import { translateOutsideComponent } from 'configs/i18n';
 
 export class RegionUtils {
+  static translateRegions(regions: Array<string>) {
+    if (regions.length > 0) {
+      return regions.map((r) => RegionUtils.translateRegion(r));
+    }
+
+    const t = translateOutsideComponent();
+
+    return [
+      t('otr.common.allRegions', {
+        ns: I18nNamespace.Common,
+      }),
+    ];
+  }
+
   static translateRegion(region: string) {
     const t = translateOutsideComponent();
 
@@ -22,22 +36,6 @@ export class RegionUtils {
     );
 
     return regionValues.sort(RegionUtils.compareOptionsByLabel);
-  }
-
-  static translateAndConcatRegions(regions: Array<string>) {
-    const t = translateOutsideComponent();
-
-    if (regions.length > 0) {
-      const translatedRegions = regions.map((r) =>
-        RegionUtils.translateRegion(r)
-      );
-
-      return translatedRegions.join(', ');
-    }
-
-    return t('otr.common.allRegions', {
-      ns: I18nNamespace.Common,
-    });
   }
 
   private static compareOptionsByLabel(a: ComboBoxOption, b: ComboBoxOption) {


### PR DESCRIPTION
## Yhteenveto

- Toiminta-alueet listataan allekkain ja aakkosjärjestyksessä
- Linkit poistettu tulkin yhteystietojen sähköposti- ja puhelinnumerokentistä etusivulla

Molemmat sovittu Niklaksen kanssa.

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
