### PR TITLE
AKR & VKT(Backend): OPHAKRKEH-444 sovelluksen konffien refaktorointia

### DIFF
--- a/backend/akr/src/main/java/fi/oph/akr/config/AppConfig.java
+++ b/backend/akr/src/main/java/fi/oph/akr/config/AppConfig.java
@@ -20,15 +20,15 @@ public class AppConfig {
   private static final Logger LOG = LoggerFactory.getLogger(AppConfig.class);
 
   @Bean
-  @ConditionalOnProperty(name = "akr.email.sending-enabled", havingValue = "false")
+  @ConditionalOnProperty(name = "app.email.sending-enabled", havingValue = "false")
   public EmailSender emailSenderNoOp() {
     LOG.warn("EmailSenderNoOp in use");
     return new EmailSenderNoOp();
   }
 
   @Bean
-  @ConditionalOnProperty(name = "akr.email.sending-enabled", havingValue = "true")
-  public EmailSender emailSender(@Value("${akr.email.ryhmasahkoposti-service-url}") String emailServiceUrl) {
+  @ConditionalOnProperty(name = "app.email.sending-enabled", havingValue = "true")
+  public EmailSender emailSender(@Value("${app.email.service-url}") String emailServiceUrl) {
     LOG.info("emailServiceUrl:{}", emailServiceUrl);
     final WebClient webClient = webClientBuilderWithCallerId().baseUrl(emailServiceUrl).build();
     return new EmailSenderViestintapalvelu(webClient, Constants.SERVICENAME, Constants.EMAIL_SENDER_NAME);

--- a/backend/akr/src/main/java/fi/oph/akr/config/security/WebSecurityConfig.java
+++ b/backend/akr/src/main/java/fi/oph/akr/config/security/WebSecurityConfig.java
@@ -45,7 +45,7 @@ public class WebSecurityConfig {
   public ServiceProperties serviceProperties() {
     final ServiceProperties serviceProperties = new ServiceProperties();
     serviceProperties.setService(
-      environment.getRequiredProperty("cas.service") + environment.getRequiredProperty("cas.login-path")
+      environment.getRequiredProperty("cas.service-url") + environment.getRequiredProperty("cas.login-path")
     );
     serviceProperties.setSendRenew(environment.getRequiredProperty("cas.send-renew", Boolean.class));
     serviceProperties.setAuthenticateAllArtifacts(true);
@@ -58,7 +58,7 @@ public class WebSecurityConfig {
   @Bean
   public CasAuthenticationProvider casAuthenticationProvider() {
     final CasAuthenticationProvider casAuthenticationProvider = new CasAuthenticationProvider();
-    final String host = environment.getProperty("host-alb", environment.getRequiredProperty("host-virkailija"));
+    final String host = environment.getRequiredProperty("host.alb");
 
     casAuthenticationProvider.setUserDetailsService(new OphUserDetailsServiceImpl(host, Constants.CALLER_ID));
 
@@ -116,7 +116,7 @@ public class WebSecurityConfig {
   @Bean
   public CasAuthenticationEntryPoint casAuthenticationEntryPoint() {
     final CasAuthenticationEntryPoint casAuthenticationEntryPoint = new CasAuthenticationEntryPoint();
-    casAuthenticationEntryPoint.setLoginUrl(environment.getProperty("cas.login"));
+    casAuthenticationEntryPoint.setLoginUrl(environment.getProperty("cas.login-url"));
     casAuthenticationEntryPoint.setServiceProperties(serviceProperties());
     return casAuthenticationEntryPoint;
   }

--- a/backend/akr/src/main/java/fi/oph/akr/scheduled/ExpiringAuthorisationsEmailCreator.java
+++ b/backend/akr/src/main/java/fi/oph/akr/scheduled/ExpiringAuthorisationsEmailCreator.java
@@ -39,7 +39,7 @@ public class ExpiringAuthorisationsEmailCreator {
   @Scheduled(cron = "0 0 3 * * *")
   @SchedulerLock(name = "checkExpiringAuthorisations", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
   public void checkExpiringAuthorisations() {
-    if (!environment.getRequiredProperty("akr.create-expiry-emails-enabled", Boolean.class)) {
+    if (!environment.getRequiredProperty("app.create-expiry-emails-enabled", Boolean.class)) {
       LOG.info("Expiry emails creation is disabled, do nothing.");
       return;
     }

--- a/backend/akr/src/main/java/fi/oph/akr/service/ContactRequestService.java
+++ b/backend/akr/src/main/java/fi/oph/akr/service/ContactRequestService.java
@@ -198,7 +198,7 @@ public class ContactRequestService {
       "requesterPhone",
       requesterPhone.isEmpty() ? "-" : requesterPhone,
       "akrHost",
-      environment.getRequiredProperty("host-virkailija")
+      environment.getRequiredProperty("host.virkailija")
     );
 
     final String recipientName = "Auktorisoitujen kääntäjien tutkintolautakunta";

--- a/backend/akr/src/main/resources/application.yaml
+++ b/backend/akr/src/main/resources/application.yaml
@@ -43,11 +43,9 @@ springdoc:
     path: /api/swagger-ui.html
   api-docs:
     path: /api/api-docs
-akr:
-  create-expiry-emails-enabled: ${create-expiry-emails-enabled:false}
-  email:
-    sending-enabled: ${email.sending-enabled:false}
-    ryhmasahkoposti-service-url: ${ryhmasahkoposti-service-url:null}
+host:
+  alb: ${virkailija.host.alb:localhost:${server.port}}
+  virkailija: ${virkailija.host.virkailija:localhost:${server.port}}
 cas:
   key: akr
   send-renew: false
@@ -55,7 +53,11 @@ cas:
   logout-path: /cas/localLogout
   logout-success-path: /etusivu
   cookie-name: JSESSIONID
-  service: ${virkailija.cas.service:http://localhost:${server.port}/akr}
+  service-url: ${virkailija.cas.service-url:http://localhost:${server.port}/akr}
   url: ${virkailija.cas.url:http://localhost:${server.port}/akr}
-  login: ${virkailija.cas.login:http://localhost:${server.port}/login}
-host-virkailija: ${virkailija.host-virkailija:localhost:${server.port}}
+  login-url: ${virkailija.cas.login-url:http://localhost:${server.port}/login}
+app:
+  create-expiry-emails-enabled: ${create-expiry-emails-enabled:false}
+  email:
+    sending-enabled: ${email.sending-enabled:false}
+    service-url: ${email.service-url:null}

--- a/backend/akr/src/main/resources/oph-configuration/akr.properties.template
+++ b/backend/akr/src/main/resources/oph-configuration/akr.properties.template
@@ -4,15 +4,14 @@ postgresql.url={{host_postgresql_akr}}
 postgresql.username={{postgres_app_user}}
 postgresql.password={{host_postgresql_akr_app_password}}
 
-host-cas: {{host_cas}}
-host-alb: {{host_alb}}
-virkailija.cas.url-base=https://{{host_cas}}
-virkailija.cas.service=https://{{host_virkailija}}/akr/virkailija
-virkailija.cas.url=${virkailija.cas.url-base}/cas
-virkailija.cas.login=${virkailija.cas.url-base}/cas/login
-virkailija.host-virkailija={{host_virkailija}}
+virkailija.host.alb={{host_alb}}
+virkailija.host.virkailija={{host_virkailija}}
 
-url-alb={{host_alb}}
-email.sending-enabled=true
-ryhmasahkoposti-service-url=${url-alb}/ryhmasahkoposti-service/email/firewall
+virkailija.cas.base-url=https://{{host_cas}}
+virkailija.cas.service-url=${virkailija.cas.base-url}/akr/virkailija
+virkailija.cas.url=${virkailija.cas.base-url}/cas
+virkailija.cas.login-url=${virkailija.cas.base-url}/cas/login
+
 create-expiry-emails-enabled=false
+email.sending-enabled=true
+email.service-url=${virkailija.host.alb}/ryhmasahkoposti-service/email/firewall

--- a/backend/akr/src/test/java/fi/oph/akr/scheduled/ExpiringAuthorisationsEmailCreatorTest.java
+++ b/backend/akr/src/test/java/fi/oph/akr/scheduled/ExpiringAuthorisationsEmailCreatorTest.java
@@ -56,7 +56,7 @@ public class ExpiringAuthorisationsEmailCreatorTest {
 
   private void doSetup(final boolean createExpiryEmailsEnabled) {
     final Environment environment = mock(Environment.class);
-    when(environment.getRequiredProperty("akr.create-expiry-emails-enabled", Boolean.class))
+    when(environment.getRequiredProperty("app.create-expiry-emails-enabled", Boolean.class))
       .thenReturn(createExpiryEmailsEnabled);
     emailCreator = new ExpiringAuthorisationsEmailCreator(authorisationRepository, clerkEmailService, environment);
   }

--- a/backend/vkt/src/main/java/fi/oph/vkt/config/security/WebSecurityConfig.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/config/security/WebSecurityConfig.java
@@ -45,7 +45,7 @@ public class WebSecurityConfig {
   public ServiceProperties serviceProperties() {
     final ServiceProperties serviceProperties = new ServiceProperties();
     serviceProperties.setService(
-      environment.getRequiredProperty("cas.service") + environment.getRequiredProperty("cas.login-path")
+      environment.getRequiredProperty("cas.service-url") + environment.getRequiredProperty("cas.login-path")
     );
     serviceProperties.setSendRenew(environment.getRequiredProperty("cas.send-renew", Boolean.class));
     serviceProperties.setAuthenticateAllArtifacts(true);
@@ -58,7 +58,7 @@ public class WebSecurityConfig {
   @Bean
   public CasAuthenticationProvider casAuthenticationProvider() {
     final CasAuthenticationProvider casAuthenticationProvider = new CasAuthenticationProvider();
-    final String host = environment.getProperty("host-alb", environment.getRequiredProperty("host-virkailija"));
+    final String host = environment.getRequiredProperty("host.alb");
 
     casAuthenticationProvider.setUserDetailsService(new OphUserDetailsServiceImpl(host, Constants.CALLER_ID));
 
@@ -116,7 +116,7 @@ public class WebSecurityConfig {
   @Bean
   public CasAuthenticationEntryPoint casAuthenticationEntryPoint() {
     final CasAuthenticationEntryPoint casAuthenticationEntryPoint = new CasAuthenticationEntryPoint();
-    casAuthenticationEntryPoint.setLoginUrl(environment.getProperty("cas.login"));
+    casAuthenticationEntryPoint.setLoginUrl(environment.getProperty("cas.login-url"));
     casAuthenticationEntryPoint.setServiceProperties(serviceProperties());
     return casAuthenticationEntryPoint;
   }

--- a/backend/vkt/src/main/resources/application.yaml
+++ b/backend/vkt/src/main/resources/application.yaml
@@ -43,6 +43,8 @@ springdoc:
     path: /api/swagger-ui.html
   api-docs:
     path: /api/api-docs
+host:
+  alb: ${virkailija.host.alb:localhost:${server.port}}
 cas:
   key: vkt
   send-renew: false
@@ -50,7 +52,6 @@ cas:
   logout-path: /cas/localLogout
   logout-success-path: /etusivu
   cookie-name: JSESSIONID
-  service: ${virkailija.cas.service:http://localhost:${server.port}/vkt}
+  service-url: ${virkailija.cas.service-url:http://localhost:${server.port}/vkt}
   url: ${virkailija.cas.url:http://localhost:${server.port}/vkt}
-  login: ${virkailija.cas.login:http://localhost:${server.port}/login}
-host-virkailija: ${virkailija.host-virkailija:localhost:${server.port}}
+  login-url: ${virkailija.cas.login-url:http://localhost:${server.port}/login}

--- a/backend/vkt/src/main/resources/oph-configuration/vkt.properties.template
+++ b/backend/vkt/src/main/resources/oph-configuration/vkt.properties.template
@@ -4,12 +4,9 @@ postgresql.url={{host_postgresql_vkt}}
 postgresql.username={{postgres_app_user}}
 postgresql.password={{host_postgresql_vkt_app_password}}
 
-host-cas: {{host_cas}}
-host-alb: {{host_alb}}
-virkailija.cas.url-base=https://{{host_cas}}
-virkailija.cas.service=https://{{host_virkailija}}/vkt/virkailija
-virkailija.cas.url=${virkailija.cas.url-base}/cas
-virkailija.cas.login=${virkailija.cas.url-base}/cas/login
-virkailija.host-virkailija={{host_virkailija}}
+virkailija.host.alb={{host_alb}}
 
-url-alb={{host_alb}}
+virkailija.cas.base-url=https://{{host_cas}}
+virkailija.cas.service-url=${virkailija.cas.base-url}/vkt/virkailija
+virkailija.cas.url=${virkailija.cas.base-url}/cas
+virkailija.cas.login-url=${virkailija.cas.base-url}/cas/login


### PR DESCRIPTION
Vastaavat selkeytykset sovelluksen konfiguraatioihin AKR:n ja VKT:n puolelle kuin OTR:ään tehty oppijanumerorekisterin käyttöönoton yhteydessä: https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/286

AKR:n versio ad67396 testattu untuvalla toimivaksi ja on ajossa siellä paraikaa. Ajossa oleva versio vastaa AKR:n osalta commitin 9fb47db tilaa. Halutessa ennen mergeä voisi viedä vielä uudestaan nämä muutokset testiajoon untuvalle jos logback-spring muutokset veisi myös deviin.