### PR TITLE
OPHVKTKEH-55: ilmoittautumisen alustus

### DIFF
--- a/backend/vkt/db/4_init.sql
+++ b/backend/vkt/db/4_init.sql
@@ -260,6 +260,17 @@ FROM person ORDER BY person_id
             LIMIT (SELECT max_participants / 2 FROM exam_event ORDER BY exam_event_id DESC LIMIT 1 OFFSET 3)
             OFFSET (SELECT max_participants FROM exam_event ORDER BY exam_event_id DESC LIMIT 1 OFFSET 3);
 
+-- Insert enrollments to 5th event by id: 9/10 of places taken
+INSERT INTO enrollment(exam_event_id, person_id,
+                       skill_oral, skill_textual, skill_understanding,
+                       partial_exam_speaking, partial_exam_speech_comprehension, partial_exam_writing, partial_exam_reading_comprehension,
+                       status, digital_certificate_consent)
+SELECT (SELECT exam_event_id FROM exam_event ORDER BY exam_event_id DESC LIMIT 1 OFFSET 4), person_id,
+       true, true, true,
+       true, true, true, true,
+       'PAID', true
+FROM person ORDER BY person_id LIMIT (SELECT max_participants - 1 FROM exam_event ORDER BY exam_event_id DESC LIMIT 1 OFFSET 4);
+
 -- Insert one cancelled enrollment to all
 INSERT INTO enrollment(exam_event_id, person_id,
                        skill_oral, skill_textual, skill_understanding,

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/PublicController.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/PublicController.java
@@ -1,13 +1,21 @@
 package fi.oph.vkt.api;
 
 import fi.oph.vkt.api.dto.PublicExamEventDTO;
+import fi.oph.vkt.api.dto.PublicReservationDTO;
+import fi.oph.vkt.model.Person;
 import fi.oph.vkt.model.type.ExamLevel;
 import fi.oph.vkt.service.PublicExamEventService;
+import fi.oph.vkt.service.PublicIdentificationService;
+import fi.oph.vkt.service.PublicReservationService;
 import java.util.List;
 import javax.annotation.Resource;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,8 +25,22 @@ public class PublicController {
   @Resource
   private PublicExamEventService publicExamEventService;
 
+  @Resource
+  private PublicIdentificationService publicIdentificationService;
+
+  @Resource
+  private PublicReservationService publicReservationService;
+
   @GetMapping
   public List<PublicExamEventDTO> list() {
     return publicExamEventService.listExamEvents(ExamLevel.EXCELLENT);
+  }
+
+  @PostMapping(path = "/{examEventId:\\d+}/reservation")
+  @ResponseStatus(HttpStatus.CREATED)
+  public PublicReservationDTO identifyAndCreateReservation(@PathVariable final long examEventId) {
+    final Person person = publicIdentificationService.identify();
+
+    return publicReservationService.createReservation(examEventId, person);
   }
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/PublicExamEventDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/PublicExamEventDTO.java
@@ -12,6 +12,6 @@ public record PublicExamEventDTO(
   @NonNull LocalDate date,
   @NonNull LocalDate registrationCloses,
   @NonNull Long participants,
-  @NonNull Integer maxParticipants,
+  @NonNull Long maxParticipants,
   @NonNull Boolean hasCongestion
 ) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/PublicPersonDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/PublicPersonDTO.java
@@ -1,0 +1,12 @@
+package fi.oph.vkt.api.dto;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+public record PublicPersonDTO(
+  @NonNull Long id,
+  @NonNull String identityNumber,
+  @NonNull String lastName,
+  @NonNull String firstName
+) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/PublicReservationDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/PublicReservationDTO.java
@@ -1,0 +1,13 @@
+package fi.oph.vkt.api.dto;
+
+import java.time.ZonedDateTime;
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+public record PublicReservationDTO(
+  @NonNull Long id,
+  @NonNull ZonedDateTime expiresAt,
+  @NonNull PublicExamEventDTO examEvent,
+  @NonNull PublicPersonDTO person
+) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkExamEventDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkExamEventDTO.java
@@ -17,6 +17,6 @@ public record ClerkExamEventDTO(
   @NonNull @NotNull LocalDate date,
   @NonNull @NotNull LocalDate registrationCloses,
   @NonNull @NotNull Boolean isVisible,
-  @NonNull @NotNull Integer maxParticipants,
+  @NonNull @NotNull Long maxParticipants,
   @NonNull @NotNull List<ClerkEnrollmentDTO> enrollments
 ) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkExamEventListDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkExamEventListDTO.java
@@ -14,6 +14,6 @@ public record ClerkExamEventListDTO(
   @NonNull LocalDate date,
   @NonNull LocalDate registrationCloses,
   @NonNull Long participants,
-  @NonNull Integer maxParticipants,
+  @NonNull Long maxParticipants,
   @NonNull Boolean isPublic
 ) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/model/ExamEvent.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/model/ExamEvent.java
@@ -46,7 +46,7 @@ public class ExamEvent extends BaseEntity {
   private boolean isVisible;
 
   @Column(name = "max_participants", nullable = false)
-  private int maxParticipants;
+  private long maxParticipants;
 
   @OneToMany(mappedBy = "examEvent")
   private List<Enrollment> enrollments = new ArrayList<>();

--- a/backend/vkt/src/main/java/fi/oph/vkt/model/Reservation.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/model/Reservation.java
@@ -34,4 +34,8 @@ public class Reservation extends BaseEntity {
 
   @Column(name = "expires_at", nullable = false)
   private LocalDateTime expiresAt;
+
+  public boolean isActive() {
+    return LocalDateTime.now().isBefore(expiresAt);
+  }
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/ClerkExamEventProjection.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/ClerkExamEventProjection.java
@@ -11,6 +11,6 @@ public record ClerkExamEventProjection(
   LocalDate date,
   LocalDate registrationCloses,
   long participants,
-  int maxParticipants,
+  long maxParticipants,
   boolean isVisible
 ) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/PersonRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/PersonRepository.java
@@ -1,0 +1,11 @@
+package fi.oph.vkt.repository;
+
+import fi.oph.vkt.model.Person;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PersonRepository extends JpaRepository<Person, Long> {
+  Optional<Person> findByIdentityNumber(String identityNumber);
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/PublicExamEventProjection.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/PublicExamEventProjection.java
@@ -9,5 +9,5 @@ public record PublicExamEventProjection(
   LocalDate date,
   LocalDate registrationCloses,
   long participants,
-  int maxParticipants
+  long maxParticipants
 ) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/ReservationRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/ReservationRepository.java
@@ -1,7 +1,10 @@
 package fi.oph.vkt.repository;
 
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Person;
 import fi.oph.vkt.model.Reservation;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.persistence.Tuple;
@@ -19,8 +22,10 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
   )
   Stream<Tuple> _countActiveReservationsByExamEvent();
 
-  default Map<Long, Integer> countActiveReservationsByExamEvent() {
+  default Map<Long, Long> countActiveReservationsByExamEvent() {
     return _countActiveReservationsByExamEvent()
-      .collect(Collectors.toMap(t -> t.get("examEventId", Long.class), t -> t.get("count", Long.class).intValue()));
+      .collect(Collectors.toMap(t -> t.get("examEventId", Long.class), t -> t.get("count", Long.class)));
   }
+
+  Optional<Reservation> findByExamEventAndPerson(ExamEvent examEvent, Person person);
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkExamEventService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkExamEventService.java
@@ -16,7 +16,6 @@ import fi.oph.vkt.util.DateUtil;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
-import javax.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,10 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ClerkExamEventService {
 
-  @Resource
   private final ExamEventRepository examEventRepository;
-
-  @Resource
   private final AuditService auditService;
 
   @Transactional(readOnly = true)

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicExamEventService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicExamEventService.java
@@ -5,6 +5,7 @@ import fi.oph.vkt.model.type.ExamLevel;
 import fi.oph.vkt.repository.ExamEventRepository;
 import fi.oph.vkt.repository.PublicExamEventProjection;
 import fi.oph.vkt.repository.ReservationRepository;
+import fi.oph.vkt.util.ExamEventUtil;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -24,14 +25,14 @@ public class PublicExamEventService {
     final List<PublicExamEventProjection> examEventProjections = examEventRepository.listPublicExamEventProjections(
       level
     );
-    final Map<Long, Integer> reservationsByExamEvent = reservationRepository.countActiveReservationsByExamEvent();
+    final Map<Long, Long> reservationsByExamEvent = reservationRepository.countActiveReservationsByExamEvent();
 
     return examEventProjections
       .stream()
       .map(e -> {
-        final int reservationsCount = reservationsByExamEvent.getOrDefault(e.id(), 0);
-        final boolean hasCongestion =
-          e.participants() < e.maxParticipants() && e.participants() + reservationsCount >= e.maxParticipants();
+        final long reservations = reservationsByExamEvent.getOrDefault(e.id(), 0L);
+        final boolean hasCongestion = ExamEventUtil.isCongested(e.participants(), reservations, e.maxParticipants());
+
         return PublicExamEventDTO
           .builder()
           .id(e.id())

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicIdentificationService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicIdentificationService.java
@@ -1,0 +1,47 @@
+package fi.oph.vkt.service;
+
+import fi.oph.vkt.model.Person;
+import fi.oph.vkt.repository.PersonRepository;
+import java.util.List;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PublicIdentificationService {
+
+  private final PersonRepository personRepository;
+
+  // TODO: identify person with information received from suomi.fi identification service
+  public Person identify() {
+    final Random random = new Random();
+    final List<String> identityNumbers = List.of(
+      "200714-982U",
+      "010934-984D",
+      "210110-9320",
+      "230182-980D",
+      "130421-9046"
+    );
+    final String identityNumber = identityNumbers.get(random.nextInt(identityNumbers.size()));
+
+    return personRepository.findByIdentityNumber(identityNumber).orElseGet(() -> createPerson(identityNumber));
+  }
+
+  private Person createPerson(final String identityNumber) {
+    final Random random = new Random();
+    final List<String> lastNames = List.of("Aaltonen", "Alanen", "Eskola", "Hakala", "Heikkinen");
+    final List<String> firstNames = List.of("Anneli", "Ella", "Hanna", "Iiris", "Liisa");
+
+    final Person person = new Person();
+    person.setIdentityNumber(identityNumber);
+    person.setLastName(lastNames.get(random.nextInt(lastNames.size())));
+    person.setFirstName(firstNames.get(random.nextInt(firstNames.size())));
+    // TODO: move contact details (email, phone number, address) under Enrollment?
+    person.setEmail("email@test");
+    person.setPhoneNumber("+3581234567");
+
+    personRepository.saveAndFlush(person);
+    return person;
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicReservationService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicReservationService.java
@@ -1,0 +1,114 @@
+package fi.oph.vkt.service;
+
+import fi.oph.vkt.api.dto.PublicExamEventDTO;
+import fi.oph.vkt.api.dto.PublicPersonDTO;
+import fi.oph.vkt.api.dto.PublicReservationDTO;
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Person;
+import fi.oph.vkt.model.Reservation;
+import fi.oph.vkt.model.type.EnrollmentStatus;
+import fi.oph.vkt.repository.ExamEventRepository;
+import fi.oph.vkt.repository.ReservationRepository;
+import fi.oph.vkt.util.ExamEventUtil;
+import fi.oph.vkt.util.exception.APIException;
+import fi.oph.vkt.util.exception.APIExceptionType;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PublicReservationService {
+
+  private final ExamEventRepository examEventRepository;
+  private final ReservationRepository reservationRepository;
+  private final Environment environment;
+
+  @Transactional
+  public PublicReservationDTO createReservation(final long examEventId, final Person person) {
+    final ExamEvent examEvent = examEventRepository.getReferenceById(examEventId);
+
+    final long participants = examEvent
+      .getEnrollments()
+      .stream()
+      .filter(e -> e.getStatus() == EnrollmentStatus.PAID || e.getStatus() == EnrollmentStatus.EXPECTING_PAYMENT)
+      .count();
+    final long reservations = examEvent.getReservations().stream().filter(Reservation::isActive).count();
+
+    if (ExamEventUtil.isCongested(participants, reservations, examEvent.getMaxParticipants())) {
+      throw new APIException(APIExceptionType.CREATE_RESERVATION_CONGESTION);
+    }
+    if (examEvent.getRegistrationCloses().isBefore(LocalDate.now())) {
+      throw new APIException(APIExceptionType.CREATE_RESERVATION_REGISTRATION_CLOSED);
+    }
+
+    final Reservation reservation = reservationRepository
+      .findByExamEventAndPerson(examEvent, person)
+      .map(this::updateExpiresAtForExistingReservation)
+      .orElseGet(() -> createNewReservation(examEvent, person));
+
+    return createReservationDTO(reservation, examEvent, person, participants);
+  }
+
+  private Reservation updateExpiresAtForExistingReservation(final Reservation reservation) {
+    reservation.setExpiresAt(newExpiresAt());
+    reservationRepository.flush();
+
+    return reservation;
+  }
+
+  private Reservation createNewReservation(final ExamEvent examEvent, final Person person) {
+    final Reservation reservation = new Reservation();
+    reservation.setExamEvent(examEvent);
+    reservation.setPerson(person);
+    reservation.setExpiresAt(newExpiresAt());
+
+    return reservationRepository.saveAndFlush(reservation);
+  }
+
+  private LocalDateTime newExpiresAt() {
+    return LocalDateTime.now().plus(Duration.parse(environment.getRequiredProperty("app.reservation.duration")));
+  }
+
+  private PublicReservationDTO createReservationDTO(
+    final Reservation reservation,
+    final ExamEvent examEvent,
+    final Person person,
+    final long examEventParticipants
+  ) {
+    final PublicExamEventDTO examEventDTO = PublicExamEventDTO
+      .builder()
+      .id(examEvent.getId())
+      .language(examEvent.getLanguage())
+      .date(examEvent.getDate())
+      .registrationCloses(examEvent.getRegistrationCloses())
+      .participants(examEventParticipants)
+      .maxParticipants(examEvent.getMaxParticipants())
+      .hasCongestion(false)
+      .build();
+
+    final PublicPersonDTO personDTO = PublicPersonDTO
+      .builder()
+      .id(person.getId())
+      .identityNumber(person.getIdentityNumber())
+      .lastName(person.getLastName())
+      .firstName(person.getFirstName())
+      .build();
+
+    final ZonedDateTime expiresAt = ZonedDateTime.of(reservation.getExpiresAt(), ZoneId.systemDefault());
+
+    return PublicReservationDTO
+      .builder()
+      .id(reservation.getId())
+      .expiresAt(expiresAt)
+      .examEvent(examEventDTO)
+      .person(personDTO)
+      .build();
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/ExamEventUtil.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/ExamEventUtil.java
@@ -1,0 +1,8 @@
+package fi.oph.vkt.util;
+
+public class ExamEventUtil {
+
+  public static boolean isCongested(final long participants, final long reservations, final long maxParticipants) {
+    return participants < maxParticipants && participants + reservations >= maxParticipants;
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/exception/APIExceptionType.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/exception/APIExceptionType.java
@@ -5,6 +5,8 @@ package fi.oph.vkt.util.exception;
  * The respective frontend enum is `APIError`.
  */
 public enum APIExceptionType {
+  CREATE_RESERVATION_CONGESTION,
+  CREATE_RESERVATION_REGISTRATION_CLOSED,
   INVALID_VERSION;
 
   public String getCode() {

--- a/backend/vkt/src/main/resources/application.yaml
+++ b/backend/vkt/src/main/resources/application.yaml
@@ -55,3 +55,6 @@ cas:
   service-url: ${virkailija.cas.service-url:http://localhost:${server.port}/vkt}
   url: ${virkailija.cas.url:http://localhost:${server.port}/vkt}
   login-url: ${virkailija.cas.login-url:http://localhost:${server.port}/login}
+app:
+  reservation:
+    duration: PT30M

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicExamEventServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicExamEventServiceTest.java
@@ -73,11 +73,12 @@ public class PublicExamEventServiceTest {
     final ExamEvent futureEvent1 = Factory.examEvent(ExamLanguage.SV);
     futureEvent1.setDate(now.plusWeeks(4));
     futureEvent1.setRegistrationCloses(now.plusWeeks(3));
+    futureEvent1.setMaxParticipants(3);
 
     final ExamEvent futureEvent2 = Factory.examEvent(ExamLanguage.FI);
     futureEvent2.setDate(now.plusWeeks(5));
     futureEvent2.setRegistrationCloses(now.plusWeeks(3));
-    futureEvent2.setMaxParticipants(11);
+    futureEvent2.setMaxParticipants(5);
 
     entityManager.persist(pastEvent);
     entityManager.persist(eventWithRegistrationClosed);
@@ -88,14 +89,14 @@ public class PublicExamEventServiceTest {
     entityManager.persist(futureEvent1);
     entityManager.persist(futureEvent2);
 
-    createReservations(futureEvent1, futureEvent1.getMaxParticipants() - 1, LocalDateTime.now().plusMinutes(1));
+    createReservations(futureEvent1, 2, LocalDateTime.now().plusMinutes(1));
     createReservations(futureEvent1, 1, LocalDateTime.now());
 
     createEnrollment(futureEvent2, EnrollmentStatus.PAID);
     createEnrollment(futureEvent2, EnrollmentStatus.QUEUED);
     createEnrollment(futureEvent2, EnrollmentStatus.EXPECTING_PAYMENT);
     createEnrollment(futureEvent2, EnrollmentStatus.CANCELED);
-    createReservations(futureEvent2, futureEvent2.getMaxParticipants() - 2, LocalDateTime.now().plusMinutes(1));
+    createReservations(futureEvent2, 3, LocalDateTime.now().plusMinutes(1));
 
     final List<PublicExamEventDTO> examEventDTOs = publicExamEventService.listExamEvents(ExamLevel.EXCELLENT);
     assertEquals(5, examEventDTOs.size());

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicReservationServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicReservationServiceTest.java
@@ -1,0 +1,199 @@
+package fi.oph.vkt.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fi.oph.vkt.Factory;
+import fi.oph.vkt.api.dto.PublicExamEventDTO;
+import fi.oph.vkt.api.dto.PublicPersonDTO;
+import fi.oph.vkt.api.dto.PublicReservationDTO;
+import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Person;
+import fi.oph.vkt.model.Reservation;
+import fi.oph.vkt.model.type.EnrollmentStatus;
+import fi.oph.vkt.repository.ExamEventRepository;
+import fi.oph.vkt.repository.ReservationRepository;
+import fi.oph.vkt.util.exception.APIException;
+import fi.oph.vkt.util.exception.APIExceptionType;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import javax.annotation.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.core.env.Environment;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WithMockUser
+@DataJpaTest
+public class PublicReservationServiceTest {
+
+  private static final Duration ONE_MINUTE = Duration.ofMinutes(1);
+
+  @Resource
+  private ExamEventRepository examEventRepository;
+
+  @Resource
+  private ReservationRepository reservationRepository;
+
+  @Resource
+  private TestEntityManager entityManager;
+
+  private PublicReservationService publicReservationService;
+
+  @BeforeEach
+  public void setup() {
+    final Environment environment = mock(Environment.class);
+    when(environment.getRequiredProperty("app.reservation.duration")).thenReturn(ONE_MINUTE.toString());
+
+    publicReservationService = new PublicReservationService(examEventRepository, reservationRepository, environment);
+  }
+
+  @Test
+  public void testCreateReservationToExamEventWithRoom() {
+    final ExamEvent examEvent = createExamEvent(2);
+    createEnrollment(examEvent, EnrollmentStatus.PAID);
+    createEnrollment(examEvent, EnrollmentStatus.CANCELED);
+    final Person person = createPerson();
+
+    final PublicReservationDTO dto = publicReservationService.createReservation(examEvent.getId(), person);
+    assertReservationDTO(examEvent, person, 1, dto);
+
+    assertTrue(reservationRepository.findById(dto.id()).isPresent());
+  }
+
+  @Test
+  public void testCreateReservationToFullExamEvent() {
+    final ExamEvent examEvent = createExamEvent(2);
+    createEnrollment(examEvent, EnrollmentStatus.PAID);
+    createEnrollment(examEvent, EnrollmentStatus.EXPECTING_PAYMENT);
+    final Person person = createPerson();
+
+    final PublicReservationDTO dto = publicReservationService.createReservation(examEvent.getId(), person);
+    assertReservationDTO(examEvent, person, 2, dto);
+
+    assertTrue(reservationRepository.findById(dto.id()).isPresent());
+  }
+
+  @Test
+  public void testCreateReservationToExamEventWithExpiredReservations() {
+    final ExamEvent examEvent = createExamEvent(1);
+    createReservation(examEvent, LocalDateTime.now());
+    createReservation(examEvent, LocalDateTime.now().minusDays(1));
+    final Person person = createPerson();
+
+    final PublicReservationDTO dto = publicReservationService.createReservation(examEvent.getId(), person);
+    assertReservationDTO(examEvent, person, 0, dto);
+
+    assertTrue(reservationRepository.findById(dto.id()).isPresent());
+  }
+
+  @Test
+  public void testCreateReservationShouldUpdateExpiresAtForExistingReservation() {
+    final ExamEvent examEvent = createExamEvent(1);
+    final Reservation reservation = createReservation(examEvent, LocalDateTime.now().minusDays(1));
+    final Person person = reservation.getPerson();
+
+    final PublicReservationDTO dto = publicReservationService.createReservation(examEvent.getId(), person);
+    assertReservationDTO(examEvent, person, 0, dto);
+
+    assertTrue(reservationRepository.findById(dto.id()).isPresent());
+    assertEquals(1, reservationRepository.count());
+  }
+
+  @Test
+  public void testCreateReservationWithCongestion() {
+    final ExamEvent examEvent = createExamEvent(1);
+    createReservation(examEvent, LocalDateTime.now().plusMinutes(1));
+    final Person person = createPerson();
+
+    final APIException ex = assertThrows(
+      APIException.class,
+      () -> publicReservationService.createReservation(examEvent.getId(), person)
+    );
+    assertEquals(APIExceptionType.CREATE_RESERVATION_CONGESTION, ex.getExceptionType());
+  }
+
+  @Test
+  public void testCreateReservationWithRegistrationClosed() {
+    final ExamEvent examEvent = Factory.examEvent();
+    examEvent.setRegistrationCloses(LocalDate.now().minusDays(1));
+    entityManager.persist(examEvent);
+    final Person person = createPerson();
+
+    final APIException ex = assertThrows(
+      APIException.class,
+      () -> publicReservationService.createReservation(examEvent.getId(), person)
+    );
+    assertEquals(APIExceptionType.CREATE_RESERVATION_REGISTRATION_CLOSED, ex.getExceptionType());
+  }
+
+  private ExamEvent createExamEvent(final int maxParticipants) {
+    final ExamEvent examEvent = Factory.examEvent();
+    examEvent.setMaxParticipants(maxParticipants);
+    entityManager.persist(examEvent);
+
+    return examEvent;
+  }
+
+  private Enrollment createEnrollment(final ExamEvent examEvent, final EnrollmentStatus status) {
+    final Person person = createPerson();
+    final Enrollment enrollment = Factory.enrollment(examEvent, person);
+    enrollment.setStatus(status);
+    entityManager.persist(enrollment);
+
+    return enrollment;
+  }
+
+  private Reservation createReservation(final ExamEvent examEvent, final LocalDateTime expiresAt) {
+    final Person person = createPerson();
+    final Reservation reservation = Factory.reservation(examEvent, person);
+    reservation.setExpiresAt(expiresAt);
+    entityManager.persist(reservation);
+
+    return reservation;
+  }
+
+  private Person createPerson() {
+    final Person person = Factory.person();
+    entityManager.persist(person);
+
+    return person;
+  }
+
+  private void assertReservationDTO(
+    final ExamEvent examEvent,
+    final Person person,
+    final int participants,
+    final PublicReservationDTO dto
+  ) {
+    final PublicExamEventDTO examEventDTO = dto.examEvent();
+    assertEquals(examEvent.getId(), examEventDTO.id());
+    assertEquals(examEvent.getLanguage(), examEventDTO.language());
+    assertEquals(examEvent.getDate(), examEventDTO.date());
+    assertEquals(examEvent.getRegistrationCloses(), examEventDTO.registrationCloses());
+    assertEquals(participants, examEventDTO.participants());
+    assertEquals(examEvent.getMaxParticipants(), examEventDTO.maxParticipants());
+
+    final PublicPersonDTO personDTO = dto.person();
+    assertEquals(person.getId(), personDTO.id());
+    assertEquals(person.getIdentityNumber(), personDTO.identityNumber());
+    assertEquals(person.getLastName(), personDTO.lastName());
+    assertEquals(person.getFirstName(), person.getFirstName());
+
+    final ZonedDateTime expectedExpiresAt = ZonedDateTime.of(
+      LocalDateTime.now().plus(ONE_MINUTE),
+      ZoneId.systemDefault()
+    );
+    assertTrue(dto.expiresAt().isAfter(expectedExpiresAt.minusSeconds(10)));
+    assertTrue(dto.expiresAt().isBefore(expectedExpiresAt.plusSeconds(1)));
+  }
+}

--- a/frontend/packages/vkt/public/i18n/fi-FI/common.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/common.json
@@ -7,6 +7,8 @@
       "contactEmail": "kielitutkinnot@oph.fi",
       "errors": {
         "api": {
+          "createReservationCongestion": "Tutkintotilaisuus on ruuhkautunut",
+          "createReservationRegistrationClosed": "Tutkintotilaisuuteen ilmoittautuminen on sulkeutunut",
           "generic": "Toiminto epäonnistui, yritä myöhemmin uudelleen",
           "invalidVersion": "Toiminto epäonnistui, koska yritit muuttaa vanhentunutta dataa. Päivitä sivu ja yritä tarvittaessa uudelleen."
         },

--- a/frontend/packages/vkt/src/App.tsx
+++ b/frontend/packages/vkt/src/App.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
-import { StyleCacheProvider } from 'shared/components';
+import { NotifierContextProvider, StyleCacheProvider } from 'shared/components';
 
 import { initI18n } from 'configs/i18n';
 import { theme } from 'configs/materialUI';
@@ -16,7 +16,9 @@ export const App = () => (
   <Provider store={store}>
     <StyleCacheProvider appName="vkt">
       <ThemeProvider theme={theme}>
-        <AppRouter />
+        <NotifierContextProvider>
+          <AppRouter />
+        </NotifierContextProvider>
       </ThemeProvider>
     </StyleCacheProvider>
   </Provider>

--- a/frontend/packages/vkt/src/components/layouts/Footer.tsx
+++ b/frontend/packages/vkt/src/components/layouts/Footer.tsx
@@ -16,15 +16,19 @@ import {
   useCommonTranslation,
   usePublicTranslation,
 } from 'configs/i18n';
-import { AppRoutes } from 'enums/app';
+import { useAppSelector } from 'configs/redux';
+import { AppRoutes, PublicUIViews } from 'enums/app';
 import { useAuthentication } from 'hooks/useAuthentication';
+import { publicUIViewSelector } from 'redux/selectors/publicUIView';
 
 export const Footer = () => {
   const { t } = usePublicTranslation({ keyPrefix: 'vkt.component.footer' });
   const translateCommon = useCommonTranslation();
 
   const { isAuthenticated } = useAuthentication();
-  const showFooter = !isAuthenticated; // TODO: add current view checks for public UI
+  const { currentView } = useAppSelector(publicUIViewSelector);
+  const showFooter =
+    !isAuthenticated && currentView !== PublicUIViews.Reservation;
 
   return (
     <footer>

--- a/frontend/packages/vkt/src/components/publicExamEvent/PublicExamEventGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/PublicExamEventGrid.tsx
@@ -1,5 +1,6 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Alert, Grid, Paper } from '@mui/material';
+import { useEffect } from 'react';
 import { Trans } from 'react-i18next';
 import { ExtLink, H1, H2, HeaderSeparator, Text } from 'shared/components';
 import { APIResponseStatus, Severity } from 'shared/enums';
@@ -7,7 +8,8 @@ import { APIResponseStatus, Severity } from 'shared/enums';
 import { PublicExamEventListing } from 'components/publicExamEvent/listing/PublicExamEventListing';
 import { PublicExamEventGridSkeleton } from 'components/skeletons/PublicExamEventGridSkeleton';
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
-import { useAppSelector } from 'configs/redux';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { loadPublicExamEvents } from 'redux/reducers/publicExamEvent';
 import { publicExamEventsSelector } from 'redux/selectors/publicExamEvent';
 
 export const PublicExamEventGrid = () => {
@@ -17,6 +19,12 @@ export const PublicExamEventGrid = () => {
 
   // Redux
   const { status, examEvents } = useAppSelector(publicExamEventsSelector);
+
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(loadPublicExamEvents());
+  }, [dispatch]);
 
   // State
   const isLoading = status === APIResponseStatus.InProgress;

--- a/frontend/packages/vkt/src/components/publicExamEvent/listing/PublicExamEventListingHeader.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/listing/PublicExamEventListingHeader.tsx
@@ -1,11 +1,13 @@
 import { TableCell, TableHead, TableRow } from '@mui/material';
-import { CustomButton, H3 } from 'shared/components';
-import { Color, Variant } from 'shared/enums';
+import { CustomButton, H3, LoadingProgressIndicator } from 'shared/components';
+import { APIResponseStatus, Color, Variant } from 'shared/enums';
 import { useWindowProperties } from 'shared/hooks';
 
 import { usePublicTranslation } from 'configs/i18n';
-import { useAppSelector } from 'configs/redux';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { loadReservation } from 'redux/reducers/publicReservation';
 import { publicExamEventsSelector } from 'redux/selectors/publicExamEvent';
+import { publicReservationSelector } from 'redux/selectors/publicReservation';
 
 export const PublicExamEventListingHeader = () => {
   const { t } = usePublicTranslation({
@@ -14,9 +16,20 @@ export const PublicExamEventListingHeader = () => {
   const { isPhone } = useWindowProperties();
 
   const { selectedExamEvent } = useAppSelector(publicExamEventsSelector);
+  const { status } = useAppSelector(publicReservationSelector);
+
+  const isReservationCreationInProgress =
+    status === APIResponseStatus.InProgress;
 
   const enrollButtonDisabled =
-    !selectedExamEvent || selectedExamEvent.hasCongestion;
+    !selectedExamEvent ||
+    selectedExamEvent.hasCongestion ||
+    isReservationCreationInProgress;
+
+  const dispatch = useAppDispatch();
+
+  const startEnrollment = () =>
+    selectedExamEvent && dispatch(loadReservation(selectedExamEvent.id));
 
   return (
     <TableHead>
@@ -36,14 +49,19 @@ export const PublicExamEventListingHeader = () => {
             <H3>{t('header.openings')}</H3>
           </TableCell>
           <TableCell>
-            <CustomButton
-              data-testid="public-exam-events__enroll-btn"
-              color={Color.Secondary}
-              variant={Variant.Contained}
-              disabled={enrollButtonDisabled}
+            <LoadingProgressIndicator
+              isLoading={isReservationCreationInProgress}
             >
-              {t('enroll')}
-            </CustomButton>
+              <CustomButton
+                data-testid="public-exam-events__enroll-btn"
+                color={Color.Secondary}
+                variant={Variant.Contained}
+                disabled={enrollButtonDisabled}
+                onClick={startEnrollment}
+              >
+                {t('enroll')}
+              </CustomButton>
+            </LoadingProgressIndicator>
           </TableCell>
         </TableRow>
       )}

--- a/frontend/packages/vkt/src/configs/i18n.ts
+++ b/frontend/packages/vkt/src/configs/i18n.ts
@@ -59,15 +59,16 @@ declare module 'react-i18next' {
   interface CustomTypeOptions {
     defaultNS: typeof langFI;
     resources: {
-      [langFI]: typeof publicFI;
-      [langSV]: typeof publicSV;
-      [langEN]: typeof publicEN;
+      [langFI]: typeof commonFI;
+      [langSV]: typeof commonSV;
+      [langEN]: typeof commonEN;
     };
   }
 }
 
 export const initI18n = () => {
   const i18n = use(initReactI18next).use(LanguageDetector).init({
+    defaultNS: 'common',
     resources,
     detection: detectionOptions,
     fallbackLng: langFI,
@@ -109,7 +110,6 @@ export const useCommonTranslation = () => {
   return t;
 };
 
-// ts-unused-exports:disable-next-line
 export const translateOutsideComponent = () => {
   return t;
 };

--- a/frontend/packages/vkt/src/enums/api.ts
+++ b/frontend/packages/vkt/src/enums/api.ts
@@ -8,7 +8,8 @@ export enum APIEndpoints {
  * Certain errors expected to be returned by the backend.
  * The respective backend enum is `APIExceptionType`.
  */
-// ts-unused-exports:disable-next-line
 export enum APIError {
+  CreateReservationCongestion = 'createReservationCongestion',
+  CreateReservationRegistrationClosed = 'createReservationRegistrationClosed',
   InvalidVersion = 'invalidVersion',
 }

--- a/frontend/packages/vkt/src/enums/app.ts
+++ b/frontend/packages/vkt/src/enums/app.ts
@@ -12,6 +12,11 @@ export enum AppRoutes {
   NotFoundPage = '*',
 }
 
+export enum PublicUIViews {
+  ExamEventListing = 'ExamEventListing',
+  Reservation = 'Reservation',
+}
+
 export enum ExamLanguage {
   ALL = 'ALL',
   FI = 'FI',

--- a/frontend/packages/vkt/src/hooks/useAPIErrorToast.ts
+++ b/frontend/packages/vkt/src/hooks/useAPIErrorToast.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { Duration, Severity } from 'shared/enums';
+import { useToast } from 'shared/hooks';
+
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { resetAPIError } from 'redux/reducers/APIError';
+import { APIErrorSelector } from 'redux/selectors/APIError';
+
+export const useAPIErrorToast = () => {
+  const dispatch = useAppDispatch();
+  const errorMessage = useAppSelector(APIErrorSelector).message;
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    if (errorMessage) {
+      showToast({
+        severity: Severity.Error,
+        description: errorMessage,
+        timeOut: Duration.Medium,
+        onClose: () => dispatch(resetAPIError()),
+      });
+    }
+  }, [errorMessage, dispatch, showToast]);
+};

--- a/frontend/packages/vkt/src/interfaces/APIError.ts
+++ b/frontend/packages/vkt/src/interfaces/APIError.ts
@@ -1,0 +1,3 @@
+export interface APIErrorState {
+  message?: string;
+}

--- a/frontend/packages/vkt/src/interfaces/publicPerson.ts
+++ b/frontend/packages/vkt/src/interfaces/publicPerson.ts
@@ -1,0 +1,6 @@
+export interface PublicPerson {
+  id: number;
+  identityNumber: string;
+  lastName: string;
+  firstName: string;
+}

--- a/frontend/packages/vkt/src/interfaces/publicReservation.ts
+++ b/frontend/packages/vkt/src/interfaces/publicReservation.ts
@@ -1,0 +1,16 @@
+import { Dayjs } from 'dayjs';
+
+import { PublicExamEvent } from 'interfaces/publicExamEvent';
+import { PublicPerson } from 'interfaces/publicPerson';
+
+export interface PublicReservation
+  extends Omit<PublicReservationResponse, 'expiresAt'> {
+  expiresAt: Dayjs;
+}
+
+export interface PublicReservationResponse {
+  id: number;
+  expiresAt: string;
+  examEvent: PublicExamEvent;
+  person: PublicPerson;
+}

--- a/frontend/packages/vkt/src/pages/PublicHomePage.tsx
+++ b/frontend/packages/vkt/src/pages/PublicHomePage.tsx
@@ -1,16 +1,13 @@
 import { Box, Grid } from '@mui/material';
-import { FC, useEffect } from 'react';
+import { FC } from 'react';
 
 import { PublicExamEventGrid } from 'components/publicExamEvent/PublicExamEventGrid';
-import { useAppDispatch } from 'configs/redux';
-import { loadPublicExamEvents } from 'redux/reducers/publicExamEvent';
+import { useAppSelector } from 'configs/redux';
+import { PublicUIViews } from 'enums/app';
+import { publicUIViewSelector } from 'redux/selectors/publicUIView';
 
 export const PublicHomePage: FC = () => {
-  const dispatch = useAppDispatch();
-
-  useEffect(() => {
-    dispatch(loadPublicExamEvents());
-  }, [dispatch]);
+  const { currentView } = useAppSelector(publicUIViewSelector);
 
   return (
     <Box className="public-homepage">
@@ -20,7 +17,9 @@ export const PublicHomePage: FC = () => {
         direction="column"
         className="public-homepage__grid-container"
       >
-        <PublicExamEventGrid />
+        {currentView === PublicUIViews.Reservation ? null : (
+          <PublicExamEventGrid />
+        )}
       </Grid>
     </Box>
   );

--- a/frontend/packages/vkt/src/redux/reducers/APIError.ts
+++ b/frontend/packages/vkt/src/redux/reducers/APIError.ts
@@ -1,0 +1,21 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { APIErrorState } from 'interfaces/APIError';
+
+const initialState: APIErrorState = {};
+
+const APIErrorSlice = createSlice({
+  name: 'APIError',
+  initialState,
+  reducers: {
+    setAPIError(state, action: PayloadAction<string>) {
+      state.message = action.payload;
+    },
+    resetAPIError(state) {
+      state.message = initialState.message;
+    },
+  },
+});
+
+export const APIErrorReducer = APIErrorSlice.reducer;
+export const { setAPIError, resetAPIError } = APIErrorSlice.actions;

--- a/frontend/packages/vkt/src/redux/reducers/publicReservation.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicReservation.ts
@@ -1,0 +1,47 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Dayjs } from 'dayjs';
+import { APIResponseStatus } from 'shared/enums';
+
+import { PublicExamEvent } from 'interfaces/publicExamEvent';
+import { PublicPerson } from 'interfaces/publicPerson';
+import { PublicReservation } from 'interfaces/publicReservation';
+
+interface PublicReservationState {
+  status: APIResponseStatus;
+  id?: number;
+  expiresAt?: Dayjs;
+  examEvent?: PublicExamEvent;
+  person?: PublicPerson;
+}
+
+const initialState: PublicReservationState = {
+  status: APIResponseStatus.NotStarted,
+  id: undefined,
+  expiresAt: undefined,
+  examEvent: undefined,
+  person: undefined,
+};
+
+const publicReservationSlice = createSlice({
+  name: 'publicReservation',
+  initialState,
+  reducers: {
+    loadReservation(state, _action: PayloadAction<number>) {
+      state.status = APIResponseStatus.InProgress;
+    },
+    rejectReservation(state) {
+      state.status = APIResponseStatus.Error;
+    },
+    storeReservation(state, action: PayloadAction<PublicReservation>) {
+      state.status = APIResponseStatus.Success;
+      state.id = action.payload.id;
+      state.expiresAt = action.payload.expiresAt;
+      state.examEvent = action.payload.examEvent;
+      state.person = action.payload.person;
+    },
+  },
+});
+
+export const publicReservationReducer = publicReservationSlice.reducer;
+export const { loadReservation, rejectReservation, storeReservation } =
+  publicReservationSlice.actions;

--- a/frontend/packages/vkt/src/redux/reducers/publicUIView.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicUIView.ts
@@ -1,0 +1,20 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { PublicUIViews } from 'enums/app';
+
+const initialState = {
+  currentView: PublicUIViews.ExamEventListing,
+};
+
+const publicUIViewSlice = createSlice({
+  name: 'publicUIView',
+  initialState,
+  reducers: {
+    setPublicUIView(state, action: PayloadAction<PublicUIViews>) {
+      state.currentView = action.payload;
+    },
+  },
+});
+
+export const publicUIViewReducer = publicUIViewSlice.reducer;
+export const { setPublicUIView } = publicUIViewSlice.actions;

--- a/frontend/packages/vkt/src/redux/sagas/index.ts
+++ b/frontend/packages/vkt/src/redux/sagas/index.ts
@@ -3,7 +3,13 @@ import { all } from 'redux-saga/effects';
 import { watchListExamEvents } from 'redux/sagas/clerkListExamEvent';
 import { watchClerkUser } from 'redux/sagas/clerkUser';
 import { watchPublicExamEvents } from 'redux/sagas/publicExamEvent';
+import { watchPublicReservations } from 'redux/sagas/publicReservation';
 
 export default function* rootSaga() {
-  yield all([watchListExamEvents(), watchClerkUser(), watchPublicExamEvents()]);
+  yield all([
+    watchListExamEvents(),
+    watchClerkUser(),
+    watchPublicExamEvents(),
+    watchPublicReservations(),
+  ]);
 }

--- a/frontend/packages/vkt/src/redux/sagas/publicReservation.ts
+++ b/frontend/packages/vkt/src/redux/sagas/publicReservation.ts
@@ -1,0 +1,41 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import { AxiosError, AxiosResponse } from 'axios';
+import { call, put, takeLatest } from 'redux-saga/effects';
+
+import axiosInstance from 'configs/axios';
+import { APIEndpoints } from 'enums/api';
+import { PublicUIViews } from 'enums/app';
+import { PublicReservationResponse } from 'interfaces/publicReservation';
+import { setAPIError } from 'redux/reducers/APIError';
+import {
+  loadReservation,
+  rejectReservation,
+  storeReservation,
+} from 'redux/reducers/publicReservation';
+import { setPublicUIView } from 'redux/reducers/publicUIView';
+import { NotifierUtils } from 'utils/notifier';
+import { SerializationUtils } from 'utils/serialization';
+
+function* loadReservationSaga(action: PayloadAction<number>) {
+  try {
+    const response: AxiosResponse<PublicReservationResponse> = yield call(
+      axiosInstance.post,
+      `${APIEndpoints.PublicExamEvent}/${action.payload}/reservation`,
+      action.payload
+    );
+    const publicReservation = SerializationUtils.deserializePublicReservation(
+      response.data
+    );
+
+    yield put(storeReservation(publicReservation));
+    yield put(setPublicUIView(PublicUIViews.Reservation));
+  } catch (error) {
+    const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
+    yield put(setAPIError(errorMessage));
+    yield put(rejectReservation());
+  }
+}
+
+export function* watchPublicReservations() {
+  yield takeLatest(loadReservation, loadReservationSaga);
+}

--- a/frontend/packages/vkt/src/redux/selectors/APIError.ts
+++ b/frontend/packages/vkt/src/redux/selectors/APIError.ts
@@ -1,0 +1,3 @@
+import { RootState } from 'configs/redux';
+
+export const APIErrorSelector = (state: RootState) => state.APIError;

--- a/frontend/packages/vkt/src/redux/selectors/publicReservation.ts
+++ b/frontend/packages/vkt/src/redux/selectors/publicReservation.ts
@@ -1,0 +1,4 @@
+import { RootState } from 'configs/redux';
+
+export const publicReservationSelector = (state: RootState) =>
+  state.publicReservationReducer;

--- a/frontend/packages/vkt/src/redux/selectors/publicUIView.ts
+++ b/frontend/packages/vkt/src/redux/selectors/publicUIView.ts
@@ -1,0 +1,3 @@
+import { RootState } from 'configs/redux';
+
+export const publicUIViewSelector = (state: RootState) => state.publicUIView;

--- a/frontend/packages/vkt/src/redux/store/index.ts
+++ b/frontend/packages/vkt/src/redux/store/index.ts
@@ -1,18 +1,24 @@
 import createSagaMiddleware from '@redux-saga/core';
 import { configureStore } from '@reduxjs/toolkit';
 
+import { APIErrorReducer } from 'redux/reducers/APIError';
 import { clerkListExamEventReducer } from 'redux/reducers/clerkListExamEvent';
 import { clerkUserReducer } from 'redux/reducers/clerkUser';
 import { publicExamEventReducer } from 'redux/reducers/publicExamEvent';
+import { publicReservationReducer } from 'redux/reducers/publicReservation';
+import { publicUIViewReducer } from 'redux/reducers/publicUIView';
 import rootSaga from 'redux/sagas/index';
 
 const saga = createSagaMiddleware();
 
 const store = configureStore({
   reducer: {
+    APIError: APIErrorReducer,
     clerkListExamEvent: clerkListExamEventReducer,
     clerkUser: clerkUserReducer,
     publicExamEvent: publicExamEventReducer,
+    publicReservationReducer: publicReservationReducer,
+    publicUIView: publicUIViewReducer,
   },
   middleware: [saga],
 });

--- a/frontend/packages/vkt/src/routers/AppRouter.tsx
+++ b/frontend/packages/vkt/src/routers/AppRouter.tsx
@@ -6,6 +6,7 @@ import { Footer } from 'components/layouts/Footer';
 import { Header } from 'components/layouts/Header';
 import { useCommonTranslation } from 'configs/i18n';
 import { AppRoutes } from 'enums/app';
+import { useAPIErrorToast } from 'hooks/useAPIErrorToast';
 import { ClerkHomePage } from 'pages/ClerkHomePage';
 import { PublicHomePage } from 'pages/PublicHomePage';
 
@@ -15,7 +16,7 @@ export const AppRouter: FC = () => {
   useEffect(() => {
     document.title = translateCommon('appTitle');
   }, [translateCommon]);
-  // TODO: useAPIErrorToast();
+  useAPIErrorToast();
 
   return (
     <BrowserRouter>

--- a/frontend/packages/vkt/src/tests/cypress/integration/public_enrollment.spec.ts
+++ b/frontend/packages/vkt/src/tests/cypress/integration/public_enrollment.spec.ts
@@ -1,0 +1,52 @@
+import { onPublicHomePage } from 'tests/cypress/support/page-objects/publicHomePage';
+import { onToast } from 'tests/cypress/support/page-objects/toast';
+
+beforeEach(() => {
+  cy.openPublicHomePage();
+});
+
+describe('Public enrollment', () => {
+  describe('to exam event with room', () => {
+    const EXAM_EVENT_ID = 2;
+
+    beforeEach(() => {
+      onPublicHomePage.clickExamEventRow(EXAM_EVENT_ID);
+      onPublicHomePage.clickEnrollButton();
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    it('WIP: allow user to enroll to the exam event', () => {});
+  });
+
+  describe('to exam event that is full', () => {
+    const EXAM_EVENT_ID = 5;
+
+    beforeEach(() => {
+      onPublicHomePage.clickExamEventRow(EXAM_EVENT_ID);
+      onPublicHomePage.clickEnrollButton();
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    it('WIP: allow user to enroll to the exam event', () => {});
+  });
+
+  describe('errors when enroll button is clicked on the home page', () => {
+    it('exam event received congestion after the home page was opened', () => {
+      onPublicHomePage.clickExamEventRow(10);
+      onPublicHomePage.clickEnrollButton();
+
+      onPublicHomePage.expectEnrollButtonEnabled();
+      onToast.expectText('Tutkintotilaisuus on ruuhkautunut');
+    });
+
+    it('registration to exam event closed after the home page was opened', () => {
+      onPublicHomePage.clickExamEventRow(11);
+      onPublicHomePage.clickEnrollButton();
+
+      onPublicHomePage.expectEnrollButtonEnabled();
+      onToast.expectText(
+        'Tutkintotilaisuuteen ilmoittautuminen on sulkeutunut'
+      );
+    });
+  });
+});

--- a/frontend/packages/vkt/src/tests/cypress/support/page-objects/publicHomePage.ts
+++ b/frontend/packages/vkt/src/tests/cypress/support/page-objects/publicHomePage.ts
@@ -55,6 +55,10 @@ class PublicHomePage {
   expectCheckboxNotChecked(id: number) {
     this.elements.examEventRowCheckbox(id).should('not.be.checked');
   }
+
+  clickEnrollButton() {
+    this.elements.enrollButton().should('be.visible').click();
+  }
 }
 
 export const onPublicHomePage = new PublicHomePage();

--- a/frontend/packages/vkt/src/tests/cypress/support/page-objects/toast.ts
+++ b/frontend/packages/vkt/src/tests/cypress/support/page-objects/toast.ts
@@ -1,0 +1,11 @@
+class Toast {
+  elements = {
+    toastNotification: () => cy.findByTestId(`toast-notification`),
+  };
+
+  expectText(text: string) {
+    this.elements.toastNotification().should('contain.text', text);
+  }
+}
+
+export const onToast = new Toast();

--- a/frontend/packages/vkt/src/tests/msw/fixtures/person.ts
+++ b/frontend/packages/vkt/src/tests/msw/fixtures/person.ts
@@ -1,0 +1,6 @@
+export const person = {
+  id: 1,
+  identityNumber: '200714-982U',
+  lastName: 'Aaltonen',
+  firstName: 'Anna',
+};

--- a/frontend/packages/vkt/src/tests/msw/handlers.ts
+++ b/frontend/packages/vkt/src/tests/msw/handlers.ts
@@ -2,12 +2,57 @@ import { rest } from 'msw';
 
 import { APIEndpoints } from 'enums/api';
 import { clerkExamEvents9 } from 'tests/msw/fixtures/clerkExamEvents9';
+import { person } from 'tests/msw/fixtures/person';
 import { publicExamEvents11 } from 'tests/msw/fixtures/publicExamEvents11';
 
 export const handlers = [
   rest.get(APIEndpoints.PublicExamEvent, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(publicExamEvents11));
   }),
+  rest.post(
+    `${APIEndpoints.PublicExamEvent}/2/reservation`,
+    (req, res, ctx) => {
+      return res(
+        ctx.status(201),
+        ctx.json({
+          id: 1,
+          expiresAt: Date.now() + 60 * 1000,
+          examEvent: publicExamEvents11[1],
+          person,
+        })
+      );
+    }
+  ),
+  rest.post(
+    `${APIEndpoints.PublicExamEvent}/5/reservation`,
+    (req, res, ctx) => {
+      return res(
+        ctx.status(201),
+        ctx.json({
+          id: 2,
+          expiresAt: Date.now() + 60 * 1000,
+          examEvent: publicExamEvents11[4],
+          person,
+        })
+      );
+    }
+  ),
+  rest.post(
+    `${APIEndpoints.PublicExamEvent}/10/reservation`,
+    (req, res, ctx) => {
+      const errorCode = 'createReservationCongestion';
+
+      return res(ctx.status(400), ctx.json({ errorCode }));
+    }
+  ),
+  rest.post(
+    `${APIEndpoints.PublicExamEvent}/11/reservation`,
+    (req, res, ctx) => {
+      const errorCode = 'createReservationRegistrationClosed';
+
+      return res(ctx.status(400), ctx.json({ errorCode }));
+    }
+  ),
   rest.get(APIEndpoints.ClerkExamEvent, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(clerkExamEvents9));
   }),

--- a/frontend/packages/vkt/src/utils/notifier.ts
+++ b/frontend/packages/vkt/src/utils/notifier.ts
@@ -1,0 +1,23 @@
+import { AxiosError } from 'axios';
+
+import { translateOutsideComponent } from 'configs/i18n';
+import { APIError } from 'enums/api';
+
+export class NotifierUtils {
+  static getAPIErrorMessage(error: AxiosError) {
+    const t = translateOutsideComponent();
+    const apiError = NotifierUtils.getAPIError(error);
+
+    return apiError
+      ? t(`vkt.common.errors.api.${apiError}`)
+      : t('vkt.common.errors.api.generic');
+  }
+
+  private static getAPIError(error: AxiosError) {
+    const errorCode = error.response?.data.errorCode;
+
+    if (errorCode && Object.values(APIError).includes(errorCode)) {
+      return errorCode;
+    }
+  }
+}

--- a/frontend/packages/vkt/src/utils/serialization.ts
+++ b/frontend/packages/vkt/src/utils/serialization.ts
@@ -8,6 +8,10 @@ import {
   PublicExamEvent,
   PublicExamEventResponse,
 } from 'interfaces/publicExamEvent';
+import {
+  PublicReservation,
+  PublicReservationResponse,
+} from 'interfaces/publicReservation';
 
 export class SerializationUtils {
   static deserializePublicExamEvent(
@@ -17,6 +21,15 @@ export class SerializationUtils {
       ...publicExamEvent,
       date: dayjs(publicExamEvent.date),
       registrationCloses: dayjs(publicExamEvent.registrationCloses),
+    };
+  }
+
+  static deserializePublicReservation(
+    publicReservation: PublicReservationResponse
+  ): PublicReservation {
+    return {
+      ...publicReservation,
+      expiresAt: dayjs(publicReservation.expiresAt),
     };
   }
 


### PR DESCRIPTION
## Yhteenveto

Kun klikataan julkisella etusivulla Ilmoittaudu-painiketta, tehdään backendille pyyntö ilmoittautumisen alustamiseksi. Jos tutkintotilaisuus on etusivun lataamisen jälkeen mutta ennen napin painamista ruuhkautunut, täyttynyt tai ilmoittautumisaika on mennyt umpeen, näytetään näistä sopivat virheilmoitukset. Tätä varten lisätty myös toastien käsittely VKT:hen ja havaittu, että i18n.ts:n `translateOutsideComponent` ei aiemmin toiminut ja se korjattu.

Varsinainen ilmoittautumisen alustus / paikkavarauksen teko tietokantaan sellainen, jota tämän yhteydessä ei ole tehty. Sen voisi toteuttaa tämän päälle vaikka OPHVKTKEH-42:ssa.

## Huomautukset

Tämän yhteydessä voisi miettiä, halutaanko ilmoittautumisflow omalle sivulleen kuten toistaiseksi tehty (/vkt/ilmoittautuminen), vai osaksi etusivua kuten AKR:ssä yhteydenottopyyntö, jonka url siis sama kuin etusivunkin.

## Check-lista

- [x] Testattu docker-compose:lla