### PR TITLE
AKR(Frontend): OPHAKRKEH-439 updated localisation files to match with sharepoint

### DIFF
--- a/frontend/packages/akr/public/i18n/en-GB/common.json
+++ b/frontend/packages/akr/public/i18n/en-GB/common.json
@@ -16,7 +16,7 @@
       "examinationDates": "Exam days",
       "frontPage": "Home",
       "loadingContent": "Downloading content",
-      "meetingDates": "Dates of meetings",
+      "meetingDates": "Meeting days",
       "navigationProtection": {
         "description": "You will lose  any changes you  have made",
         "header": "Are you sure you want to leave this page?"

--- a/frontend/packages/akr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/akr/public/i18n/en-GB/translation.json
@@ -71,8 +71,8 @@
             "removal": {
               "ariaLabel": "Delete the authorisation",
               "dialog": {
-                "description": "This action cannot be undone!",
                 "confirmButton": "Delete the authorisation",
+                "description": "This action cannot be undone!",
                 "header": "Are you sure you want to delete the authorisation?"
               }
             }
@@ -85,7 +85,7 @@
             "diaryNumber": "Case identifier",
             "endDate": "End date",
             "examinationDate": "Exam day",
-            "languagePair": "End date",
+            "languagePair": "Language pair",
             "permissionToPublish": "Permission to publish",
             "startDate": "Start date"
           },
@@ -104,8 +104,8 @@
         },
         "toasts": {
           "notFound": "The selected translator could not be found",
-          "updateFailed": "Failed to save the information",
-          "updated": "The information was saved"
+          "updated": "The information was saved",
+          "updateFailed": "Failed to save the information"
         },
         "translatorDetails": {
           "cancelUpdateDialog": {
@@ -137,20 +137,20 @@
         }
       },
       "contactRequestForm": {
-        "description": "You can use this contact request form to leave a contact request to the authorised translators you have selected. Please write a description of the required translation in as much detail as possible to your message.",
         "cancelRequestDialog": {
           "description": "Do you want to cancel the contact request? You will lose the information you have filled in",
           "title": "Cancel contact request"
         },
         "characters": "characters",
         "chosenTranslatorsForLanguagePair": "The translators you have selected from the language pair",
+        "description": "You can use this contact request form to leave a contact request to the authorised translators you have selected. Please write a description of the required translation in as much detail as possible to your message.",
         "doneStep": {
           "description": "This page will automatically redirect you back to the home page. If nothing happens, click the button below.",
           "title": "Your contact request has been sent and you will be contacted."
         },
         "errorDialog": {
-          "description": "Try again later. If the problem persists, contact us by email at: auktoris.lautakunta@oph.fi",
           "back": "Back",
+          "description": "Try again later. If the problem persists, contact us by email at: auktoris.lautakunta@oph.fi",
           "title": "An error was encountered when sending the contact request"
         },
         "formLabels": {
@@ -168,13 +168,13 @@
           "linkLabel": null
         },
         "steps": {
+          "active": "Active",
+          "completed": "Completed",
           "Done": "Complete!",
           "FillContactDetails": "Fill in contact details",
           "PreviewAndSend": "Preview and send",
           "VerifyTranslators": "Confirm translators",
-          "WriteMessage": "Write message",
-          "active": "Active",
-          "completed": "Completed"
+          "WriteMessage": "Write message"
         },
         "title": "Leaving a contact request",
         "verifySelectedTranslatorsStep": {
@@ -220,6 +220,9 @@
             "ariaLabel": "Examination system of authorised translators (oph.fi), open in a new tab",
             "link": "https://www.oph.fi/en/services/briefly-about-authorised-translators-examination",
             "text": "Examination system of authorised translators (oph.fi)"
+          },
+          "contact": {
+            "title": null
           },
           "privacy": {
             "text": "Privacy policy (in Finnish)"
@@ -289,7 +292,7 @@
       "publicTranslatorFilters": {
         "buttons": {
           "empty": "Clear",
-          "newSearch": "Conduct a new search",
+          "newSearch": "New search",
           "search": "Show results"
         },
         "captions": {
@@ -314,8 +317,8 @@
           "translatorsSelected": "You can select only one language pair for contacting"
         },
         "town": {
-          "placeholder": "Municipality of residence",
-          "title": "Search by translator’s municipality of residence"
+          "placeholder": "Municipality",
+          "title": "Search by translator’s municipality"
         }
       },
       "table": {
@@ -339,6 +342,7 @@
         "examinationDateCreateDuplicateDate": "Failed to add the exam day because the selected date is already an exam day",
         "examinationDateDeleteHasAuthorisations": "Failed to delete the exam day because authorisations have been recorded for it",
         "generic": "The action failed, please try again later",
+        "invalidVersion": null,
         "meetingDateCreateDuplicateDate": "Failed to add the meeting day because the selected date is already a meeting day",
         "meetingDateDeleteHasAuthorisations": "Failed to delete the meeting day because authorisations have been recorded for it",
         "meetingDateUpdateDuplicateDate": "Failed to modify the meeting day failed because the selected date is already a meeting day",
@@ -382,6 +386,7 @@
         }
       },
       "clerkSendEmailPage": {
+        "characters": "characters",
         "dialogs": {
           "cancel": {
             "description": "Do you want to cancel sending the email? You will lose the information you have filled in.",
@@ -420,13 +425,19 @@
         }
       },
       "homepage": {
+        "cookieBanner": {
+          "buttonAriaLabel": null,
+          "buttonText": null,
+          "description": null,
+          "title": null
+        },
         "description": "The Finnish National Agency for Education maintains a register of authorised translators, into which the authorised translators approved by the Authorised Translators’ Examination Board are entered. You can use the search engine to find an authorised translator either by language pair, name, or municipality of residence. You can use the search form to leave a contact request to the translators you have selected. If there is a malfunction in the register, contact us by email to obtain contact details of authorised translators: auktoris.lautakunta@oph.fi. The public register of authorised translators contains only the names of those interpreters who have given the permission to publish their names online.",
         "filters": {
           "title": "Search for an authorised translator"
         },
         "noSearchResults": "No search results",
         "note": "When searching by language pair, the possible search options are from the languages of Finland (Finnish, Swedish and Sámi languages) into foreign languages or vice versa, and between the languages of Finland.",
-        "requestContact": "Contact us",
+        "requestContact": "Contact",
         "title": "Register of Authorised Translators"
       },
       "meetingDatesPage": {
@@ -443,7 +454,7 @@
       "translator": {
         "languagePairs": "Language pairs",
         "name": "Name",
-        "town": "Municipality of residence"
+        "town": "Municipality"
       }
     }
   }

--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -71,8 +71,8 @@
             "removal": {
               "ariaLabel": "Poista auktorisointi",
               "dialog": {
-                "description": "Tätä toimintoa ei voi peruuttaa!",
                 "confirmButton": "Poista auktorisointi",
+                "description": "Tätä toimintoa ei voi peruuttaa!",
                 "header": "Haluatko varmasti poistaa auktorisoinnin?"
               }
             }
@@ -104,8 +104,8 @@
         },
         "toasts": {
           "notFound": "Valittua kääntäjää ei löytynyt",
-          "updateFailed": "Tietojen tallennus epäonnistui",
-          "updated": "Tiedot tallennettiin"
+          "updated": "Tiedot tallennettiin",
+          "updateFailed": "Tietojen tallennus epäonnistui"
         },
         "translatorDetails": {
           "cancelUpdateDialog": {
@@ -137,20 +137,20 @@
         }
       },
       "contactRequestForm": {
-        "description": "Tällä yhteydenottolomakkeella voit jättää valitsemillesi auktorisoiduille kääntäjille yhteydenottopyynnön. Kirjoitathan viestiin mahdollisimman tarkan kuvauksen tarvittavasta käännöstyöstä.",
         "cancelRequestDialog": {
           "description": "Haluatko peruuttaa yhteydenottopyynnön? Menetät täyttämäsi tiedot.",
           "title": "Peruuta yhteydenottopyyntö"
         },
         "characters": "merkkiä",
         "chosenTranslatorsForLanguagePair": "Valitsemasi kääntäjät kieliparista",
+        "description": "Tällä yhteydenottolomakkeella voit jättää valitsemillesi auktorisoiduille kääntäjille yhteydenottopyynnön. Kirjoitathan viestiin mahdollisimman tarkan kuvauksen tarvittavasta käännöstyöstä.",
         "doneStep": {
           "description": "Tämä sivu ohjaa sinut automaattisesti takaisin etusivulle. Jos mitään ei tapahdu voit klikata alla olevasta napista.",
           "title": "Yhteydenottopyyntösi on lähetetty ja sinuun ollaan yhteydessä."
         },
         "errorDialog": {
-          "description": "Kokeile myöhemmin uudelleen. Jos ongelma toistuu, ota yhteyttä sähköpostilla: auktoris.lautakunta@oph.fi",
           "back": "Takaisin",
+          "description": "Kokeile myöhemmin uudelleen. Jos ongelma toistuu, ota yhteyttä sähköpostilla: auktoris.lautakunta@oph.fi",
           "title": "Virhe lähetettäessä yhteydenottopyyntöä"
         },
         "formLabels": {
@@ -168,13 +168,13 @@
           "linkLabel": "tietosuojaselosteen"
         },
         "steps": {
+          "active": "Aktiivinen",
+          "completed": "Suoritettu",
           "Done": "Valmis!",
           "FillContactDetails": "Täytä yhteystietosi",
           "PreviewAndSend": "Esikatsele ja lähetä",
           "VerifyTranslators": "Vahvista kääntäjät",
-          "WriteMessage": "Kirjoita viesti",
-          "active": "Aktiivinen",
-          "completed": "Suoritettu"
+          "WriteMessage": "Kirjoita viesti"
         },
         "title": "Yhteydenottopyynnön jättäminen",
         "verifySelectedTranslatorsStep": {
@@ -425,13 +425,13 @@
         }
       },
       "homepage": {
-        "description": "Opetushallitus ylläpitää auktorisoitujen kääntäjien rekisteriä. Hakukoneella voit hakea auktorisoitua kääntäjää/auktorisoituja kääntäjiä joko kieliparin, nimen tai asuinkunnan mukaan. Voit jättää yhteydenottopyynnön valitsemillesi kääntäjille alla olevalla hakulomakkeella. Jos rekisterissä on toimintahäiriö, ota yhteyttä sähköpostitse saadaksesi auktorisoitujen kääntäjien yhteystietoja: auktoris.lautakunta@oph.fi",
         "cookieBanner": {
           "buttonAriaLabel": "Hyväksy evästeet",
           "buttonText": "Hyväksy",
           "description": "Tämä sivusto käyttää välttämättömiä evästeitä toimiakseen.",
           "title": "Hyväksy evästeet"
         },
+        "description": "Opetushallitus ylläpitää auktorisoitujen kääntäjien rekisteriä. Hakukoneella voit hakea auktorisoitua kääntäjää/auktorisoituja kääntäjiä joko kieliparin, nimen tai asuinkunnan mukaan. Voit jättää yhteydenottopyynnön valitsemillesi kääntäjille alla olevalla hakulomakkeella. Jos rekisterissä on toimintahäiriö, ota yhteyttä sähköpostitse saadaksesi auktorisoitujen kääntäjien yhteystietoja: auktoris.lautakunta@oph.fi",
         "filters": {
           "title": "Hae auktorisoitua kääntäjää"
         },

--- a/frontend/packages/akr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/translation.json
@@ -29,7 +29,7 @@
         "authorisationStatus": {
           "effective": "Auktoriserade",
           "expiredDeduplicated": "Löpt ut",
-          "expiring": "Löpt ut",
+          "expiring": null,
           "formerVir": "VIR 2008"
         },
         "languagePair": {
@@ -71,8 +71,8 @@
             "removal": {
               "ariaLabel": "Ta bort auktorisering",
               "dialog": {
-                "description": "Denna funktion kan inte ångras!",
                 "confirmButton": "Ta bort auktorisering",
+                "description": "Denna funktion kan inte ångras!",
                 "header": "Är du säker på att du vill ta bort auktoriseringen?"
               }
             }
@@ -85,7 +85,7 @@
             "diaryNumber": "Diarienummer",
             "endDate": "Slutdatum",
             "examinationDate": "Examensdag",
-            "languagePair": "Slutdatum",
+            "languagePair": "Språkpar",
             "permissionToPublish": "Publiceringstillstånd",
             "startDate": "Startdatum"
           },
@@ -104,8 +104,8 @@
         },
         "toasts": {
           "notFound": "Vald translator kunde inte hittas",
-          "updateFailed": "Det gick inte att spara uppgifterna",
-          "updated": "Uppgifterna sparades"
+          "updated": "Uppgifterna sparades",
+          "updateFailed": "Det gick inte att spara uppgifterna"
         },
         "translatorDetails": {
           "cancelUpdateDialog": {
@@ -137,20 +137,20 @@
         }
       },
       "contactRequestForm": {
-        "description": "Med denna blankett kan du lämna en kontaktförfrågan till vald auktoriserad translator. Skriv en så noggrann beskrivning som möjligt av översättningsarbetet i meddelandet.",
         "cancelRequestDialog": {
           "description": "Vill du avbryta kontaktförfrågan? Du förlorar de uppgifter du fyllt i",
           "title": "Avbryt kontaktförfrågan"
         },
         "characters": "tecken",
         "chosenTranslatorsForLanguagePair": "Translatorerna du valt med språkparet",
+        "description": "Med denna blankett kan du lämna en kontaktförfrågan till vald auktoriserad translator. Skriv en så noggrann beskrivning som möjligt av översättningsarbetet i meddelandet.",
         "doneStep": {
           "description": "Denna sida leder dig automatiskt tillbaka till framsidan. Om ingenting händer kan du klicka på knappen ovan.",
           "title": "Din kontaktförfrågan har skickats och vi kontaktar dig."
         },
         "errorDialog": {
-          "description": "Försök igen senare. Kontakta oss per e-post: auktoris.lautakunta@oph.fi om problemet upprepas.",
           "back": "Tillbaka",
+          "description": "Försök igen senare. Kontakta oss per e-post: auktoris.lautakunta@oph.fi om problemet upprepas.",
           "title": "Ett fel uppstod vid sändningen av kontaktförfrågan"
         },
         "formLabels": {
@@ -168,13 +168,13 @@
           "linkLabel": null
         },
         "steps": {
+          "active": "Aktiv",
+          "completed": "Utfört",
           "Done": "Klart!",
           "FillContactDetails": "Fyll i kontaktuppgifter",
           "PreviewAndSend": "Förhandsgranska och sänd",
           "VerifyTranslators": "Bekräfta translator",
-          "WriteMessage": "Skriv meddelande",
-          "active": "Aktiv",
-          "completed": "Utfört"
+          "WriteMessage": "Skriv meddelande"
         },
         "title": "Lämna en kontaktförfrågan",
         "verifySelectedTranslatorsStep": {
@@ -220,6 +220,9 @@
             "ariaLabel": "Examenssystemet för auktoriserade translatorer (oph.fi), öppnas i en ny flik",
             "link": "https://www.oph.fi/sv/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/auktorisoidun-kaantajan-tutkinto",
             "text": "Systemet med auktoriserade translatorer (oph.fi)"
+          },
+          "contact": {
+            "title": null
           },
           "privacy": {
             "text": "Dataskyddsbeskrivning"
@@ -339,6 +342,7 @@
         "examinationDateCreateDuplicateDate": "Det gick inte att lägga till examensdagen eftersom det valda datumet redan är en examensdag",
         "examinationDateDeleteHasAuthorisations": "Det gick inte att ta bort examensdagen eftersom det har registrerats auktoriseringar på den",
         "generic": "Funktionen misslyckades, försök på nytt senare",
+        "invalidVersion": null,
         "meetingDateCreateDuplicateDate": "Det gick inte lägga till mötesdagen eftersom det valda datumet redan är ett mötesdatum",
         "meetingDateDeleteHasAuthorisations": "Det gick inte att ta bort mötesdagen eftersom det har registrerats auktoriseringar på den",
         "meetingDateUpdateDuplicateDate": "Mötesdagen kunde inte redigeras eftersom det valda datumet redan är en mötesdag",
@@ -382,6 +386,7 @@
         }
       },
       "clerkSendEmailPage": {
+        "characters": "tecken",
         "dialogs": {
           "cancel": {
             "description": "Vill du avbryta sändningen av e-post? Du förlorar de uppgifter du fyllt i.",
@@ -420,13 +425,19 @@
         }
       },
       "homepage": {
+        "cookieBanner": {
+          "buttonAriaLabel": null,
+          "buttonText": null,
+          "description": null,
+          "title": null
+        },
         "description": "Utbildningsstyrelsen upprätthåller ett register över auktoriserade translatorer, där translatorer som har auktoriserats av Examensnämnden för auktoriserade translatorer registreras. Med sökmotorn kan du söka en auktoriserad translator eller flera enligt språkpar, på namn eller boendeort. Observera att sökandet enligt språkpar ger som möjliga sökalternativ från inhemska språk ( finska, svenska, samiska språk) till främmande språk eller tvärtom samt mellan inhemska språk. I det offentliga registret över auktoriserade translatorer finns endast uppgifter om de translatorer som har gett sitt samtycke till att deras uppgifter publiceras på webben. I fall av ett funktionsfel i registret vänligen kontakta vår e-postadress för att få kontaktuppgifter av auktoriserade translatorer auktoris.lautakunta@oph.fi",
         "filters": {
           "title": "Sök auktoriserad translator"
         },
         "noSearchResults": "Inga sökresultat",
         "note": "När du söker med språkpar är de möjliga sökalternativen från inhemska språk (finska, svenska, samiska) till främmande språk eller tvärtom samt mellan inhemska språk.",
-        "requestContact": "Kontakta oss",
+        "requestContact": "Kontakta",
         "title": "Register över auktoriserade translatorer"
       },
       "meetingDatesPage": {


### PR DESCRIPTION
## Yhteenveto

Käännökset tuli ladattua sharepointista excelinä ja muutettua noita jsoniksi `i18n-json-to-xlsx-converter`:ia hyödyntäen. Päivitin käännöksiä pääosin sharepointista tänne, tosin sharepointissa taisin muutaman käännösavaimen paikkaa myös taulukossa vaihtaa. Nyt sovelluksen käännökset jsonina mätsäävät sharepointin taulukoiden käännöksiin, `vimdiff`:llä varmistettu.

Saavutettavuuskäännöksien osalta sharepointtiin oli jäänyt joku vanha versio niistä ja päädyin lopulta korvaamaan sharepointissa vanhat käännökset näillä sovelluksen käännöksillä.

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
