### PR TITLE
OTR(Frontend): OPHOTRKEH-154 radio buttons visible

### DIFF
--- a/frontend/packages/otr/src/configs/materialUI.ts
+++ b/frontend/packages/otr/src/configs/materialUI.ts
@@ -54,6 +54,30 @@ export const theme = createTheme({
         },
       },
     },
+    MuiRadio: {
+      styleOverrides: {
+        root: {
+          color: grey700Color,
+          '&.Mui-checked': {
+            color: secondaryColor,
+          },
+          '&.Mui-disabled': {
+            color: grey700Color,
+          },
+        },
+      },
+    },
+    MuiAutocomplete: {
+      styleOverrides: {
+        tag: {
+          backgroundColor: secondaryColor,
+          color: primaryColor,
+          '.MuiChip-deleteIcon': {
+            color: primaryLightColor,
+          },
+        },
+      },
+    },
     MuiCalendarPicker: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
## Yhteenveto

Kävin aiemmin copy pasteamassa materialUI config tiedoston AKR:stä OTR:ään sillä oletuksella, että näiden oli tarkoitus vastata toisiaan. OTR:ssä oli kuitenkin materialUI konffeissa omat tyylitykset radio buttoneihin ja noihin Autocomplete:eihin liittyen. Palautin näiden tyylitykset ennalleen mitä ne olivat ennen AKR:n version kopiointia ja nyt maakuntien radio buttonit näkyy taas ja valitut maakunnat sinisellä pohjalla.