### PR TITLE
OPHOTRKEH-180: Fix ClerkInterpreterDetails on Safari

### DIFF
--- a/frontend/packages/akr/package.json
+++ b/frontend/packages/akr/package.json
@@ -22,6 +22,6 @@
     "akr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.7"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.9"
   }
 }

--- a/frontend/packages/otr/package.json
+++ b/frontend/packages/otr/package.json
@@ -25,6 +25,6 @@
     "otr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.7"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.9"
   }
 }

--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.3.9] - 2022-10-11
+
+### Changed
+
+- Remove `maxHeight: 100%` from the `columns` CSS class.
+  Doesn't seem to affect layout in any other way than circumventing
+  an issue on Safari when a child with this class is contained within
+  a grid row.
+
 ## [1.3.8] - 2022-10-04
 
 ### Added

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/styles/abstracts/common/_layout.scss
+++ b/frontend/packages/shared/src/styles/abstracts/common/_layout.scss
@@ -9,7 +9,6 @@
   align-items: center;
   display: flex;
   flex-direction: row;
-  max-height: 100%;
 }
 
 .flex-end {

--- a/frontend/packages/vkt/package.json
+++ b/frontend/packages/vkt/package.json
@@ -25,6 +25,6 @@
     "vkt:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.6"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.9"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2517,7 +2517,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.akr@workspace:packages/akr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.7"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.9"
   languageName: unknown
   linkType: soft
 
@@ -2525,7 +2525,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.otr@workspace:packages/otr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.7"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.9"
   languageName: unknown
   linkType: soft
 
@@ -2614,7 +2614,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.9":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -2624,7 +2624,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.vkt@workspace:packages/vkt"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.6"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.9"
   languageName: unknown
   linkType: soft
 
@@ -11146,20 +11146,6 @@ __metadata:
   dependencies:
     kind-of: ^6.0.2
   checksum: 39b3dd9630a774aba288a680e7d2901f5c0eae7b8387fc5c8ea559918b29b3da144b7bdb990d7ccd9e11be05508ac9e459ce51d01fd65e583282f6ffafcba2e7
-  languageName: node
-  linkType: hard
-
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.6":
-  version: 1.3.6
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.3.6::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.3.6%2F0b2a2ac06e629c5cf1e38b11d879247f5d04ed8d"
-  checksum: 31d6a5ffc2d053367454fafe519c7e6a8dfe87f2b375e7460b51539cff77b83187535bb8384960382264ad5d0e960fa3a7e8dc33f36e84094f4186a3caf34aa4
-  languageName: node
-  linkType: hard
-
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.3.7":
-  version: 1.3.7
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.3.7::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.3.7%2F10821b861d9d8fb181fddc4a71dd7fb73f49cac4"
-  checksum: 25e9b1dd9dbd0366f76daa7cdc7a735d71e2cec25a2428f030ccde9f149d7464748c12b03a9f066ccc87b1d773115f26da8f3b5d2b3f56b122d5b82b5f1be7cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Poistettu ilmeisesti turha `max-height: 100%` määrittely `columns`-luokasta. Jostain syystä ko. asetus sai Safarin laskemaan elementin korkeuden väärin tässä tapauksessa jossa elementti oli gridin sisällä.

## Huomautukset

Päivitetty myös AKR:n ja VKT:n osalta dependencyt jotta voidaan varmistaa ettei CSS-muutos riko mitään layouttia.
