### PR TITLE
AKR(Frontend): Don't link to additional information from within CookieBanner

### DIFF
--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -430,11 +430,6 @@
           "buttonAriaLabel": "Hyväksy evästeet",
           "buttonText": "Hyväksy",
           "description": "Tämä sivusto käyttää välttämättömiä evästeitä toimiakseen.",
-          "additionalInfo": "Voit lukea lisätietoa evästeistä painamalla",
-          "extLink": {
-            "text": "tästä linkistä",
-            "ariaLabel": "Lisätietoja evästeistä"
-          },
           "title": "Hyväksy evästeet"
         },
         "filters": {

--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -429,7 +429,8 @@
         "cookieBanner": {
           "buttonAriaLabel": "Hyväksy evästeet",
           "buttonText": "Hyväksy",
-          "description": "Tämä sivusto käyttää välttämättömiä evästeitä toimiakseen. Voit lukea lisätietoa evästeistä painamalla",
+          "description": "Tämä sivusto käyttää välttämättömiä evästeitä toimiakseen.",
+          "additionalInfo": "Voit lukea lisätietoa evästeistä painamalla",
           "extLink": {
             "text": "tästä linkistä",
             "ariaLabel": "Lisätietoja evästeistä"

--- a/frontend/packages/akr/src/pages/PublicHomePage.tsx
+++ b/frontend/packages/akr/src/pages/PublicHomePage.tsx
@@ -1,7 +1,6 @@
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Box, Grid } from '@mui/material';
 import { FC, useEffect } from 'react';
-import { CookieBanner, ExtLink, Text } from 'shared/components';
+import { CookieBanner, Text } from 'shared/components';
 
 import { PublicTranslatorGrid } from 'components/publicTranslator/PublicTranslatorGrid';
 import { useAppTranslation } from 'configs/i18n';
@@ -31,15 +30,7 @@ export const PublicHomePage: FC = () => {
         cookieTag="akr"
         buttonAriaLabel={t('buttonAriaLabel')}
       >
-        <Text data-testid="cookie-banner-description">
-          {t('description')}
-          <ExtLink
-            text={t('extLink.text')}
-            href=""
-            endIcon={<OpenInNewIcon />}
-            aria-label={t('extLink.ariaLabel')}
-          />
-        </Text>
+        <Text data-testid="cookie-banner-description">{t('description')}</Text>
       </CookieBanner>
       <Grid
         container

--- a/frontend/packages/akr/src/tests/cypress/integration/cookie-banner.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/cookie-banner.spec.ts
@@ -12,7 +12,7 @@ describe('Cookie Banner', () => {
 
     onCookieBanner.expectCookieBannerVisible();
     onCookieBanner.expectCookieBannerDescription(
-      'Tämä sivusto käyttää välttämättömiä evästeitä toimiakseen. Voit lukea lisätietoa evästeistä painamallatästä linkistä'
+      'Tämä sivusto käyttää välttämättömiä evästeitä toimiakseen.'
     );
     onCookieBanner.clickAcceptCookies();
     onCookieBanner.expectCookieBannerNotVisible();


### PR DESCRIPTION
Splitting the original translation into two parts and using only the first part for now. The second part is still left in the translation file, even though currently unused. Remove, change or keep as is once it's decided what to include in the banner.

## Yhteenveto

_Toteutuksen yhteenveto..._

## Lisätiedot

_Tehdyt muutokset..._

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
- [ ] Testattu docker-compose:lla
