### PR TITLE
AKR & OTR (Frontend): OPHAKRKEH-442 virkailijan etusivujen taulukoiden rivit linkkeinä

### DIFF
--- a/frontend/packages/akr/src/components/clerkTranslator/listing/ClerkTranslatorListing.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/listing/ClerkTranslatorListing.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, TableCell, TableHead, TableRow } from '@mui/material';
 import { Box } from '@mui/system';
 import { FC, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { H2, H3, PaginatedTable, Text } from 'shared/components';
 import { APIResponseStatus, Color } from 'shared/enums';
 import { DateUtils } from 'shared/utils';
@@ -49,36 +49,30 @@ const ListingRow = ({ translator }: { translator: ClerkTranslator }) => {
   const filteredSelectedIds = useAppSelector(selectFilteredSelectedIds);
   const dispatch = useAppDispatch();
 
-  const { lastName, firstName, authorisations } = translator;
+  const { id, lastName, firstName, authorisations } = translator;
 
   const visibleAuthorisations = [
-    authorisations.effective,
-    authorisations.expiredDeduplicated,
-    authorisations.formerVir,
-  ].flat();
+    ...authorisations.effective,
+    ...authorisations.expiredDeduplicated,
+    ...authorisations.formerVir,
+  ];
 
   const isSelected = filteredSelectedIds.includes(translator.id);
 
-  const navigate = useNavigate();
+  const overviewUrl = AppRoutes.ClerkTranslatorOverviewPage.replace(
+    /:translatorId$/,
+    `${id}`
+  );
 
-  const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
-    e?.stopPropagation();
-    navigate(
-      AppRoutes.ClerkTranslatorOverviewPage.replace(
-        /:translatorId$/,
-        `${translator.id}`
-      )
-    );
-    dispatch(setClerkTranslatorOverview(translator));
-  };
+  const handleRowClick = () => dispatch(setClerkTranslatorOverview(translator));
 
   const handleCheckboxClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
 
     if (isSelected) {
-      dispatch(deselectClerkTranslator(translator.id));
+      dispatch(deselectClerkTranslator(id));
     } else {
-      dispatch(selectClerkTranslator(translator.id));
+      dispatch(selectClerkTranslator(id));
     }
   };
 
@@ -121,20 +115,22 @@ const ListingRow = ({ translator }: { translator: ClerkTranslator }) => {
 
   return (
     <TableRow
-      className="cursor-pointer"
+      className="clerk-translator-listing__row"
       onClick={handleRowClick}
       selected={isSelected}
     >
       <TableCell padding="checkbox">
         <Checkbox
-          data-testid={`clerk-translators__id-${translator.id}-row`}
+          data-testid={`clerk-translators__id-${id}-row`}
           checked={isSelected}
           color={Color.Secondary}
           onClick={handleCheckboxClick}
         />
       </TableCell>
       <TableCell>
-        <Text>{`${lastName} ${firstName}`}</Text>
+        <Link className="clerk-translator-listing__row__link" to={overviewUrl}>
+          <Text>{`${lastName} ${firstName}`}</Text>
+        </Link>
       </TableCell>
       {Object.values(AuthorisationColumn).map((activeColumn) => (
         <TableCell key={activeColumn}>
@@ -236,7 +232,7 @@ export const ClerkTranslatorListing: FC = () => {
             initialRowsPerPage={10}
             rowsPerPageOptions={[10, 20, 50]}
             rowsPerPageLabel={t('component.table.pagination.rowsPerPage')}
-            className={'clerk-translator__listing table-layout-auto'}
+            className="table-layout-auto"
             stickyHeader
           />
         </>

--- a/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListing.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListing.tsx
@@ -69,7 +69,7 @@ export const ClerkInterpreterListing = () => {
           initialRowsPerPage={10}
           rowsPerPageOptions={[10, 20, 50]}
           rowsPerPageLabel={translateCommon('rowsPerPageLabel')}
-          className={'clerk-interpreter__listing table-layout-auto'}
+          className="table-layout-auto"
           stickyHeader
         />
       );

--- a/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingRow.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingRow.tsx
@@ -1,5 +1,5 @@
 import { TableCell, TableRow } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Text } from 'shared/components';
 import { DateUtils } from 'shared/utils';
 
@@ -21,29 +21,37 @@ export const ClerkInterpreterListingRow = ({
   const translateLanguage = useKoodistoLanguagesTranslation();
   const translateCommon = useCommonTranslation();
 
-  const dispatch = useAppDispatch();
-  const navigate = useNavigate();
-
-  const { lastName, nickName, qualifications } = interpreter;
+  const { id, lastName, nickName, qualifications } = interpreter;
 
   const visibleQualifications =
     QualificationUtils.getQualificationsVisibleInClerkHomePage(qualifications);
 
-  const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
-    e?.stopPropagation();
-    navigate(
-      AppRoutes.ClerkInterpreterOverviewPage.replace(
-        /:interpreterId$/,
-        `${interpreter.id}`
-      )
-    );
+  const overviewUrl = AppRoutes.ClerkInterpreterOverviewPage.replace(
+    /:interpreterId$/,
+    `${id}`
+  );
+
+  const dispatch = useAppDispatch();
+
+  /**
+   * Sets interpreter in `ClerkInterpreterOverviewState` to avoid excessive backend request
+   * to fetch details of the interpreter again when the overview page is opened.
+   *
+   * Remove in OPHOTRKEH-181 if listing endpoint is changed only to return the required data
+   * in listing view.
+   */
+  const handleRowClick = () =>
     dispatch(setClerkInterpreterOverview(interpreter));
-  };
 
   return (
-    <TableRow className="cursor-pointer" onClick={handleRowClick}>
+    <TableRow
+      className="clerk-interpreter-listing__row"
+      onClick={handleRowClick}
+    >
       <TableCell>
-        <Text>{`${lastName} ${nickName}`}</Text>
+        <Link className="clerk-interpreter-listing__row__link" to={overviewUrl}>
+          <Text>{`${lastName} ${nickName}`}</Text>
+        </Link>
       </TableCell>
       <TableCell>
         {visibleQualifications.map(({ fromLang, toLang }, k) => (

--- a/frontend/packages/otr/src/styles/components/clerkInterpreter/_clerk-interpreter-listing.scss
+++ b/frontend/packages/otr/src/styles/components/clerkInterpreter/_clerk-interpreter-listing.scss
@@ -1,12 +1,6 @@
-.clerk-translator-listing {
-  &__ineffective {
-    &#{&} {
-      color: $color-grey-600;
-    }
-  }
-
+.clerk-interpreter-listing {
   &__row {
-    td:nth-child(2) {
+    td:first-child {
       position: relative;
     }
 
@@ -22,7 +16,7 @@
       left: 0;
       position: absolute;
       top: 0;
-      width: 638%;
+      width: 659%;
     }
   }
 }

--- a/frontend/packages/otr/src/styles/styles.scss
+++ b/frontend/packages/otr/src/styles/styles.scss
@@ -11,6 +11,7 @@
 @import 'components/publicInterpreter/public-interpreter-listing';
 @import 'components/publicInterpreter/public-interpreter-filters';
 @import 'components/clerkInterpreter/clerk-interpreter-autocomplete-filters';
+@import 'components/clerkInterpreter/clerk-interpreter-listing';
 
 // Pages
 @import 'pages/clerk-homepage';

--- a/frontend/packages/vkt/src/components/clerkExamEvent/listing/ClerkExamEventListingRow.tsx
+++ b/frontend/packages/vkt/src/components/clerkExamEvent/listing/ClerkExamEventListingRow.tsx
@@ -1,6 +1,6 @@
 import { TableCell, TableRow } from '@mui/material';
 import { Dayjs } from 'dayjs';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Text } from 'shared/components';
 
 import { useCommonTranslation } from 'configs/i18n';
@@ -15,32 +15,32 @@ export const ClerkExamEventListingRow = ({
 }) => {
   const translateCommon = useCommonTranslation();
 
-  const navigate = useNavigate();
-
-  const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
-    e?.stopPropagation();
-    navigate(
-      AppRoutes.ClerkExamEventPage.replace(/:examEventId$/, `${examEvent.id}`)
-    );
-  };
+  const examEventUrl = AppRoutes.ClerkExamEventPage.replace(
+    /:examEventId$/,
+    `${examEvent.id}`
+  );
 
   const formatDate = (date: Dayjs) => date.format('DD.MM.YYYY');
 
   return (
     <>
       <TableRow
-        className="cursor-pointer"
+        className="clerk-exam-event-listing__row"
         data-testid={`clerk-exam-events__id-${examEvent.id}-row`}
-        onClick={handleRowClick}
       >
         <TableCell>
-          <Text>
-            {ExamEventUtils.languageAndLevelText(
-              examEvent.language,
-              examEvent.level,
-              translateCommon
-            )}
-          </Text>
+          <Link
+            className="clerk-exam-event-listing__row__link"
+            to={examEventUrl}
+          >
+            <Text>
+              {ExamEventUtils.languageAndLevelText(
+                examEvent.language,
+                examEvent.level,
+                translateCommon
+              )}
+            </Text>
+          </Link>
         </TableCell>
         <TableCell>
           <Text>{formatDate(examEvent.date)}</Text>

--- a/frontend/packages/vkt/src/styles/components/clerkExamEvent/_clerk-exam-event-listing.scss
+++ b/frontend/packages/vkt/src/styles/components/clerkExamEvent/_clerk-exam-event-listing.scss
@@ -1,12 +1,6 @@
-.clerk-translator-listing {
-  &__ineffective {
-    &#{&} {
-      color: $color-grey-600;
-    }
-  }
-
+.clerk-exam-event-listing {
   &__row {
-    td:nth-child(2) {
+    td:first-child {
       position: relative;
     }
 
@@ -22,7 +16,7 @@
       left: 0;
       position: absolute;
       top: 0;
-      width: 638%;
+      width: 489%;
     }
   }
 }

--- a/frontend/packages/vkt/src/styles/styles.scss
+++ b/frontend/packages/vkt/src/styles/styles.scss
@@ -5,6 +5,7 @@
 @import 'base/base';
 
 // Components
+@import 'components/clerkExamEvent/clerk-exam-event-listing';
 @import 'components/i18n/lang-selector';
 @import 'components/layouts/header';
 @import 'components/layouts/footer';


### PR DESCRIPTION
## Yhteenveto

Toistaiseksi draft pull request, joka pyrkii asettamaan tulkkien rivit klikattaviksi OTR:n virkailijan etusivulla. Toteutus vastaa `passatgt`:n vastausta stackoverflowssa pl. se, että rivin leveyttä ei pakoteta: https://stackoverflow.com/questions/17147821/how-to-make-a-whole-row-in-a-table-clickable-as-a-link

Ongelmana tässä se, että width: 660% (tai 659% ehkä parempi) tekee rivin koko sen leveydeltään klikattavaksi kun screenin leveys on tarpeeksi iso. Pienemmällä ikkunakoolla kun sarakkeiden tekstit sovitetaan mahdollisesti kahdelle riville (nimi), ei tuo 660% linkin leveys kata enää koko riviä vaan oikealla ei ole enää responsiivisuutta. Jos kuitenkin parempi kuin alkuperäinen toteutus ja parempaakaan ei löydetä, niin voitanee mennä tälläkin?

Tehdään muutos vielä AKR:n puolelle sitten jos/kun vaikuttaa sellaiselta että sopii OTR:n tarpeeseen.