### PR TITLE
OPHAKRKEH-451: puuttuvat käännökset ruotsin ja englannin kielille

### DIFF
--- a/frontend/packages/akr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/akr/public/i18n/en-GB/translation.json
@@ -93,8 +93,8 @@
           "noAuthorisations": "No authorisations meeting the selected criteria were found",
           "toasts": {
             "addingSucceeded": "Authorisation added successfully",
-            "removingSucceeded": null,
-            "updatingPublishPermissionSucceeded": null
+            "removingSucceeded": "Selected authorisation deleted",
+            "updatingPublishPermissionSucceeded": "The publish permission for authorisation changed"
           },
           "toggleFilters": {
             "effective": "Valid",
@@ -164,8 +164,8 @@
         },
         "privacyStatement": {
           "ariaLabel": "Privacy policy",
-          "label": null,
-          "linkLabel": null
+          "label": "I have read the <0></0> of this service and accept it.",
+          "linkLabel": "privacy policy statement"
         },
         "steps": {
           "active": "Active",
@@ -222,10 +222,10 @@
             "text": "Examination system of authorised translators (oph.fi)"
           },
           "contact": {
-            "title": null
+            "title": "Feedback and development suggestions"
           },
           "privacy": {
-            "text": "Privacy policy (in Finnish)"
+            "text": "Privacy policy statement (in Finnish)"
           }
         }
       },
@@ -342,17 +342,17 @@
         "examinationDateCreateDuplicateDate": "Failed to add the exam day because the selected date is already an exam day",
         "examinationDateDeleteHasAuthorisations": "Failed to delete the exam day because authorisations have been recorded for it",
         "generic": "The action failed, please try again later",
-        "invalidVersion": null,
+        "invalidVersion": "The action failed because you tried to modify outdated data. Please refresh the page and try again later if necessary.",
         "meetingDateCreateDuplicateDate": "Failed to add the meeting day because the selected date is already a meeting day",
         "meetingDateDeleteHasAuthorisations": "Failed to delete the meeting day because authorisations have been recorded for it",
         "meetingDateUpdateDuplicateDate": "Failed to modify the meeting day failed because the selected date is already a meeting day",
         "meetingDateUpdateHasAuthorisations": "Failed to modify the meeting day because authorisations have been recorded for it",
         "translatorCreateDuplicateEmail": "Failed to add the translator because the email address is already in use",
         "translatorCreateDuplicateIdentityNumber": "Failed to add the translator because the personal identity code is already in use",
-        "translatorCreateUnknownCountry": null,
+        "translatorCreateUnknownCountry": "Failed to add the translator because the country code is unknown",
         "translatorUpdateDuplicateEmail": "Failed to modify the translator because the email address is already in use",
         "translatorUpdateDuplicateIdentityNumber": "Failed to modify the translator because the personal identity code is already in use",
-        "translatorUpdateUnknownCountry": null
+        "translatorUpdateUnknownCountry": "Failed to modify the translator because the country code is unknown"
       },
       "customTextField": {
         "emailFormat": "The email address is incorrect",
@@ -420,18 +420,18 @@
       "examinationDatesPage": {
         "title": "Exam days",
         "toasts": {
-          "addingSucceeded": null,
-          "removingSucceeded": null
+          "addingSucceeded": "Examination date {{date}} added successfully",
+          "removingSucceeded": "Examination date {{date}} deleted"
         }
       },
       "homepage": {
         "cookieBanner": {
-          "buttonAriaLabel": null,
-          "buttonText": null,
-          "description": null,
-          "title": null
+          "buttonAriaLabel": "Accept cookies",
+          "buttonText": "Accept",
+          "description": "This web site uses mandatory cookies to be functional.",
+          "title": "Accept cookies"
         },
-        "description": "The Finnish National Agency for Education maintains a register of authorised translators, into which the authorised translators approved by the Authorised Translators’ Examination Board are entered. You can use the search engine to find an authorised translator either by language pair, name, or municipality of residence. You can use the search form to leave a contact request to the translators you have selected. If there is a malfunction in the register, contact us by email to obtain contact details of authorised translators: auktoris.lautakunta@oph.fi. The public register of authorised translators contains only the names of those interpreters who have given the permission to publish their names online.",
+        "description": "The Finnish National Agency for Education maintains a register of authorised translators. You can use the search engine to find an authorised translator or several either by language pair, name, or municipality of residence. You can use the search form to leave a contact request to the translators you have selected. If there is a malfunction in the register, contact us by email to obtain contact details of authorised translators: auktoris.lautakunta@oph.fi",
         "filters": {
           "title": "Search for an authorised translator"
         },
@@ -443,8 +443,8 @@
       "meetingDatesPage": {
         "title": "Meeting days",
         "toasts": {
-          "addingSucceeded": null,
-          "removingSucceeded": null
+          "addingSucceeded": "Meeting date {{date}} added successfully",
+          "removingSucceeded": "Meeting date {{date}} deleted"
         }
       },
       "notFoundPage": {

--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -164,7 +164,7 @@
         },
         "privacyStatement": {
           "ariaLabel": "Tietosuojaseloste",
-          "label": "Olen lukenut tämän palvelun <0>tietosuojaselosteen</0> ja hyväksyn sen.",
+          "label": "Olen lukenut tämän palvelun <0></0> ja hyväksyn sen.",
           "linkLabel": "tietosuojaselosteen"
         },
         "steps": {

--- a/frontend/packages/akr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/translation.json
@@ -93,8 +93,8 @@
           "noAuthorisations": "Inga auktoriseringar hittades för de valda kriterierna",
           "toasts": {
             "addingSucceeded": "Auktoriseringen har lagts till",
-            "removingSucceeded": "Valda auktoriseringen har strykt",
-            "updatingPublishPermissionSucceeded": "Publiceringstillståndet för auktoriseringen har ändrat"
+            "removingSucceeded": "Valda auktoriseringen har strykts",
+            "updatingPublishPermissionSucceeded": "Publiceringstillståndet för auktoriseringen har ändrats"
           },
           "toggleFilters": {
             "effective": "I kraft",
@@ -421,14 +421,14 @@
         "title": "Examensdagar",
         "toasts": {
           "addingSucceeded": "Examendagen {{date}} har lagts till",
-          "removingSucceeded": "Examendagen {{date}} har tagit bort"
+          "removingSucceeded": "Examendagen {{date}} har tagits bort"
         }
       },
       "homepage": {
         "cookieBanner": {
           "buttonAriaLabel": "Acceptera cookies",
           "buttonText": "Acceptera",
-          "description": "Den här webbplatsen använder nödvändiga cookies för att fungera",
+          "description": "Den här webbplatsen använder nödvändiga cookies för att fungera.",
           "title": "Acceptera cookies"
         },
         "description": "Utbildningsstyrelsen upprätthåller ett register över auktoriserade translatorer. Med sökmotorn kan du söka en auktoriserad translator eller flera enligt språkpar, på namn eller boendeort. Du kan lämna en kontaktförfrågan för de translatorer som du väljer med nedan för sökformuläret. I fall av ett funktionsfel i registret vänligen kontakta vår e-postadress för att få kontaktuppgifter av auktoriserade translatorer auktoris.lautakunta@oph.fi",
@@ -444,7 +444,7 @@
         "title": "Mötesdagar",
         "toasts": {
           "addingSucceeded": "Mötedagen {{date}} har lagts till",
-          "removingSucceeded": "Mötedagen {{date}} har tagit bort"
+          "removingSucceeded": "Mötedagen {{date}} har tagits bort"
         }
       },
       "notFoundPage": {

--- a/frontend/packages/akr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/translation.json
@@ -29,7 +29,7 @@
         "authorisationStatus": {
           "effective": "Auktoriserade",
           "expiredDeduplicated": "Löpt ut",
-          "expiring": null,
+          "expiring": "Löper ut",
           "formerVir": "VIR 2008"
         },
         "languagePair": {
@@ -93,8 +93,8 @@
           "noAuthorisations": "Inga auktoriseringar hittades för de valda kriterierna",
           "toasts": {
             "addingSucceeded": "Auktoriseringen har lagts till",
-            "removingSucceeded": null,
-            "updatingPublishPermissionSucceeded": null
+            "removingSucceeded": "Valda auktoriseringen har strykt",
+            "updatingPublishPermissionSucceeded": "Publiceringstillståndet för auktoriseringen har ändrat"
           },
           "toggleFilters": {
             "effective": "I kraft",
@@ -164,8 +164,8 @@
         },
         "privacyStatement": {
           "ariaLabel": "Dataskyddsbeskrivning",
-          "label": null,
-          "linkLabel": null
+          "label": "Jag har läst <0></0> av den här tjänsten och accepterar den.",
+          "linkLabel": "dataskyddsbeskrivningen"
         },
         "steps": {
           "active": "Aktiv",
@@ -214,7 +214,7 @@
         },
         "links": {
           "accessibility": {
-            "text": "Tillgänglighetsdirektiv"
+            "text": "Tillgänglighetsdirektiv (på finska)"
           },
           "akrHomepage": {
             "ariaLabel": "Examenssystemet för auktoriserade translatorer (oph.fi), öppnas i en ny flik",
@@ -222,10 +222,10 @@
             "text": "Systemet med auktoriserade translatorer (oph.fi)"
           },
           "contact": {
-            "title": null
+            "title": "Respons och utvecklingidéer"
           },
           "privacy": {
-            "text": "Dataskyddsbeskrivning"
+            "text": "Dataskyddsbeskrivning (på finska)"
           }
         }
       },
@@ -292,7 +292,7 @@
       "publicTranslatorFilters": {
         "buttons": {
           "empty": "Töm",
-          "newSearch": "Gör en ny sökning",
+          "newSearch": "Ny sökning",
           "search": "Visa resultat"
         },
         "captions": {
@@ -342,17 +342,17 @@
         "examinationDateCreateDuplicateDate": "Det gick inte att lägga till examensdagen eftersom det valda datumet redan är en examensdag",
         "examinationDateDeleteHasAuthorisations": "Det gick inte att ta bort examensdagen eftersom det har registrerats auktoriseringar på den",
         "generic": "Funktionen misslyckades, försök på nytt senare",
-        "invalidVersion": null,
+        "invalidVersion": "Funktionen misslyckades därför att du försökte att ändra förlegad data. Uppdatera sidan och försöka vid behov igen.",
         "meetingDateCreateDuplicateDate": "Det gick inte lägga till mötesdagen eftersom det valda datumet redan är ett mötesdatum",
         "meetingDateDeleteHasAuthorisations": "Det gick inte att ta bort mötesdagen eftersom det har registrerats auktoriseringar på den",
         "meetingDateUpdateDuplicateDate": "Mötesdagen kunde inte redigeras eftersom det valda datumet redan är en mötesdag",
         "meetingDateUpdateHasAuthorisations": "Mötesdagen kunde inte redigeras eftersom det har registrerats auktoriseringar på den",
         "translatorCreateDuplicateEmail": "Det gick inte att lägga till translatorn eftersom e-postadressen redan används",
         "translatorCreateDuplicateIdentityNumber": "Det gick inte att lägga till translatorn eftersom personbeteckningen redan används",
-        "translatorCreateUnknownCountry": null,
+        "translatorCreateUnknownCountry": "Det gick inte att lägga till translatorn eftersom landmärket är okänt",
         "translatorUpdateDuplicateEmail": "Det gick inte att redigera translatorn eftersom e-postadressen redan används",
         "translatorUpdateDuplicateIdentityNumber": "Det gick inte att redigera translatorn eftersom personbeteckningen redan används",
-        "translatorUpdateUnknownCountry": null
+        "translatorUpdateUnknownCountry": "Det gick inte att redigera translatorn eftersom landmärket är okänt"
       },
       "customTextField": {
         "emailFormat": "E-postadressen är felaktig",
@@ -420,18 +420,18 @@
       "examinationDatesPage": {
         "title": "Examensdagar",
         "toasts": {
-          "addingSucceeded": null,
-          "removingSucceeded": null
+          "addingSucceeded": "Examendagen {{date}} har lagts till",
+          "removingSucceeded": "Examendagen {{date}} har tagit bort"
         }
       },
       "homepage": {
         "cookieBanner": {
-          "buttonAriaLabel": null,
-          "buttonText": null,
-          "description": null,
-          "title": null
+          "buttonAriaLabel": "Acceptera cookies",
+          "buttonText": "Acceptera",
+          "description": "Den här webbplatsen använder nödvändiga cookies för att fungera",
+          "title": "Acceptera cookies"
         },
-        "description": "Utbildningsstyrelsen upprätthåller ett register över auktoriserade translatorer, där translatorer som har auktoriserats av Examensnämnden för auktoriserade translatorer registreras. Med sökmotorn kan du söka en auktoriserad translator eller flera enligt språkpar, på namn eller boendeort. Observera att sökandet enligt språkpar ger som möjliga sökalternativ från inhemska språk ( finska, svenska, samiska språk) till främmande språk eller tvärtom samt mellan inhemska språk. I det offentliga registret över auktoriserade translatorer finns endast uppgifter om de translatorer som har gett sitt samtycke till att deras uppgifter publiceras på webben. I fall av ett funktionsfel i registret vänligen kontakta vår e-postadress för att få kontaktuppgifter av auktoriserade translatorer auktoris.lautakunta@oph.fi",
+        "description": "Utbildningsstyrelsen upprätthåller ett register över auktoriserade translatorer. Med sökmotorn kan du söka en auktoriserad translator eller flera enligt språkpar, på namn eller boendeort. Du kan lämna en kontaktförfrågan för de translatorer som du väljer med nedan för sökformuläret. I fall av ett funktionsfel i registret vänligen kontakta vår e-postadress för att få kontaktuppgifter av auktoriserade translatorer auktoris.lautakunta@oph.fi",
         "filters": {
           "title": "Sök auktoriserad translator"
         },
@@ -443,8 +443,8 @@
       "meetingDatesPage": {
         "title": "Mötesdagar",
         "toasts": {
-          "addingSucceeded": null,
-          "removingSucceeded": null
+          "addingSucceeded": "Mötedagen {{date}} har lagts till",
+          "removingSucceeded": "Mötedagen {{date}} har tagit bort"
         }
       },
       "notFoundPage": {


### PR DESCRIPTION
## Yhteenveto

Lisätty puuttuvat käännökset sovellusta varten (myös virkailijan käyttöliittymään) ja korjattu joitakin olemassaolevia ruotsin ja englanninkielisiä käännöksiä parhaan osaamisen mukaan. Pitää päivittää nämä vielä exceliin.

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
