### PR TITLE
OTR(Backend): OPHOTRKEH-172 onr käyttöön pilviympäristöissä ja muita konffimuutoksia

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/config/AppConfig.java
+++ b/backend/otr/src/main/java/fi/oph/otr/config/AppConfig.java
@@ -26,34 +26,34 @@ public class AppConfig {
   private static final Logger LOG = LoggerFactory.getLogger(AppConfig.class);
 
   @Bean
-  @ConditionalOnProperty(name = "otr.email.sending-enabled", havingValue = "false")
+  @ConditionalOnProperty(name = "app.email.sending-enabled", havingValue = "false")
   public EmailSender emailSenderNoOp() {
     LOG.warn("EmailSenderNoOp in use");
     return new EmailSenderNoOp();
   }
 
   @Bean
-  @ConditionalOnProperty(name = "otr.email.sending-enabled", havingValue = "true")
-  public EmailSender emailSender(@Value("${otr.email.ryhmasahkoposti-service-url}") String emailServiceUrl) {
+  @ConditionalOnProperty(name = "app.email.sending-enabled", havingValue = "true")
+  public EmailSender emailSender(@Value("${app.email.service-url}") String emailServiceUrl) {
     LOG.info("emailServiceUrl:{}", emailServiceUrl);
     final WebClient webClient = webClientBuilderWithCallerId().baseUrl(emailServiceUrl).build();
     return new EmailSenderViestintapalvelu(webClient, Constants.SERVICENAME, Constants.EMAIL_SENDER_NAME);
   }
 
   @Bean
-  @ConditionalOnProperty(name = "otr.onr.enabled", havingValue = "false")
+  @ConditionalOnProperty(name = "app.onr.enabled", havingValue = "false")
   public OnrOperationApi onrOperationApiMock() {
     LOG.warn("OnrOperationApiMock in use");
     return new OnrOperationApiMock();
   }
 
   @Bean
-  @ConditionalOnProperty(name = "otr.onr.enabled", havingValue = "true")
+  @ConditionalOnProperty(name = "app.onr.enabled", havingValue = "true")
   public OnrOperationApi onrOperationApiImpl(
-    @Value("${otr.onr.service-url}") String onrServiceUrl,
-    @Value("${otr.onr.cas.url}") String casUrl,
-    @Value("${otr.onr.cas.username}") String casUsername,
-    @Value("${otr.onr.cas.password}") String casPassword
+    @Value("${app.onr.service-url}") String onrServiceUrl,
+    @Value("${cas.url}") String casUrl,
+    @Value("${app.onr.cas.username}") String casUsername,
+    @Value("${app.onr.cas.password}") String casPassword
   ) {
     LOG.info("onrServiceUrl:{}", onrServiceUrl);
     final CasConfig casConfig = CasConfig.SpringSessionCasConfig(

--- a/backend/otr/src/main/java/fi/oph/otr/config/security/WebSecurityConfig.java
+++ b/backend/otr/src/main/java/fi/oph/otr/config/security/WebSecurityConfig.java
@@ -45,7 +45,7 @@ public class WebSecurityConfig {
   public ServiceProperties serviceProperties() {
     final ServiceProperties serviceProperties = new ServiceProperties();
     serviceProperties.setService(
-      environment.getRequiredProperty("cas.service") + environment.getRequiredProperty("cas.login-path")
+      environment.getRequiredProperty("cas.service-url") + environment.getRequiredProperty("cas.login-path")
     );
     serviceProperties.setSendRenew(environment.getRequiredProperty("cas.send-renew", Boolean.class));
     serviceProperties.setAuthenticateAllArtifacts(true);
@@ -58,7 +58,7 @@ public class WebSecurityConfig {
   @Bean
   public CasAuthenticationProvider casAuthenticationProvider() {
     final CasAuthenticationProvider casAuthenticationProvider = new CasAuthenticationProvider();
-    final String host = environment.getProperty("host-alb", environment.getRequiredProperty("host-virkailija"));
+    final String host = environment.getRequiredProperty("host.alb");
 
     casAuthenticationProvider.setUserDetailsService(new OphUserDetailsServiceImpl(host, Constants.CALLER_ID));
 
@@ -116,7 +116,7 @@ public class WebSecurityConfig {
   @Bean
   public CasAuthenticationEntryPoint casAuthenticationEntryPoint() {
     final CasAuthenticationEntryPoint casAuthenticationEntryPoint = new CasAuthenticationEntryPoint();
-    casAuthenticationEntryPoint.setLoginUrl(environment.getProperty("cas.login"));
+    casAuthenticationEntryPoint.setLoginUrl(environment.getProperty("cas.login-url"));
     casAuthenticationEntryPoint.setServiceProperties(serviceProperties());
     return casAuthenticationEntryPoint;
   }

--- a/backend/otr/src/main/resources/application.yaml
+++ b/backend/otr/src/main/resources/application.yaml
@@ -43,6 +43,8 @@ springdoc:
     path: /api/swagger-ui.html
   api-docs:
     path: /api/api-docs
+host:
+  alb: ${virkailija.host.alb:localhost:${server.port}}
 cas:
   key: otr
   send-renew: false
@@ -50,18 +52,16 @@ cas:
   logout-path: /cas/localLogout
   logout-success-path: /etusivu
   cookie-name: JSESSIONID
-  service: ${virkailija.cas.service:http://localhost:${server.port}/otr}
+  service-url: ${virkailija.cas.service-url:http://localhost:${server.port}/otr}
   url: ${virkailija.cas.url:http://localhost:${server.port}/otr}
-  login: ${virkailija.cas.login:http://localhost:${server.port}/login}
-host-virkailija: ${virkailija.host-virkailija:localhost:${server.port}}
-otr:
+  login-url: ${virkailija.cas.login-url:http://localhost:${server.port}/login}
+app:
   email:
     sending-enabled: ${email.sending-enabled:false}
-    ryhmasahkoposti-service-url: ${ryhmasahkoposti-service-url:null}
+    service-url: ${email.service-url:null}
   onr:
     enabled: ${onr.enabled:false}
     service-url: ${onr.service-url:https://virkailija.untuvaopintopolku.fi/oppijanumerorekisteri-service}
     cas:
-      url: ${virkailija.cas.url:https://virkailija.untuvaopintopolku.fi/cas}
-      username: ${oppijanumerorekisteri-service.rekisteri.username:username}
-      password: ${oppijanumerorekisteri-service.rekisteri.password:password}
+      username: ${onr.cas.username:username}
+      password: ${onr.cas.password:password}

--- a/backend/otr/src/main/resources/oph-configuration/otr.properties.template
+++ b/backend/otr/src/main/resources/oph-configuration/otr.properties.template
@@ -4,19 +4,17 @@ postgresql.url={{host_postgresql_otr}}
 postgresql.username={{postgres_app_user}}
 postgresql.password={{host_postgresql_otr_app_password}}
 
-host-cas: {{host_cas}}
-host-alb: {{host_alb}}
-virkailija.cas.url-base=https://{{host_cas}}
-virkailija.cas.service=https://{{host_virkailija}}/otr/virkailija
-virkailija.cas.url=${virkailija.cas.url-base}/cas
-virkailija.cas.login=${virkailija.cas.url-base}/cas/login
-virkailija.host-virkailija={{host_virkailija}}
+virkailija.host.alb={{host_alb}}
 
-url-alb={{host_alb}}
+virkailija.cas.base-url=https://{{host_cas}}
+virkailija.cas.service-url=${virkailija.cas.base-url}/otr/virkailija
+virkailija.cas.url=${virkailija.cas.base-url}/cas
+virkailija.cas.login-url=${virkailija.cas.base-url}/cas/login
+
 email.sending-enabled=true
-ryhmasahkoposti-service-url=${url-alb}/ryhmasahkoposti-service/email/firewall
+email.service-url=${virkailija.host.alb}/ryhmasahkoposti-service/email/firewall
 
-onr.enabled=false
-onr.service-url=${url-alb}/oppijanumerorekisteri-service
-oppijanumerorekisteri-service.rekisteri.username=
-oppijanumerorekisteri-service.rekisteri.password=
+onr.enabled=true
+onr.service-url=https://{{host_virkailija}}/oppijanumerorekisteri-service
+onr.cas.username={{otr_onr_cas_username}}
+onr.cas.password={{otr_onr_cas_password}}


### PR DESCRIPTION
## Yhteenveto

Päivitetty sovelluksen konfiguraatioita (application.yaml, otr.properties.template) siten, että oppijanumerorekisteri-integraatio toimii pilviympäristöissä `cloud-environment-untuva` alle viedyillä käyttäjätunnus-salasana parilla (samat kuin vanhan oikeustulkkirekisterin käyttämät). Refaktoroitu konfiguraatioiden käyttöä noin muutenkin.

Committia e2a9e2f vastaava versio on deployattu untuvalle.

## Huomautukset
- `cloud-environment-untuva` repoon on commitoitu nyt `opintopolku.yml` tiedostoon rivit, joilla määritetään `otr_onr_cas_username` ja `otr_onr_cas_password`. Nuo olisi varmaan parasta olla salaisuuksien hallinnan alla. Laitoin toistaiseksi tuonne sillä ei pitäisi heikentää tietoturvaa siitä miten tähänkään mennessä samainen käyttäjätunnus-salasana pari ollut selkokielellä luettavissa sieltä `oikeustulkkirekisteri`-sovelluksen käytettävänä.
- `{{host_virkailija}}` vastaa sisällöltään samaa kuin `{{host_cas}}` eli esim. untuvalla `virkailija.untuvaopintopolku.fi`
- Kontin konfiguraatioita untuvalla pääsee tarkastelemaan ajamalla `./tools/ecs-exec.sh untuva otr`

Jos oppijanumerorekisteri-integraatiota haluaa testata, niin voi sovelluksen päässä käydä esim. muokkaamassa Jari Hakalan tietoja (tulkki id:llä 3, https://virkailija.untuvaopintopolku.fi/henkilo-ui/virkailija/1.2.246.562.24.31234500003).
