### PR TITLE
OTR(Frontend): OPHOTRKEH-180 maksimikorkeus tulkin sivun yhteystietosarakkeille

### DIFF
--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetailsFields.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/ClerkInterpreterDetailsFields.tsx
@@ -346,7 +346,7 @@ export const ClerkInterpreterDetailsFields = ({
       </div>
       <H3>{t('header.contactInformation')}</H3>
       <div className="grid-columns gapped">
-        <div className="columns">
+        <div className="columns clerk-interpreter__details-fields__contact">
           <ClerkInterpreterDetailsTextField
             {...getCommonTextFieldProps(ClerkInterpreterTextFieldEnum.Email)}
             fullWidth
@@ -359,7 +359,7 @@ export const ClerkInterpreterDetailsFields = ({
           />
           <Text>{translateCommon('permissionToPublish')}</Text>
         </div>
-        <div className="columns">
+        <div className="columns clerk-interpreter__details-fields__contact">
           <ClerkInterpreterDetailsTextField
             {...getCommonTextFieldProps(
               ClerkInterpreterTextFieldEnum.PhoneNumber
@@ -374,7 +374,7 @@ export const ClerkInterpreterDetailsFields = ({
           />
           <Text>{translateCommon('permissionToPublish')}</Text>
         </div>
-        <div className="columns">
+        <div className="columns clerk-interpreter__details-fields__contact">
           <ClerkInterpreterDetailsTextField
             {...getCommonTextFieldProps(
               ClerkInterpreterTextFieldEnum.OtherContactInfo

--- a/frontend/packages/otr/src/styles/components/clerkInterpreter/_clerk-interpreter-details-fields.scss
+++ b/frontend/packages/otr/src/styles/components/clerkInterpreter/_clerk-interpreter-details-fields.scss
@@ -1,0 +1,8 @@
+.clerk-interpreter {
+  &__details-fields {
+    &__contact {
+      // Fixes heights of contact details columns in Safari
+      max-height: 53.7px;
+    }
+  }
+}

--- a/frontend/packages/otr/src/styles/styles.scss
+++ b/frontend/packages/otr/src/styles/styles.scss
@@ -11,6 +11,7 @@
 @import 'components/publicInterpreter/public-interpreter-listing';
 @import 'components/publicInterpreter/public-interpreter-filters';
 @import 'components/clerkInterpreter/clerk-interpreter-autocomplete-filters';
+@import 'components/clerkInterpreter/clerk-interpreter-details-fields';
 
 // Pages
 @import 'pages/clerk-homepage';


### PR DESCRIPTION
## Yhteenveto

Safarilla kun avataan tulkin sivu näytti selain yhteystietosarakkeet jostain syystä selvästi korkeampina kuin mitä ne näkyivät esim. Chromella tai Firefoxilla. Asetettu maksimikorkeus `53.7px` näille sarakkeille, kun Chromella ne vaikuttivat dev toolsin mukaan olevan tuon verran.
