### PR TITLE
VKT(Frontend): Fix flaky Cypress tests

### DIFF
--- a/frontend/packages/vkt/package.json
+++ b/frontend/packages/vkt/package.json
@@ -16,7 +16,7 @@
     "vkt:lint": "yarn vkt:eslint && yarn vkt:tslint && yarn vkt:stylelint && yarn vkt:exportlint",
     "vkt:qa": "yarn vkt:lint && yarn vkt:format && yarn vkt:test:jest && yarn vkt:start:ci",
     "vkt:start": "yarn g:webpack serve --config webpack.config.js --env proxy=http://localhost:8082",
-    "vkt:start:ci": "yarn g:webpack serve --env cypress --config webpack.config.js --no-open",
+    "vkt:start:ci": "yarn g:webpack serve --env cypress --env prod --config webpack.config.js --no-open --no-client-overlay",
     "vkt:start:docker-compose": "yarn g:webpack serve --config webpack.config.js --env proxy=http://vkt-backend:8082 --env docker",
     "vkt:stylelint": "yarn g:stylelint --fix \"./src/**/*.scss\"",
     "vkt:test:cypress": "TZ=Europe/Helsinki yarn g:cypress run",

--- a/frontend/packages/vkt/src/components/clerkExamEvent/ClerkExamEventGrid.tsx
+++ b/frontend/packages/vkt/src/components/clerkExamEvent/ClerkExamEventGrid.tsx
@@ -1,13 +1,11 @@
 import { Grid, Paper } from '@mui/material';
-import { useEffect } from 'react';
 import { H1 } from 'shared/components';
 import { APIResponseStatus } from 'shared/enums';
 
 import { ClerkExamEventListing } from 'components/clerkExamEvent/listing/ClerkExamEventListing';
 import { PublicExamEventGridSkeleton } from 'components/skeletons/PublicExamEventGridSkeleton';
 import { useClerkTranslation } from 'configs/i18n';
-import { useAppDispatch, useAppSelector } from 'configs/redux';
-import { loadExamEvents } from 'redux/reducers/clerkListExamEvent';
+import { useAppSelector } from 'configs/redux';
 import {
   clerkListExamEventsSelector,
   selectFilteredClerkExamEvents,
@@ -21,16 +19,8 @@ export const ClerkExamEventGrid = () => {
   const { status } = useAppSelector(clerkListExamEventsSelector);
   const examEvents = useAppSelector(selectFilteredClerkExamEvents);
 
-  const dispatch = useAppDispatch();
-
   // State
   const isLoading = status === APIResponseStatus.InProgress;
-
-  useEffect(() => {
-    if (status === APIResponseStatus.NotStarted) {
-      dispatch(loadExamEvents());
-    }
-  }, [dispatch, status]);
 
   return (
     <>

--- a/frontend/packages/vkt/src/components/publicExamEvent/PublicExamEventGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/PublicExamEventGrid.tsx
@@ -1,6 +1,5 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Alert, Grid, Paper } from '@mui/material';
-import { useEffect } from 'react';
 import { Trans } from 'react-i18next';
 import { ExtLink, H1, H2, HeaderSeparator, Text } from 'shared/components';
 import { APIResponseStatus, Severity } from 'shared/enums';
@@ -8,8 +7,7 @@ import { APIResponseStatus, Severity } from 'shared/enums';
 import { PublicExamEventListing } from 'components/publicExamEvent/listing/PublicExamEventListing';
 import { PublicExamEventGridSkeleton } from 'components/skeletons/PublicExamEventGridSkeleton';
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
-import { useAppDispatch, useAppSelector } from 'configs/redux';
-import { loadPublicExamEvents } from 'redux/reducers/publicExamEvent';
+import { useAppSelector } from 'configs/redux';
 import { publicExamEventsSelector } from 'redux/selectors/publicExamEvent';
 
 export const PublicExamEventGrid = () => {
@@ -19,17 +17,10 @@ export const PublicExamEventGrid = () => {
 
   // Redux
   const { status, examEvents } = useAppSelector(publicExamEventsSelector);
-  const dispatch = useAppDispatch();
 
   // State
   const isLoading = status === APIResponseStatus.InProgress;
   const hasResults = examEvents.length > 0;
-
-  useEffect(() => {
-    if (status === APIResponseStatus.NotStarted) {
-      dispatch(loadPublicExamEvents());
-    }
-  }, [dispatch, status]);
 
   return (
     <>

--- a/frontend/packages/vkt/src/pages/ClerkHomePage.tsx
+++ b/frontend/packages/vkt/src/pages/ClerkHomePage.tsx
@@ -1,17 +1,31 @@
 import { Box, Grid } from '@mui/material';
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
+import { APIResponseStatus } from 'shared/enums';
 
 import { ClerkExamEventGrid } from 'components/clerkExamEvent/ClerkExamEventGrid';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { loadExamEvents } from 'redux/reducers/clerkListExamEvent';
+import { clerkListExamEventsSelector } from 'redux/selectors/clerkListExamEvent';
 
-export const ClerkHomePage: FC = () => (
-  <Box className="clerk-homepage">
-    <Grid
-      container
-      rowSpacing={4}
-      direction="column"
-      className="clerk-homepage__grid-container"
-    >
-      <ClerkExamEventGrid />
-    </Grid>
-  </Box>
-);
+export const ClerkHomePage: FC = () => {
+  const dispatch = useAppDispatch();
+  const { status } = useAppSelector(clerkListExamEventsSelector);
+  useEffect(() => {
+    if (status === APIResponseStatus.NotStarted) {
+      dispatch(loadExamEvents());
+    }
+  }, [dispatch, status]);
+
+  return (
+    <Box className="clerk-homepage">
+      <Grid
+        container
+        rowSpacing={4}
+        direction="column"
+        className="clerk-homepage__grid-container"
+      >
+        <ClerkExamEventGrid />
+      </Grid>
+    </Box>
+  );
+};

--- a/frontend/packages/vkt/src/pages/ClerkHomePage.tsx
+++ b/frontend/packages/vkt/src/pages/ClerkHomePage.tsx
@@ -10,6 +10,7 @@ import { clerkListExamEventsSelector } from 'redux/selectors/clerkListExamEvent'
 export const ClerkHomePage: FC = () => {
   const dispatch = useAppDispatch();
   const { status } = useAppSelector(clerkListExamEventsSelector);
+
   useEffect(() => {
     if (status === APIResponseStatus.NotStarted) {
       dispatch(loadExamEvents());

--- a/frontend/packages/vkt/src/pages/PublicHomePage.tsx
+++ b/frontend/packages/vkt/src/pages/PublicHomePage.tsx
@@ -1,17 +1,27 @@
 import { Box, Grid } from '@mui/material';
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 
 import { PublicExamEventGrid } from 'components/publicExamEvent/PublicExamEventGrid';
+import { useAppDispatch } from 'configs/redux';
+import { loadPublicExamEvents } from 'redux/reducers/publicExamEvent';
 
-export const PublicHomePage: FC = () => (
-  <Box className="public-homepage">
-    <Grid
-      container
-      rowSpacing={4}
-      direction="column"
-      className="public-homepage__grid-container"
-    >
-      <PublicExamEventGrid />
-    </Grid>
-  </Box>
-);
+export const PublicHomePage: FC = () => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(loadPublicExamEvents());
+  }, [dispatch]);
+
+  return (
+    <Box className="public-homepage">
+      <Grid
+        container
+        rowSpacing={4}
+        direction="column"
+        className="public-homepage__grid-container"
+      >
+        <PublicExamEventGrid />
+      </Grid>
+    </Box>
+  );
+};

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -174,7 +174,7 @@ const getESLintPlugin = (env) => {
 
 const getHtmlWebpackPlugin = (env, appName, dirName) => {
   const configs = {
-    publicPath: env.prod ? `/${appName}/` : "/",
+    publicPath: (env.prod && !env.cypress) ? `/${appName}/` : "/",
     template: path.join(dirName, "public", "index.html"),
     templateParameters: {
       GIT_INFO: "Not available",


### PR DESCRIPTION
## Yhteenveto

Tämän PR:n ydin on että CI:llä Cypress-testejä ajetaan tuotantobuildattua JS:ää vasten. 
Tuotantobuildatun JS:n tärkein ero tämän PR:n näkökulmasta development buildiin on se, että tuotantobuildissa Reactin [Strict Mode](https://reactjs.org/docs/strict-mode.html) ei ole käytössä.

Reactin Strict Mode on tarkoitettu auttamaan devausta mm. paljastamalla epäturvallisia patterneja koodista, ja tämän aikaansaamiseksi Strict Mode mm. remountaa komponentteja niiden ensimmäisellä luontikerralla. Tästä käsittääkseni johtuu esimerkiksi se että lokaalisti devatessa useat requestit tehdään tuplana, kun taas tuotantobuildilla (esim. eri opintopolku-ympäristöissä) tätä ei tapahdu.

Hypoteesini taas VKT:hen liittyen on että tuo komponenttien remountti joko itsessään tai sitten tuplana tapahtuvasta API-kutsusta aiheutuva re-render saa aikaan sen että elementti jota Cypress yrittää manipuloida poistuu kriittisellä hetkellä DOMista. 
En osaa suoraan sanoa miksi tämä näkyy nyt juuri VKT:n testeissä, mutta mikäli tämä koetaan järkeväksi korjaukseksi, niin voisi kenties ottaa käyttöön myös muissa projekteissa.