### PR TITLE
OTR(Frontend): OPHOTRKEH-136 vtj info tekstit

### DIFF
--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -78,7 +78,8 @@
             "extraInformation": "Lisätiedot",
             "personalInformation": "Henkilötiedot",
             "regions": "Toiminta-alue"
-          }
+          },
+          "individualisedInformation": "Tiedot haettu väestötietojärjestelmästä"
         },
         "qualifications": {
           "actions": {
@@ -120,6 +121,12 @@
         },
         "toasts": {
           "updated": "Tiedot tallennettiin"
+        }
+      },
+      "clerkNewInterpreterDetails": {
+        "title": {
+          "existingPerson": "Tiedot lisätään olemassa olevalle oppijalle",
+          "newPerson": "Tiedot lisätään oppijanumerorekisteriin"
         }
       },
       "footer": {

--- a/frontend/packages/otr/src/components/clerkInterpreter/new/ClerkNewInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/new/ClerkNewInterpreterDetails.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, useState } from 'react';
 import { ComboBoxOption } from 'shared/interfaces';
 
 import { ClerkInterpreterDetailsFields } from 'components/clerkInterpreter/overview/ClerkInterpreterDetailsFields';
+import { useAppTranslation } from 'configs/i18n';
 import { useAppDispatch } from 'configs/redux';
 import { ClerkNewInterpreter } from 'interfaces/clerkNewInterpreter';
 import { updateClerkNewInterpreter } from 'redux/reducers/clerkNewInterpreter';
@@ -14,6 +15,11 @@ export const ClerkNewInterpreterDetails = ({
   interpreter: ClerkNewInterpreter;
   onDetailsChange: () => void;
 }) => {
+  // i18n
+  const { t } = useAppTranslation({
+    keyPrefix: 'otr.component.clerkNewInterpreterDetails',
+  });
+
   // Local state
   const [areaOfOperation, setAreaOfOperation] = useState(
     RegionUtils.getAreaOfOperation(interpreter.regions)
@@ -58,8 +64,13 @@ export const ClerkNewInterpreterDetails = ({
       dispatch(updateClerkNewInterpreter(updatedInterpreterDetails));
     };
 
+  const title = interpreter.onrId
+    ? t('title.existingPerson')
+    : t('title.newPerson');
+
   return (
     <ClerkInterpreterDetailsFields
+      title={title}
       interpreterBasicInformation={interpreter}
       isPersonalInformationIndividualised={interpreter.isIndividualised}
       isAddressIndividualised={interpreter.hasIndividualisedAddress}
@@ -67,7 +78,7 @@ export const ClerkNewInterpreterDetails = ({
       setAreaOfOperation={setAreaOfOperation}
       onFieldChange={(field) => handleDetailsChange(field)}
       isViewMode={false}
-      displayFieldErrorBeforeChange={false}
+      showFieldErrorBeforeChange={false}
     />
   );
 };

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetails.tsx
@@ -173,6 +173,7 @@ export const ClerkInterpreterDetails = () => {
 
   return (
     <ClerkInterpreterDetailsFields
+      title={`${interpreter?.lastName} ${interpreter?.firstName}`}
       interpreterBasicInformation={interpreterDetails}
       isPersonalInformationIndividualised={interpreter?.isIndividualised}
       isAddressIndividualised={interpreter?.hasIndividualisedAddress}
@@ -189,7 +190,7 @@ export const ClerkInterpreterDetails = () => {
           hasRequiredDetails={hasRequiredDetails}
         />
       }
-      displayFieldErrorBeforeChange={true}
+      showFieldErrorBeforeChange={true}
     />
   );
 };

--- a/frontend/packages/otr/src/styles/pages/_clerk-interpreter-overview-page.scss
+++ b/frontend/packages/otr/src/styles/pages/_clerk-interpreter-overview-page.scss
@@ -5,6 +5,10 @@
     padding: 3rem;
   }
 
+  .individualised {
+    margin-left: 1rem;
+  }
+
   .regions {
     flex: 1;
   }

--- a/frontend/packages/otr/src/styles/pages/_clerk-new-interpreter-page.scss
+++ b/frontend/packages/otr/src/styles/pages/_clerk-new-interpreter-page.scss
@@ -5,6 +5,10 @@
     padding: 3rem;
   }
 
+  .individualised {
+    margin-left: 1rem;
+  }
+
   .regions {
     flex: 1;
   }

--- a/frontend/packages/otr/src/tests/cypress/integration/clerk_new_interpreter_page.spec.ts
+++ b/frontend/packages/otr/src/tests/cypress/integration/clerk_new_interpreter_page.spec.ts
@@ -19,6 +19,12 @@ describe('ClerkNewInterpreterPage', () => {
       onClerkPersonSearchPage.clickProceedButton();
     });
 
+    it('title should indicate a new person is created in ONR', () => {
+      onClerkNewInterpreterPage.expectTitle(
+        'Tiedot lisätään oppijanumerorekisteriin'
+      );
+    });
+
     it('only identity number field should be prefilled and disabled', () => {
       onClerkNewInterpreterPage.expectInterpreterFieldValue(
         'identityNumber',
@@ -120,6 +126,12 @@ describe('ClerkNewInterpreterPage', () => {
     beforeEach(() => {
       onClerkPersonSearchPage.typeSocialSecurityNumber(person1.identityNumber);
       onClerkPersonSearchPage.clickSearchButton();
+    });
+
+    it('title should indicate interpreter is created for an existing person', () => {
+      onClerkNewInterpreterPage.expectTitle(
+        'Tiedot lisätään olemassa olevalle oppijalle'
+      );
     });
 
     it('personal information fields should be prefilled and disabled', () => {

--- a/frontend/packages/otr/src/tests/cypress/integration/interpreterOverview/clerk_interpreter_details.spec.ts
+++ b/frontend/packages/otr/src/tests/cypress/integration/interpreterOverview/clerk_interpreter_details.spec.ts
@@ -4,6 +4,7 @@ import { onDialog } from 'tests/cypress/support/page-objects/dialog';
 import { onQualificationDetails } from 'tests/cypress/support/page-objects/qualificationDetails';
 import { onToast } from 'tests/cypress/support/page-objects/toast';
 import { clerkInterpreter } from 'tests/msw/fixtures/clerkInterpreter';
+import { clerkInterpreterIndividualised } from 'tests/msw/fixtures/clerkInterpreterIndividualised';
 
 describe('ClerkInterpreterOverview:ClerkInterpreterDetails', () => {
   beforeEach(() => {
@@ -82,6 +83,10 @@ describe('ClerkInterpreterOverview:ClerkInterpreterDetails', () => {
       fieldType,
       newLastName
     );
+    onClerkInterpreterOverviewPage.expectTitle(
+      `${clerkInterpreter.lastName} ${clerkInterpreter.firstName}`
+    );
+
     onClerkInterpreterOverviewPage.clickSaveInterpreterDetailsButton();
 
     onClerkInterpreterOverviewPage.expectMode(UIMode.View);
@@ -89,6 +94,9 @@ describe('ClerkInterpreterOverview:ClerkInterpreterDetails', () => {
       fieldName,
       fieldType,
       newLastName
+    );
+    onClerkInterpreterOverviewPage.expectTitle(
+      `${newLastName} ${clerkInterpreter.firstName}`
     );
     onToast.expectText('Tiedot tallennettiin');
 
@@ -167,6 +175,13 @@ describe('ClerkInterpreterOverview:ClerkInterpreterDetails', () => {
     onClerkInterpreterOverviewPage.expectText(
       'Sähköpostiosoite on virheellinen'
     );
+
+    onClerkInterpreterOverviewPage.editInterpreterField(
+      'phoneNumber',
+      'input',
+      'xyz'
+    );
+    onClerkInterpreterOverviewPage.expectText('Puhelinnumero on virheellinen');
   });
 
   it('should show identity number as the only disabled personal information field for a non-individualised interpreter', () => {
@@ -185,7 +200,9 @@ describe('ClerkInterpreterOverview:ClerkInterpreterDetails', () => {
   });
 
   it('should show each personal information field as disabled for an individualised interpreter', () => {
-    onClerkInterpreterOverviewPage.navigateById(12);
+    onClerkInterpreterOverviewPage.navigateById(
+      clerkInterpreterIndividualised.id
+    );
     onClerkInterpreterOverviewPage.clickEditInterpreterDetailsButton();
 
     ['lastName', 'firstName', 'nickName', 'identityNumber'].forEach((field) => {

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkInterpreterOverviewPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkInterpreterOverviewPage.ts
@@ -36,6 +36,7 @@ class ClerkInterpreterOverviewPage {
       cy.findByTestId(`qualifications-table__id-${id}-row`),
     saveQualificationButton: () =>
       cy.findByTestId('add-qualification-modal__save'),
+    title: () => cy.findByTestId('clerk-interpreter__basic-information__title'),
   };
 
   navigateById(id: number) {
@@ -46,6 +47,10 @@ class ClerkInterpreterOverviewPage {
 
   navigateBackToRegister() {
     this.elements.backToRegisterButton().should('be.visible').click();
+  }
+
+  expectTitle(text: string) {
+    this.elements.title().should('contain.text', text);
   }
 
   clickEditInterpreterDetailsButton() {

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkNewInterpreterPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkNewInterpreterPage.ts
@@ -21,7 +21,12 @@ class ClerkNewInterpreterPage {
       cy.findByTestId('add-qualification-modal__save'),
     saveInterpreterButton: () =>
       cy.findByTestId('clerk-new-interpreter-page__save-button'),
+    title: () => cy.findByTestId('clerk-interpreter__basic-information__title'),
   };
+
+  expectTitle(text: string) {
+    this.elements.title().should('contain.text', text);
+  }
 
   editInterpreterField(fieldName: string, fieldType: string, newValue) {
     this.elements


### PR DESCRIPTION
## Yhteenveto

Jos tulkin henkilö- ja/tai osoitetiedot tulevat väestötietojärjestelmästä, näytetään tästä infoteksti tulkin tarkastelunäkymässä. Samanaikaisesti muutettu myös näkymää siten, että info- ja virhetekstit toimivat samoin kuin AKR:ssäkin. Käytännössä ainoa muutos oli se, että jos puhelinnumero on virheellinen, näkyy tästä huomio infotekstinä.

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
- [x] Testattu docker-compose:lla
