### PR TITLE
AKR:OTR:Shared(Frontend): primary options for LanguageSelect in props

### DIFF
--- a/frontend/packages/akr/package.json
+++ b/frontend/packages/akr/package.json
@@ -22,6 +22,6 @@
     "akr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.4"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.7"
   }
 }

--- a/frontend/packages/akr/src/components/clerkTranslator/add/AddAuthorisation.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/add/AddAuthorisation.tsx
@@ -217,10 +217,11 @@ export const AddAuthorisation = ({
               autoHighlight
               label={t('fieldPlaceholders.from')}
               variant={TextFieldVariant.Outlined}
-              languages={AuthorisationUtils.getKoodistoLangKeys()}
-              excludedLanguage={authorisation.languagePair.to || undefined}
               value={getLanguageSelectValue(authorisation.languagePair.from)}
               onChange={handleLanguageSelectChange('from')}
+              languages={AuthorisationUtils.getKoodistoLangKeys()}
+              excludedLanguage={authorisation.languagePair.to}
+              primaryLanguages={AuthorisationUtils.primaryLangs}
               translateLanguage={translateLanguage}
             />
           </div>
@@ -231,10 +232,11 @@ export const AddAuthorisation = ({
               autoHighlight
               label={t('fieldPlaceholders.to')}
               variant={TextFieldVariant.Outlined}
-              languages={AuthorisationUtils.getKoodistoLangKeys()}
-              excludedLanguage={authorisation.languagePair.from || undefined}
               value={getLanguageSelectValue(authorisation.languagePair.to)}
               onChange={handleLanguageSelectChange('to')}
+              languages={AuthorisationUtils.getKoodistoLangKeys()}
+              excludedLanguage={authorisation.languagePair.from}
+              primaryLanguages={AuthorisationUtils.primaryLangs}
               translateLanguage={translateLanguage}
             />
           </div>

--- a/frontend/packages/akr/src/components/clerkTranslator/add/AddAuthorisation.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/add/AddAuthorisation.tsx
@@ -219,9 +219,12 @@ export const AddAuthorisation = ({
               variant={TextFieldVariant.Outlined}
               value={getLanguageSelectValue(authorisation.languagePair.from)}
               onChange={handleLanguageSelectChange('from')}
-              languages={AuthorisationUtils.getKoodistoLangKeys()}
-              excludedLanguage={authorisation.languagePair.to}
+              languages={AuthorisationUtils.selectableLanguagesForLanguageFilter(
+                AuthorisationUtils.getKoodistoLangKeys(),
+                authorisation.languagePair.to
+              )}
               primaryLanguages={AuthorisationUtils.primaryLangs}
+              excludedLanguage={authorisation.languagePair.to}
               translateLanguage={translateLanguage}
             />
           </div>
@@ -234,9 +237,12 @@ export const AddAuthorisation = ({
               variant={TextFieldVariant.Outlined}
               value={getLanguageSelectValue(authorisation.languagePair.to)}
               onChange={handleLanguageSelectChange('to')}
-              languages={AuthorisationUtils.getKoodistoLangKeys()}
-              excludedLanguage={authorisation.languagePair.from}
+              languages={AuthorisationUtils.selectableLanguagesForLanguageFilter(
+                AuthorisationUtils.getKoodistoLangKeys(),
+                authorisation.languagePair.from
+              )}
               primaryLanguages={AuthorisationUtils.primaryLangs}
+              excludedLanguage={authorisation.languagePair.from}
               translateLanguage={translateLanguage}
             />
           </div>

--- a/frontend/packages/akr/src/components/clerkTranslator/filters/ClerkTranslatorAutocompleteFilters.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/filters/ClerkTranslatorAutocompleteFilters.tsx
@@ -21,6 +21,7 @@ import { PermissionToPublish } from 'enums/app';
 import { ClerkTranslatorFilter } from 'interfaces/clerkTranslator';
 import { addClerkTranslatorFilter } from 'redux/reducers/clerkTranslator';
 import { clerkTranslatorsSelector } from 'redux/selectors/clerkTranslator';
+import { AuthorisationUtils } from 'utils/authorisation';
 
 export const ClerkTranslatorAutocompleteFilters = () => {
   const { t } = useAppTranslation({
@@ -85,22 +86,24 @@ export const ClerkTranslatorAutocompleteFilters = () => {
             autoHighlight
             data-testid="clerk-translator-filters__from-lang"
             label={t('languagePair.fromPlaceholder')}
-            excludedLanguage={filters.toLang}
             value={getLanguageSelectValue(filters.fromLang)}
-            languages={langs.from}
             variant={TextFieldVariant.Outlined}
             onChange={handleFilterChange('fromLang')}
+            languages={langs.from}
+            excludedLanguage={filters.toLang}
+            primaryLanguages={AuthorisationUtils.primaryLangs}
             translateLanguage={translateLanguage}
           />
           <LanguageSelect
             autoHighlight
             data-testid="clerk-translator-filters__to-lang"
             label={t('languagePair.toPlaceholder')}
-            excludedLanguage={filters.fromLang}
             value={getLanguageSelectValue(filters.toLang)}
-            languages={langs.to}
             variant={TextFieldVariant.Outlined}
             onChange={handleFilterChange('toLang')}
+            languages={langs.to}
+            excludedLanguage={filters.fromLang}
+            primaryLanguages={AuthorisationUtils.primaryLangs}
             translateLanguage={translateLanguage}
           />
         </div>

--- a/frontend/packages/akr/src/components/clerkTranslator/filters/ClerkTranslatorAutocompleteFilters.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/filters/ClerkTranslatorAutocompleteFilters.tsx
@@ -89,9 +89,12 @@ export const ClerkTranslatorAutocompleteFilters = () => {
             value={getLanguageSelectValue(filters.fromLang)}
             variant={TextFieldVariant.Outlined}
             onChange={handleFilterChange('fromLang')}
-            languages={langs.from}
-            excludedLanguage={filters.toLang}
+            languages={AuthorisationUtils.selectableLanguagesForLanguageFilter(
+              langs.from,
+              filters.toLang
+            )}
             primaryLanguages={AuthorisationUtils.primaryLangs}
+            excludedLanguage={filters.toLang}
             translateLanguage={translateLanguage}
           />
           <LanguageSelect
@@ -101,9 +104,12 @@ export const ClerkTranslatorAutocompleteFilters = () => {
             value={getLanguageSelectValue(filters.toLang)}
             variant={TextFieldVariant.Outlined}
             onChange={handleFilterChange('toLang')}
-            languages={langs.to}
-            excludedLanguage={filters.fromLang}
+            languages={AuthorisationUtils.selectableLanguagesForLanguageFilter(
+              langs.to,
+              filters.fromLang
+            )}
             primaryLanguages={AuthorisationUtils.primaryLangs}
+            excludedLanguage={filters.fromLang}
             translateLanguage={translateLanguage}
           />
         </div>

--- a/frontend/packages/akr/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
+++ b/frontend/packages/akr/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
@@ -279,9 +279,12 @@ export const PublicTranslatorFilters = ({
               aria-label={`${t('languagePair.fromAriaLabel')}`}
               disabled={isLangFilterDisabled}
               onKeyUp={handleKeyUp}
-              languages={langs.from}
-              excludedLanguage={filters.toLang}
+              languages={AuthorisationUtils.selectableLanguagesForLanguageFilter(
+                langs.from,
+                filters.toLang
+              )}
               primaryLanguages={AuthorisationUtils.primaryLangs}
+              excludedLanguage={filters.toLang}
               translateLanguage={translateLanguage}
             />
             <LanguageSelect
@@ -294,9 +297,12 @@ export const PublicTranslatorFilters = ({
               aria-label={`${t('languagePair.toAriaLabel')}`}
               disabled={isLangFilterDisabled}
               onKeyUp={handleKeyUp}
-              languages={langs.to}
-              excludedLanguage={filters.fromLang}
+              languages={AuthorisationUtils.selectableLanguagesForLanguageFilter(
+                langs.to,
+                filters.fromLang
+              )}
               primaryLanguages={AuthorisationUtils.primaryLangs}
+              excludedLanguage={filters.fromLang}
               translateLanguage={translateLanguage}
             />
           </Box>

--- a/frontend/packages/akr/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
+++ b/frontend/packages/akr/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
@@ -50,6 +50,7 @@ import {
   filterPublicTranslators,
   publicTranslatorsSelector,
 } from 'redux/selectors/publicTranslator';
+import { AuthorisationUtils } from 'utils/authorisation';
 
 export const PublicTranslatorFilters = ({
   showTable,
@@ -275,11 +276,12 @@ export const PublicTranslatorFilters = ({
               label={t('languagePair.fromPlaceholder')}
               placeholder={t('languagePair.fromPlaceholder')}
               id="filters-from-lang"
-              excludedLanguage={filters.toLang}
-              languages={langs.from}
               aria-label={`${t('languagePair.fromAriaLabel')}`}
               disabled={isLangFilterDisabled}
               onKeyUp={handleKeyUp}
+              languages={langs.from}
+              excludedLanguage={filters.toLang}
+              primaryLanguages={AuthorisationUtils.primaryLangs}
               translateLanguage={translateLanguage}
             />
             <LanguageSelect
@@ -289,11 +291,12 @@ export const PublicTranslatorFilters = ({
               label={t('languagePair.toPlaceholder')}
               placeholder={t('languagePair.toPlaceholder')}
               id="filters-to-lang"
-              excludedLanguage={filters.fromLang}
-              languages={langs.to}
               aria-label={`${t('languagePair.toAriaLabel')}`}
               disabled={isLangFilterDisabled}
               onKeyUp={handleKeyUp}
+              languages={langs.to}
+              excludedLanguage={filters.fromLang}
+              primaryLanguages={AuthorisationUtils.primaryLangs}
               translateLanguage={translateLanguage}
             />
           </Box>

--- a/frontend/packages/akr/src/tests/cypress/fixtures/json/public_translators_50.json
+++ b/frontend/packages/akr/src/tests/cypress/fixtures/json/public_translators_50.json
@@ -1,7 +1,7 @@
 {
   "langs": {
-    "from": ["DE", "ET", "FI", "FR", "RU", "SV"],
-    "to": ["DE", "ET", "FI", "FR", "RU", "SV"]
+    "from": ["DE", "ET", "FI", "FR", "RU", "SEIN", "SEPO", "SV"],
+    "to": ["DE", "ET", "FI", "FR", "IT", "RU", "SEKO", "SV"]
   },
   "towns": [
     { "name": "Helsinki" },
@@ -843,6 +843,14 @@
         {
           "from": "FI",
           "to": "SV"
+        },
+        {
+          "from": "SEIN",
+          "to": "SV"
+        },
+        {
+          "from": "FI",
+          "to": "IT"
         }
       ],
       "lastName": "Karjalainen"
@@ -858,6 +866,10 @@
         {
           "from": "SV",
           "to": "FI"
+        },
+        {
+          "from": "SEPO",
+          "to": "SEKO"
         }
       ],
       "lastName": "Kinnunen"

--- a/frontend/packages/akr/src/tests/cypress/integration/public_translator.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/public_translator.spec.ts
@@ -1,8 +1,5 @@
 import { APIEndpoints } from 'enums/api';
-import {
-  compulsoryLangs,
-  onPublicTranslatorFilters,
-} from 'tests/cypress/support/page-objects/publicTranslatorFilters';
+import { onPublicTranslatorFilters } from 'tests/cypress/support/page-objects/publicTranslatorFilters';
 import { onPublicTranslatorsListing } from 'tests/cypress/support/page-objects/publicTranslatorsListing';
 import { onToast } from 'tests/cypress/support/page-objects/toast';
 import { runWithIntercept } from 'tests/cypress/support/utils/api';
@@ -49,14 +46,48 @@ describe('PublicTranslatorFilters', () => {
     onPublicTranslatorsListing.expectEmptyListing();
   });
 
-  it('it should provide only compulsory languages as toLang options if the fromLang field has a different value', () => {
-    onPublicTranslatorFilters.selectFromLangByName('viro');
-    onPublicTranslatorFilters.expectToLangSelectValues(compulsoryLangs);
+  it('it should provide all other languages under langs.to as toLang options if fromLang is a primary language', () => {
+    onPublicTranslatorFilters.selectFromLangByName('ruotsi');
+
+    const selectableLangs = [
+      'suomi',
+      'koltansaame',
+      'italia',
+      'ranska',
+      'saksa',
+      'venäjä',
+      'viro',
+    ];
+    onPublicTranslatorFilters.expectToLangSelectValues(selectableLangs);
   });
 
-  it('it should provide only compulsory languages as fromLang options if the toLang field has a different value', () => {
+  it('it should provide only primary languages under langs.to as toLang options if fromLang is a secondary language', () => {
+    onPublicTranslatorFilters.selectFromLangByName('saksa');
+
+    const selectableLangs = ['suomi', 'ruotsi', 'koltansaame'];
+    onPublicTranslatorFilters.expectToLangSelectValues(selectableLangs);
+  });
+
+  it('it should provide all other languages under langs.from as fromLang options if toLang is a primary language', () => {
+    onPublicTranslatorFilters.selectToLangByName('suomi');
+
+    const selectableLangs = [
+      'ruotsi',
+      'inarinsaame',
+      'pohjoissaame',
+      'ranska',
+      'saksa',
+      'venäjä',
+      'viro',
+    ];
+    onPublicTranslatorFilters.expectFromLangSelectValues(selectableLangs);
+  });
+
+  it('it should provide only primary languages under langs.from as fromLang options if toLang is a secondary language', () => {
     onPublicTranslatorFilters.selectToLangByName('viro');
-    onPublicTranslatorFilters.expectFromLangSelectValues(compulsoryLangs);
+
+    const selectableLangs = ['suomi', 'ruotsi', 'inarinsaame', 'pohjoissaame'];
+    onPublicTranslatorFilters.expectFromLangSelectValues(selectableLangs);
   });
 
   it('it should show a toast notification when language pair is not defined, and a row is clicked', () => {

--- a/frontend/packages/akr/src/tests/cypress/support/page-objects/publicTranslatorFilters.ts
+++ b/frontend/packages/akr/src/tests/cypress/support/page-objects/publicTranslatorFilters.ts
@@ -1,4 +1,7 @@
-export const compulsoryLangs = ['suomi', 'ruotsi'];
+const expectOpenLangSelectValues = (values) => {
+  cy.findAllByRole('option').should('have.length', values.length);
+  values.forEach((value) => cy.findAllByRole('listbox').contains(value));
+};
 
 class PublicTranslatorFilters {
   elements = {
@@ -85,13 +88,12 @@ class PublicTranslatorFilters {
 
   expectFromLangSelectValues(values: Array<string>) {
     this.clickFromLang();
-    cy.findAllByRole('option').should('have.length', values.length);
-    values.forEach((value) => cy.findAllByRole('listbox').contains(value));
+    expectOpenLangSelectValues(values);
   }
+
   expectToLangSelectValues(values: Array<string>) {
     this.clickToLang();
-    cy.findAllByRole('option').should('have.length', values.length);
-    values.forEach((value) => cy.findAllByRole('listbox').contains(value));
+    expectOpenLangSelectValues(values);
   }
 }
 

--- a/frontend/packages/akr/src/utils/authorisation.ts
+++ b/frontend/packages/akr/src/utils/authorisation.ts
@@ -3,6 +3,8 @@ import { ClerkTranslatorAuthorisations } from 'interfaces/clerkTranslator';
 import koodistoLangsFI from 'public/i18n/koodisto/langs/koodisto_langs_fi-FI.json';
 
 export class AuthorisationUtils {
+  static primaryLangs = ['FI', 'SV', 'SEIN', 'SEKO', 'SEPO'];
+
   static isEffective(
     { id }: Authorisation,
     { effective }: ClerkTranslatorAuthorisations

--- a/frontend/packages/akr/src/utils/authorisation.ts
+++ b/frontend/packages/akr/src/utils/authorisation.ts
@@ -5,6 +5,17 @@ import koodistoLangsFI from 'public/i18n/koodisto/langs/koodisto_langs_fi-FI.jso
 export class AuthorisationUtils {
   static primaryLangs = ['FI', 'SV', 'SEIN', 'SEKO', 'SEPO'];
 
+  static selectableLanguagesForLanguageFilter(
+    languages: Array<string>,
+    otherLanguage?: string
+  ) {
+    if (!otherLanguage || this.primaryLangs.includes(otherLanguage)) {
+      return languages;
+    }
+
+    return this.primaryLangs.filter((lang) => languages.includes(lang));
+  }
+
   static isEffective(
     { id }: Authorisation,
     { effective }: ClerkTranslatorAuthorisations

--- a/frontend/packages/otr/package.json
+++ b/frontend/packages/otr/package.json
@@ -25,6 +25,6 @@
     "otr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.3"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.7"
   }
 }

--- a/frontend/packages/otr/src/components/clerkInterpreter/add/AddQualification.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/add/AddQualification.tsx
@@ -42,7 +42,7 @@ interface NewQualification
 }
 
 const newQualification: NewQualification = {
-  fromLang: 'FI',
+  fromLang: QualificationUtils.defaultFromLang,
   toLang: '',
   examinationType: undefined as unknown as ExaminationType,
   beginDate: undefined,
@@ -180,10 +180,11 @@ export const AddQualification = ({
               autoHighlight
               label={t('fieldPlaceholders.from')}
               variant={TextFieldVariant.Outlined}
-              languages={['FI']}
-              excludedLanguage={qualification.toLang || undefined}
               value={getLanguageSelectValue(qualification.fromLang)}
+              disabled={true}
               onChange={handleLanguageSelectChange('fromLang')}
+              languages={QualificationUtils.selectableFromLangs}
+              excludedLanguage={qualification.toLang}
               translateLanguage={translateLanguage}
             />
           </div>
@@ -194,10 +195,10 @@ export const AddQualification = ({
               autoHighlight
               label={t('fieldPlaceholders.to')}
               variant={TextFieldVariant.Outlined}
-              languages={QualificationUtils.getKoodistoLangKeys()}
-              excludedLanguage={qualification.fromLang || undefined}
               value={getLanguageSelectValue(qualification.toLang)}
               onChange={handleLanguageSelectChange('toLang')}
+              languages={QualificationUtils.getKoodistoLangKeys()}
+              excludedLanguage={qualification.fromLang}
               translateLanguage={translateLanguage}
             />
           </div>

--- a/frontend/packages/otr/src/components/clerkInterpreter/filters/ClerkInterpreterAutocompleteFilters.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/filters/ClerkInterpreterAutocompleteFilters.tsx
@@ -21,6 +21,7 @@ import { ExaminationType, PermissionToPublish } from 'enums/interpreter';
 import { ClerkInterpreterFilters } from 'interfaces/clerkInterpreter';
 import { addClerkInterpreterFilter } from 'redux/reducers/clerkInterpreter';
 import { clerkInterpretersSelector } from 'redux/selectors/clerkInterpreter';
+import { QualificationUtils } from 'utils/qualifications';
 
 export const ClerkInterpreterAutocompleteFilters = () => {
   const { t } = useAppTranslation({
@@ -87,23 +88,23 @@ export const ClerkInterpreterAutocompleteFilters = () => {
             autoHighlight
             data-testid="clerk-interpreter-filters__from-lang"
             label={t('languagePair.fromPlaceholder')}
-            excludedLanguage={filters.toLang}
             value={getLanguageSelectValue(filters.fromLang)}
-            languages={[filters.fromLang || '']}
             disabled={true}
             variant={TextFieldVariant.Outlined}
             onChange={handleFilterChange('fromLang')}
+            languages={QualificationUtils.selectableFromLangs}
+            excludedLanguage={filters.toLang}
             translateLanguage={translateLanguage}
           />
           <LanguageSelect
             autoHighlight
             data-testid="clerk-interpreter-filters__to-lang"
             label={t('languagePair.toPlaceholder')}
-            excludedLanguage={filters.fromLang}
             value={getLanguageSelectValue(filters.toLang)}
-            languages={distinctToLangs}
             variant={TextFieldVariant.Outlined}
             onChange={handleFilterChange('toLang')}
+            languages={distinctToLangs}
+            excludedLanguage={filters.fromLang}
             translateLanguage={translateLanguage}
           />
         </div>

--- a/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListing.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListing.tsx
@@ -1,6 +1,11 @@
 import { Box } from '@mui/system';
 import { useEffect } from 'react';
-import { CustomCircularProgress, H3, PaginatedTable } from 'shared/components';
+import {
+  CustomCircularProgress,
+  H2,
+  H3,
+  PaginatedTable,
+} from 'shared/components';
 import { APIResponseStatus, Color } from 'shared/enums';
 
 import { ClerkInterpreterListingHeader } from 'components/clerkInterpreter/listing/ClerkInterpreterListingHeader';
@@ -16,6 +21,14 @@ import {
 
 const getRowDetails = (interpreter: ClerkInterpreter) => {
   return <ClerkInterpreterListingRow interpreter={interpreter} />;
+};
+
+const HeaderTitle = () => {
+  const { t } = useAppTranslation({
+    keyPrefix: 'otr.component.clerkInterpreterListing.header',
+  });
+
+  return <H2>{t('title')}</H2>;
 };
 
 export const ClerkInterpreterListing = () => {
@@ -51,7 +64,7 @@ export const ClerkInterpreterListing = () => {
         <PaginatedTable
           data={filteredInterpreters}
           header={<ClerkInterpreterListingHeader />}
-          headerTitle={t('component.clerkInterpreterListing.header.title')}
+          headerContent={<HeaderTitle />}
           getRowDetails={getRowDetails}
           initialRowsPerPage={10}
           rowsPerPageOptions={[10, 20, 50]}

--- a/frontend/packages/otr/src/components/publicInterpreter/filters/PublicInterpreterFilters.tsx
+++ b/frontend/packages/otr/src/components/publicInterpreter/filters/PublicInterpreterFilters.tsx
@@ -36,9 +36,8 @@ import {
   filterPublicInterpreters,
   publicInterpretersSelector,
 } from 'redux/selectors/publicInterpreter';
+import { QualificationUtils } from 'utils/qualifications';
 import { RegionUtils } from 'utils/regions';
-
-const DEFAULT_FROM_LANG = 'FI';
 
 export const PublicInterpreterFilters = ({
   showTable,
@@ -60,14 +59,17 @@ export const PublicInterpreterFilters = ({
 
   // Defaults
   const defaultFiltersState = {
-    fromLang: DEFAULT_FROM_LANG,
+    fromLang: QualificationUtils.defaultFromLang,
     toLang: '',
     name: '',
     region: '',
   };
 
   const defaultValuesState: PublicInterpreterFilterValues = {
-    fromLang: languageToComboBoxOption(translateLanguage, DEFAULT_FROM_LANG),
+    fromLang: languageToComboBoxOption(
+      translateLanguage,
+      QualificationUtils.defaultFromLang
+    ),
     toLang: null,
     name: '',
     region: null,
@@ -86,7 +88,7 @@ export const PublicInterpreterFilters = ({
   const dispatch = useAppDispatch();
   const { interpreters } = useAppSelector(publicInterpretersSelector);
 
-  const langsTo = Array.from(
+  const toLangs = Array.from(
     new Set(
       interpreters.flatMap(({ languages }) =>
         (languages ?? []).map((language) => language.to)
@@ -220,11 +222,11 @@ export const PublicInterpreterFilters = ({
               label={t('languagePair.fromPlaceholder')}
               placeholder={t('languagePair.fromPlaceholder')}
               id="filters-from-lang"
-              excludedLanguage={filters.toLang}
-              languages={[DEFAULT_FROM_LANG]}
               disabled={true}
               aria-label={`${t('languagePair.fromAriaLabel')}`}
               onKeyUp={handleKeyUp}
+              languages={QualificationUtils.selectableFromLangs}
+              excludedLanguage={filters.toLang}
               translateLanguage={translateLanguage}
             />
             <LanguageSelect
@@ -233,10 +235,10 @@ export const PublicInterpreterFilters = ({
               label={t('languagePair.toPlaceholder')}
               placeholder={t('languagePair.toPlaceholder')}
               id="filters-to-lang"
-              excludedLanguage={filters.fromLang}
-              languages={langsTo}
               aria-label={`${t('languagePair.toAriaLabel')}`}
               onKeyUp={handleKeyUp}
+              languages={toLangs}
+              excludedLanguage={filters.fromLang}
               translateLanguage={translateLanguage}
             />
           </Box>

--- a/frontend/packages/otr/src/redux/reducers/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkInterpreter.ts
@@ -20,7 +20,7 @@ const initialState: ClerkInterpreterState = {
   status: APIResponseStatus.NotStarted,
   filters: {
     qualificationStatus: QualificationStatus.Effective,
-    fromLang: 'FI',
+    fromLang: QualificationUtils.defaultFromLang,
   },
   distinctToLangs: [],
 };

--- a/frontend/packages/otr/src/redux/reducers/publicInterpreter.ts
+++ b/frontend/packages/otr/src/redux/reducers/publicInterpreter.ts
@@ -5,6 +5,7 @@ import {
   PublicInterpreter,
   PublicInterpreterFilter,
 } from 'interfaces/publicInterpreter';
+import { QualificationUtils } from 'utils/qualifications';
 
 interface PublicInterpreterState {
   status: APIResponseStatus;
@@ -16,7 +17,7 @@ const initialState: PublicInterpreterState = {
   status: APIResponseStatus.NotStarted,
   interpreters: [],
   filters: {
-    fromLang: 'FI',
+    fromLang: QualificationUtils.defaultFromLang,
     toLang: '',
     name: '',
     region: '',

--- a/frontend/packages/otr/src/tests/cypress/fixtures/utils/clerkInterpreterOverview.ts
+++ b/frontend/packages/otr/src/tests/cypress/fixtures/utils/clerkInterpreterOverview.ts
@@ -1,10 +1,5 @@
 export const addQualificationFields = [
   {
-    fieldName: 'from',
-    fieldType: 'input',
-    value: 'suomi',
-  },
-  {
     fieldName: 'to',
     fieldType: 'input',
     value: 'ruotsi',

--- a/frontend/packages/otr/src/utils/qualifications.ts
+++ b/frontend/packages/otr/src/utils/qualifications.ts
@@ -4,6 +4,9 @@ import { Qualification } from 'interfaces/qualification';
 import koodistoLangsFI from 'public/i18n/koodisto/langs/koodisto_langs_fi-FI.json';
 
 export class QualificationUtils {
+  static defaultFromLang = 'FI';
+  static selectableFromLangs = ['FI'];
+
   static isEffective(
     { id }: Qualification,
     { effective }: ClerkInterpreterQualifications

--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.3.7] - 2022-09-28
+
+### Changed
+
+- Updated `LanguageSelect` parameters
+
 ## [1.3.6] - 2022-09-28
 
 ### Fixed

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/components/LanguageSelect/LanguageSelect.test.tsx
+++ b/frontend/packages/shared/src/components/LanguageSelect/LanguageSelect.test.tsx
@@ -14,7 +14,8 @@ describe('LanguageSelect', () => {
           variant={TextFieldVariant.Outlined}
           languages={languages}
           value={null}
-          excludedLanguage="BN"
+          excludedLanguage="FI"
+          primaryLanguages={['SV']}
           translateLanguage={jest.fn((l: string) => l)}
         />
       )

--- a/frontend/packages/shared/src/components/LanguageSelect/LanguageSelect.tsx
+++ b/frontend/packages/shared/src/components/LanguageSelect/LanguageSelect.tsx
@@ -5,13 +5,6 @@ import {
 } from '../../interfaces/comboBox';
 import { ComboBox, sortOptionsByLabels } from '../ComboBox/ComboBox';
 
-interface LanguageSelectProps {
-  languages: Array<string>;
-  excludedLanguage?: string;
-  primaryLanguages?: Array<string>;
-  translateLanguage: (l: string) => string;
-}
-
 export const languageToComboBoxOption = (
   translate: (l: string) => string,
   lang: string
@@ -20,39 +13,50 @@ export const languageToComboBoxOption = (
   value: lang,
 });
 
+interface LanguageSelectProps {
+  languages: Array<string>;
+  primaryLanguages?: Array<string>;
+  excludedLanguage?: string;
+  translateLanguage: (l: string) => string;
+}
+
+/**
+ * Returns ComboBox with values as language options.
+ *
+ * The first selectable options are `primaryLanguages` that are also part of `languages`.
+ * The remaining options are the rest of the `languages` sorted by their display values.
+ * If `excludedLanguage` is also provided, that language is filtered out of the result.
+ *
+ * @param languages - selectable language options
+ * @param primaryLanguages - first language options
+ * @param excludedLanguage - excluded language option
+ * @param translateLanguage
+ * @param rest
+ * @constructor
+ */
 export const LanguageSelect = ({
   languages,
-  excludedLanguage,
   primaryLanguages,
+  excludedLanguage,
   translateLanguage,
   ...rest
 }: LanguageSelectProps &
   Omit<ComboBoxProps, 'values'> &
   AutoCompleteComboBox) => {
+  const includedLanguages = excludedLanguage
+    ? languages.filter((language) => language !== excludedLanguage)
+    : languages;
+
   const primaryOptions: Array<ComboBoxOption> =
     primaryLanguages
-      ?.filter(
-        (language) =>
-          languages.includes(language) && language !== excludedLanguage
-      )
+      ?.filter((language) => includedLanguages.includes(language))
       .map((language) =>
         languageToComboBoxOption(translateLanguage, language)
       ) || [];
 
-  let secondaryOptions: Array<ComboBoxOption> = [];
-
-  if (
-    !excludedLanguage ||
-    !primaryLanguages ||
-    primaryLanguages.includes(excludedLanguage)
-  ) {
-    secondaryOptions = languages
-      .filter(
-        (language) =>
-          language !== excludedLanguage && !primaryLanguages?.includes(language)
-      )
-      .map((language) => languageToComboBoxOption(translateLanguage, language));
-  }
+  const secondaryOptions: Array<ComboBoxOption> = includedLanguages
+    .filter((language) => !primaryLanguages?.includes(language))
+    .map((language) => languageToComboBoxOption(translateLanguage, language));
 
   const sortedOptions = [
     ...primaryOptions,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2517,7 +2517,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.akr@workspace:packages/akr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.4"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.7"
   languageName: unknown
   linkType: soft
 
@@ -2525,7 +2525,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.otr@workspace:packages/otr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.3"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.7"
   languageName: unknown
   linkType: soft
 
@@ -2614,7 +2614,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.6":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.7":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -11149,17 +11149,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.3":
-  version: 1.3.3
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.3.3::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.3.3%2Fee740963a710c2be79a939884ff6c2518e92c9fb"
-  checksum: b39759a5977f69b0efc40f135cd982d3716531dd7c479ea7e275bcb4e448dffc5d78a2b380aaf469222054d3c1ce5edc6cf852c1dac527185ec6e042634b6f15
-  languageName: node
-  linkType: hard
-
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.4":
-  version: 1.3.4
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.3.4::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.3.4%2F0c1a7c148356886453793009d13722dacd08418b"
-  checksum: 822c5db6743c75edfb1ea787dada91580a90337b08ecdb45e791871354afabef094a8fa9a6cd76fd570a73daaa7a13fb13d387b44fe2ef8bf8f93bea870d12a3
+"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.6":
+  version: 1.3.6
+  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.3.6::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.3.6%2F0b2a2ac06e629c5cf1e38b11d879247f5d04ed8d"
+  checksum: 31d6a5ffc2d053367454fafe519c7e6a8dfe87f2b375e7460b51539cff77b83187535bb8384960382264ad5d0e960fa3a7e8dc33f36e84094f4186a3caf34aa4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Muutettu `LanguageSelect` komponentti ottamaan propsina `primaryLanguages` parameterin. Toistaiseksi ko. komponentti määritte itse primääriset kielivalinnat. Samalla muutettu OTR:ää siten, että primäärisiä kielivalintoja ei valintaelementeissä ole. AKR:n puolella säästetty alkuperäinen toimintalogiikka.

## Check-lista

- [x] Testattu docker-compose:lla
