### PR TITLE
AKR(Frontend): OPHAKRKEH-459 public town filter fiksi

### DIFF
--- a/frontend/packages/akr/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
+++ b/frontend/packages/akr/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
@@ -225,11 +225,12 @@ export const PublicTranslatorFilters = ({
   };
 
   const townAsComboboxOption = (publicTown: PublicTown) => {
-    const value = publicTown.name;
+    const country = publicTown.country
+      ? translateCountry(publicTown.country)
+      : '';
+    const value = `${publicTown.name}::${publicTown.country ?? ''}`;
     const townName = isCurrentLangSv() ? publicTown.nameSv : publicTown.name;
-    const label = publicTown.country
-      ? `${townName} (${translateCountry(publicTown.country)})`
-      : townName;
+    const label = country ? `${townName} (${country})` : townName;
 
     return { value, label };
   };

--- a/frontend/packages/akr/src/redux/selectors/publicTranslator.ts
+++ b/frontend/packages/akr/src/redux/selectors/publicTranslator.ts
@@ -91,5 +91,11 @@ const filterByTown = (
   publicTranslator: PublicTranslator,
   filters: PublicTranslatorFilter
 ) => {
-  return publicTranslator.town?.toLowerCase() === filters.town.toLowerCase();
+  const [town, country] = filters.town.split('::');
+
+  return country
+    ? publicTranslator.town?.toLowerCase() === town.toLowerCase() &&
+        publicTranslator.country?.toLowerCase() === country.toLowerCase()
+    : publicTranslator.town?.toLowerCase() === town.toLowerCase() &&
+        !publicTranslator.country;
 };

--- a/frontend/packages/akr/src/tests/cypress/fixtures/json/public_translators_50.json
+++ b/frontend/packages/akr/src/tests/cypress/fixtures/json/public_translators_50.json
@@ -35,7 +35,9 @@
     { "name": "Oipouk", "country": "LVA" },
     { "name": "Oovrop", "country": "LVA" },
     { "name": "Ukrut", "country": "LVA" },
-    { "name": "Uluo", "country": "LVA" }
+    { "name": "Uluo", "country": "LVA" },
+    { "name": "Luxembourg" },
+    { "name": "Luxembourg", "country": "LUX" }
   ],
   "translators": [
     {
@@ -837,42 +839,22 @@
       "town": "Kemi"
     },
     {
-      "firstName": "Iida",
-      "id": 4106,
-      "languagePairs": [
-        {
-          "from": "FI",
-          "to": "SV"
-        },
-        {
-          "from": "SEIN",
-          "to": "SV"
-        },
-        {
-          "from": "FI",
-          "to": "IT"
-        }
-      ],
-      "lastName": "Karjalainen"
+      "id": 998,
+      "firstName": "Jonna",
+      "lastName": "Kauto",
+      "town": "Luxembourg",
+      "languagePairs": [{ "from": "FI", "to": "EN" }]
     },
     {
-      "firstName": "Iiro",
-      "id": 834,
+      "id": 999,
+      "firstName": "Jarmo",
+      "lastName": "Jarmonen",
+      "town": "Luxembourg",
+      "country": "LUX",
       "languagePairs": [
-        {
-          "from": "FI",
-          "to": "SV"
-        },
-        {
-          "from": "SV",
-          "to": "FI"
-        },
-        {
-          "from": "SEPO",
-          "to": "SEKO"
-        }
-      ],
-      "lastName": "Kinnunen"
+        { "from": "DE", "to": "FI" },
+        { "from": "EN", "to": "FI" }
+      ]
     }
   ]
 }

--- a/frontend/packages/akr/src/tests/cypress/integration/public_translator.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/public_translator.spec.ts
@@ -16,7 +16,7 @@ describe('PublicTranslatorFilters', () => {
   it('should allow filtering results by language pair, name and town', () => {
     onPublicTranslatorFilters.expectSearchButtonText('Näytä tulokset (50)');
     onPublicTranslatorFilters.filterByLanguagePair('suomi', 'ruotsi');
-    onPublicTranslatorsListing.expectTranslatorsCount(27);
+    onPublicTranslatorsListing.expectTranslatorsCount(25);
 
     onPublicTranslatorFilters.filterByTown('Helsinki');
     onPublicTranslatorFilters.expectSearchButtonText('Näytä tulokset (2)');
@@ -37,10 +37,22 @@ describe('PublicTranslatorFilters', () => {
     onPublicTranslatorsListing.expectTranslatorsCount(1);
   });
 
+  it('should return results only with or without country name when filtering by town name', () => {
+    onPublicTranslatorFilters.filterByTown('Luxembourg');
+    onPublicTranslatorFilters.expectSearchButtonText('Näytä tulokset (1)');
+    onPublicTranslatorsListing.expectTranslatorsCount(1);
+    cy.wait(1000);
+
+    onPublicTranslatorFilters.filterByTown('Luxembourg (Luxemburg)');
+    onPublicTranslatorFilters.expectSearchButtonText('Näytä tulokset (1)');
+    onPublicTranslatorsListing.expectTranslatorsCount(1);
+    cy.wait(1000);
+  });
+
   it('should clear filters and listed translators when the reset button is clicked', () => {
     onPublicTranslatorFilters.filterByLanguagePair('suomi', 'ruotsi');
-    onPublicTranslatorFilters.expectSearchButtonText('Näytä tulokset (27)');
-    onPublicTranslatorsListing.expectTranslatorsCount(27);
+    onPublicTranslatorFilters.expectSearchButtonText('Näytä tulokset (25)');
+    onPublicTranslatorsListing.expectTranslatorsCount(25);
 
     onPublicTranslatorFilters.emptySearch();
     onPublicTranslatorsListing.expectEmptyListing();


### PR DESCRIPTION
## Yhteenveto

Town filter value käytetään Dropdown listan keynä. Nykymuodossa bäkkäriltä saattaa tulla useampi samanniminen town (distinct kutsutaan objektille { town, townSv, country }). Korjattu town filter antamalla valueksi `town-country`-yhdistelmä ja käyttämällä tätä town filter selectorissa.

## Huomautukset

Tähän liittyvä bugi tuotannossa on jo korjattu lisäämällä "bugiselle" kääntäjälle country arvo, jolloin se suodattui oikein distinct:llä. Tällä kuitenkin estetään UI:n bugiutuminen jatkossa jos samanlaisia tapauksia ilmenee.

## Check-lista

- [ ] Testattu docker-compose:lla
