### PR TITLE
VKT(Backend): OPHVKTKEH-43 ilmoittautujien tiedot kantaan

### DIFF
--- a/backend/vkt/db/1_tables.sql
+++ b/backend/vkt/db/1_tables.sql
@@ -150,7 +150,15 @@ CREATE TABLE public.person (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     modified_at timestamp with time zone DEFAULT now() NOT NULL,
     deleted_at timestamp with time zone,
-    onr_id character varying(255) NOT NULL
+    identity_number character varying(255) NOT NULL,
+    last_name text NOT NULL,
+    first_name text NOT NULL,
+    email text NOT NULL,
+    phone_number text NOT NULL,
+    street text,
+    postal_code text,
+    town text,
+    country text
 );
 
 
@@ -235,11 +243,11 @@ ALTER TABLE ONLY public.exam_event
 
 
 --
--- Name: person uk_person_onr_id; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: person uk_person_identity_number; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.person
-    ADD CONSTRAINT uk_person_onr_id UNIQUE (onr_id);
+    ADD CONSTRAINT uk_person_identity_number UNIQUE (identity_number);
 
 
 --

--- a/backend/vkt/db/3_liquibase.sql
+++ b/backend/vkt/db/3_liquibase.sql
@@ -69,6 +69,7 @@ COPY public.databasechangelog (id, author, filename, dateexecuted, orderexecuted
 2022-09-19-create-table-person	mikhuttu	migrations.xml	2022-09-28 13:03:11.580327	4	EXECUTED	8:1218e1e61ba39ea9793c670923ee5a80	createTable tableName=person; addUniqueConstraint constraintName=uk_person_onr_id, tableName=person		\N	4.9.1	\N	\N	4370191374
 2022-09-19-create-table-enrollment_status	mikhuttu	migrations.xml	2022-09-28 13:03:11.593403	5	EXECUTED	8:cb6dc3009864c99347b4097cd3d777a1	createTable tableName=enrollment_status; insert tableName=enrollment_status; insert tableName=enrollment_status; insert tableName=enrollment_status; insert tableName=enrollment_status		\N	4.9.1	\N	\N	4370191374
 2022-09-19-create-table-enrollment	mikhuttu	migrations.xml	2022-09-28 13:03:11.613202	6	EXECUTED	8:edba4d8326701eb21ede9eb4afb6c628	createTable tableName=enrollment; addForeignKeyConstraint baseTableName=enrollment, constraintName=fk_enrollment_exam_event, referencedTableName=exam_event; addForeignKeyConstraint baseTableName=enrollment, constraintName=fk_enrollment_person, ref...		\N	4.9.1	\N	\N	4370191374
+2022-10-12-change-person-columns	mikhuttu	migrations.xml	2022-10-12 18:42:43.132484	7	EXECUTED	8:d27f77bcff4989716b0be1fb83639ccf	dropColumn tableName=person; addColumn tableName=person; addUniqueConstraint constraintName=uk_person_identity_number, tableName=person		\N	4.9.1	\N	\N	5600162993
 \.
 
 

--- a/backend/vkt/db/4_init.sql
+++ b/backend/vkt/db/4_init.sql
@@ -171,9 +171,39 @@ VALUES (
 );
 
 -- Insert persons
-INSERT INTO person(onr_id)
-SELECT ('1.2.246.562.24.312345000' || lpad(i::text, 2, '0'))
-FROM generate_series(1, 22) i;
+INSERT INTO person(identity_number, last_name, first_name, email, phone_number, street, postal_code, town, country)
+SELECT
+  'id' || i::text,
+  last_names[mod(i, array_length(last_names, 1)) + 1],
+  first_names[mod(i, array_length(first_names, 1)) + 1],
+  'person' || i::text || '@example.invalid',
+  '+35840' || (1000000 + i)::text,
+  CASE mod(i, 5)
+    WHEN 0 THEN streets[mod(i / 5 - 1, array_length(streets, 1)) + 1]
+    ELSE NULL
+    END,
+  CASE mod(i, 5)
+    WHEN 0 THEN postal_codes[mod(i / 5 - 1, array_length(postal_codes, 1)) + 1]
+    ELSE NULL
+    END,
+  CASE mod(i, 5)
+    WHEN 0 THEN towns[mod(i / 5 - 1, array_length(towns, 1)) + 1]
+    ELSE NULL
+    END,
+  CASE mod(i, 5)
+    WHEN 0 THEN countries[mod(i / 5 - 1, array_length(countries, 1)) + 1]
+    ELSE NULL
+    END
+FROM generate_series(1, 22) i,
+   (SELECT ('{Anneli, Ella, Hanna, Iiris, Liisa, Maria, Ninni, Viivi, Sointu, Jaakko, Lasse, Kyösti, ' ||
+            'Markku, Kristian, Mikael, Nooa, Otto, Olli}')::text[] AS first_names) AS first_name_table,
+   (SELECT ('{Aaltonen, Alanen, Eskola, Hakala, Heikkinen, Heinonen, Hiltunen, Hirvonen, ' ||
+            'Hämäläinen, Kallio, Karjalainen, Kinnunen, Korhonen, Koskinen, Laakso, ' ||
+            'Lahtinen, Laine, Lehtonen, Leinonen, Leppänen}')::text[] AS last_names) AS last_name_table,
+   (SELECT ('{Erottajankatu 1, Mäkelänkatu 70, Postikatu 2, Hamngatan 4}')::text[] AS streets) AS street_table,
+   (SELECT ('{00130, 00610, 33100, 111 47}')::text[] AS postal_codes) AS postal_code_table,
+   (SELECT ('{Helsinki, Helsinki, Tampere, Stockholm}')::text[] AS towns) AS town_table,
+   (SELECT ('{Suomi, Finland, SUOMI, Sverige}')::text[] AS countries) AS country_table;
 
 -- Insert enrollments to 2nd event by id: full, all paid
 INSERT INTO enrollment(exam_event_id, person_id,

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkPersonDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkPersonDTO.java
@@ -12,7 +12,6 @@ public record ClerkPersonDTO(
   @NonNull @NotBlank String identityNumber,
   @NonNull @NotBlank String lastName,
   @NonNull @NotBlank String firstName,
-  @NonNull @NotBlank String nickName,
   @NonNull @NotBlank String email,
   @NonNull @NotBlank String phoneNumber,
   String street,

--- a/backend/vkt/src/main/java/fi/oph/vkt/model/Person.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/model/Person.java
@@ -24,9 +24,33 @@ public class Person extends BaseEntity {
   @Column(name = "person_id", nullable = false)
   private long id;
 
-  @Column(name = "onr_id", nullable = false, unique = true)
   @Size(max = 255)
-  private String onrId;
+  @Column(name = "identity_number", nullable = false, unique = true)
+  private String identityNumber;
+
+  @Column(name = "last_name", nullable = false)
+  private String lastName;
+
+  @Column(name = "first_name", nullable = false)
+  private String firstName;
+
+  @Column(name = "email", nullable = false)
+  private String email;
+
+  @Column(name = "phone_number", nullable = false)
+  private String phoneNumber;
+
+  @Column(name = "street")
+  private String street;
+
+  @Column(name = "postal_code")
+  private String postalCode;
+
+  @Column(name = "town")
+  private String town;
+
+  @Column(name = "country")
+  private String country;
 
   @OneToMany(mappedBy = "person")
   private List<Enrollment> enrollments = new ArrayList<>();

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkExamEventService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkExamEventService.java
@@ -65,8 +65,6 @@ public class ClerkExamEventService {
     final ExamEvent examEvent = examEventRepository.getReferenceById(examEventId);
     final List<Enrollment> enrollments = examEvent.getEnrollments();
 
-    // TODO: fetch personal datas by onrIds
-    final List<String> personOnrIds = enrollments.stream().map(Enrollment::getPerson).map(Person::getOnrId).toList();
     final List<ClerkEnrollmentDTO> enrollmentDTOs = enrollments.stream().map(this::getEnrollmentDTO).toList();
 
     final ClerkExamEventDTO examEventDTO = ClerkExamEventDTO
@@ -86,7 +84,6 @@ public class ClerkExamEventService {
     return examEventDTO;
   }
 
-  // TODO: personalData as second parameter
   private ClerkEnrollmentDTO getEnrollmentDTO(final Enrollment enrollment) {
     final ClerkPersonDTO personDTO = getClerkPersonDTO(enrollment.getPerson());
     final List<ClerkExamPaymentDTO> paymentDTOs = getClerkExamPaymentDTOs(enrollment);
@@ -110,22 +107,20 @@ public class ClerkExamEventService {
       .build();
   }
 
-  // TODO: personalData as second parameter
   private ClerkPersonDTO getClerkPersonDTO(final Person person) {
     return ClerkPersonDTO
       .builder()
       .id(person.getId())
       .version(person.getVersion())
-      .identityNumber("000000-0000")
-      .lastName("Tester")
-      .firstName("Foo Bar")
-      .nickName("Foo")
-      .email("foo.tester@vkt.invalid")
-      .phoneNumber("+358401234567")
-      .street(null)
-      .postalCode(null)
-      .town(null)
-      .country(null)
+      .identityNumber(person.getIdentityNumber())
+      .lastName(person.getLastName())
+      .firstName(person.getFirstName())
+      .email(person.getEmail())
+      .phoneNumber(person.getPhoneNumber())
+      .street(person.getStreet())
+      .postalCode(person.getPostalCode())
+      .town(person.getTown())
+      .country(person.getCountry())
       .build();
   }
 

--- a/backend/vkt/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/backend/vkt/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -216,4 +216,34 @@
                              constraintName="uk_enrollment_exam_event_person"/>
     </changeSet>
 
+    <changeSet id="2022-10-12-change-person-columns" author="mikhuttu">
+        <dropColumn tableName="person">
+            <column name="onr_id"/>
+        </dropColumn>
+
+        <addColumn tableName="person">
+            <column name="identity_number" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_name" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="first_name" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="email" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="phone_number" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="street" type="TEXT"/>
+            <column name="postal_code" type="TEXT"/>
+            <column name="town" type="TEXT"/>
+            <column name="country" type="TEXT"/>
+        </addColumn>
+
+        <addUniqueConstraint tableName="person" columnNames="identity_number" constraintName="uk_person_identity_number"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/backend/vkt/src/test/java/fi/oph/vkt/Factory.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/Factory.java
@@ -29,7 +29,11 @@ public class Factory {
 
   public static Person person() {
     final Person person = new Person();
-    person.setOnrId(UUID.randomUUID().toString());
+    person.setIdentityNumber(UUID.randomUUID().toString());
+    person.setLastName("Tester");
+    person.setFirstName("Foo Bar");
+    person.setEmail("foo.tester@invalid");
+    person.setPhoneNumber("+10001234567");
 
     return person;
   }

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/ClerkExamEventServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/ClerkExamEventServiceTest.java
@@ -150,7 +150,17 @@ public class ClerkExamEventServiceTest {
     examEvent.setMaxParticipants(1);
 
     final Person person1 = Factory.person();
+    person1.setStreet("Katu 1");
+    person1.setPostalCode("00000");
+    person1.setTown("Kunta");
+    person1.setCountry("Maa");
+
     final Person person2 = Factory.person();
+    person2.setLastName("Aardvark");
+    person2.setFirstName("Anna Hannah");
+    person2.setEmail("anna@aardvark");
+    person2.setPhoneNumber("+1999000");
+
     final Enrollment enrollment1 = Factory.enrollment(examEvent, person1);
     final Enrollment enrollment2 = createEnrollmentWithNonDefaultAttributes(enrollment1, examEvent, person2);
     final ExamEvent otherExamEvent = Factory.examEvent(ExamLanguage.SV);
@@ -211,7 +221,6 @@ public class ClerkExamEventServiceTest {
       .orElseThrow(() ->
         new RuntimeException("DTO not found for expected Enrollment. Something is wrong with the test.")
       );
-    final ClerkPersonDTO personDTO = enrollmentDTO.person();
 
     assertEquals(expected.getVersion(), enrollmentDTO.version());
     assertEquals(expected.isOralSkill(), enrollmentDTO.oralSkill());
@@ -225,10 +234,21 @@ public class ClerkExamEventServiceTest {
     assertEquals(expected.getPreviousEnrollmentDate(), enrollmentDTO.previousEnrollmentDate());
     assertEquals(expected.isDigitalCertificateConsent(), enrollmentDTO.digitalCertificateConsent());
 
-    // TODO: add more checks once ONR mock is integrated to the service
-    assertEquals(expected.getPerson().getId(), personDTO.id());
-    assertEquals(expected.getPerson().getVersion(), personDTO.version());
-
+    assertPersonDTO(expected.getPerson(), enrollmentDTO.person());
     assertEquals(0, enrollmentDTO.payments().size());
+  }
+
+  private void assertPersonDTO(final Person expected, final ClerkPersonDTO personDTO) {
+    assertEquals(expected.getId(), personDTO.id());
+    assertEquals(expected.getVersion(), personDTO.version());
+    assertEquals(expected.getIdentityNumber(), personDTO.identityNumber());
+    assertEquals(expected.getLastName(), personDTO.lastName());
+    assertEquals(expected.getFirstName(), personDTO.firstName());
+    assertEquals(expected.getEmail(), personDTO.email());
+    assertEquals(expected.getPhoneNumber(), personDTO.phoneNumber());
+    assertEquals(expected.getStreet(), personDTO.street());
+    assertEquals(expected.getPostalCode(), personDTO.postalCode());
+    assertEquals(expected.getTown(), personDTO.town());
+    assertEquals(expected.getCountry(), personDTO.country());
   }
 }


### PR DESCRIPTION
## Yhteenveto

Ilmoittautuneiden henkilötiedot talletetaan tietokantaan `person` tauluun sinne aiemmin kaavaillun oppijanumeron sijaan. 

## Huomautukset

Figman perusteella henkilöiden kutsumanimillä ei olisi ehkä UI:ssa käyttöä joten jätin sen tallettamisen ainakin toistaiseksi toteuttamatta. Backend palauttaa kutsumanimen tosin frontendille yhä (valiten etunimistä kutsumanimeksi ensimmäisen), mutta pitäisikö tiputtaa sen sijaan suosiolla tuo `nickName` ClerkPersonDTO:sta pois?

## Check-lista
- [x] Testattu docker-compose:lla
