### PR TITLE
OTR & AKR(Frontend): OPHOTRKEH-191 osoitetta ei löytynyt -sivu

### DIFF
--- a/frontend/packages/akr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/akr/public/i18n/en-GB/translation.json
@@ -448,7 +448,7 @@
         }
       },
       "notFoundPage": {
-        "description": "The address may be wrong or outdated. Click the button below to return to the home page",
+        "description": "The address may be wrong or outdated. Click the button below to return to the home page.",
         "title": "Unfortunately, the page you are looking for was not found"
       },
       "translator": {

--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -456,7 +456,7 @@
         }
       },
       "notFoundPage": {
-        "description": "Osoite saattaa olla väärä tai vanhentunut. Voit palata etusivulle alla olevasta napista",
+        "description": "Osoite saattaa olla väärä tai vanhentunut. Voit palata etusivulle alla olevasta napista.",
         "title": "Valitettavasti etsimääsi sivua ei löytynyt"
       },
       "statisticsPage": {

--- a/frontend/packages/akr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/translation.json
@@ -448,7 +448,7 @@
         }
       },
       "notFoundPage": {
-        "description": "Adressen kan vara fel eller föråldrad. Gå tillbaka till framsidan med knappen nedan",
+        "description": "Adressen kan vara fel eller föråldrad. Gå tillbaka till framsidan med knappen nedan.",
         "title": "Tyvärr kan sidan du sökte efter inte hittas"
       },
       "translator": {

--- a/frontend/packages/otr/public/i18n/en-GB/common.json
+++ b/frontend/packages/otr/public/i18n/en-GB/common.json
@@ -15,6 +15,7 @@
         "EAT": null,
         "KKT": null
       },
+      "frontPage": "Home",
       "loadingContent": "Downloading content",
       "meetingDates": "Meeting days",
       "navigationProtection": {

--- a/frontend/packages/otr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/otr/public/i18n/en-GB/translation.json
@@ -328,7 +328,7 @@
         }
       },
       "notFoundPage": {
-        "description": "The address may be wrong or outdated. Click the button below to return to the home page",
+        "description": "The address may be wrong or outdated. Click the button below to return to the home page.",
         "title": "Unfortunately, the page you are looking for was not found"
       }
     }

--- a/frontend/packages/otr/public/i18n/fi-FI/common.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/common.json
@@ -16,6 +16,7 @@
         "EAT": "Erikoisammattitutkinto (EAT)",
         "KKT": "Korkeakouluopinnot (KKT)"
       },
+      "frontPage": "Etusivu",
       "loadingContent": "Sisältöä ladataan",
       "meetingDates": "Kokouspäivät",
       "navigationProtection": {

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -340,7 +340,7 @@
         }
       },
       "notFoundPage": {
-        "description": "Osoite saattaa olla väärä tai vanhentunut. Voit palata etusivulle alla olevasta napista",
+        "description": "Osoite saattaa olla väärä tai vanhentunut. Voit palata etusivulle alla olevasta napista.",
         "title": "Valitettavasti etsimääsi sivua ei löytynyt"
       }
     }

--- a/frontend/packages/otr/public/i18n/sv-SE/common.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/common.json
@@ -15,6 +15,7 @@
         "EAT": null,
         "KKT": null
       },
+      "frontPage": "Framsida",
       "loadingContent": "Innehållet laddas ner",
       "meetingDates": "Mötesdagar",
       "navigationProtection": {

--- a/frontend/packages/otr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/translation.json
@@ -328,7 +328,7 @@
         }
       },
       "notFoundPage": {
-        "description": "Adressen kan vara fel eller föråldrad. Gå tillbaka till framsidan med knappen nedan",
+        "description": "Adressen kan vara fel eller föråldrad. Gå tillbaka till framsidan med knappen nedan.",
         "title": "Tyvärr kan sidan du sökte efter inte hittas"
       }
     }

--- a/frontend/packages/otr/src/pages/NotFoundPage.tsx
+++ b/frontend/packages/otr/src/pages/NotFoundPage.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react';
+import { CustomButton, H1, Text } from 'shared/components';
+
+import { useAppTranslation, useCommonTranslation } from 'configs/i18n';
+import { AppRoutes } from 'enums/app';
+
+export const NotFoundPage: FC = () => {
+  const { t } = useAppTranslation({
+    keyPrefix: 'otr.pages.notFoundPage',
+  });
+  const translateCommon = useCommonTranslation();
+
+  return (
+    <div className="not-found-page">
+      <H1>{t('title')}</H1>
+      <Text>{t('description')}</Text>
+      <CustomButton
+        className="not-found-page__btn"
+        color="secondary"
+        variant="contained"
+        href={AppRoutes.PublicHomePage}
+      >
+        {translateCommon('frontPage')}
+      </CustomButton>
+    </div>
+  );
+};

--- a/frontend/packages/otr/src/routers/AppRouter.tsx
+++ b/frontend/packages/otr/src/routers/AppRouter.tsx
@@ -12,6 +12,7 @@ import { ClerkInterpreterOverviewPage } from 'pages/ClerkInterpreterOverviewPage
 import { ClerkNewInterpreterPage } from 'pages/ClerkNewInterpreterPage';
 import { ClerkPersonSearchPage } from 'pages/ClerkPersonSearchPage';
 import { MeetingDatesPage } from 'pages/MeetingDatesPage';
+import { NotFoundPage } from 'pages/NotFoundPage';
 import { PublicHomePage } from 'pages/PublicHomePage';
 
 export const AppRouter: FC = () => {
@@ -54,6 +55,7 @@ export const AppRouter: FC = () => {
                 path={AppRoutes.ClerkNewInterpreterPage}
                 element={<ClerkNewInterpreterPage />}
               />
+              <Route path={AppRoutes.NotFoundPage} element={<NotFoundPage />} />
             </Routes>
           </div>
         </main>

--- a/frontend/packages/otr/src/styles/pages/_not-found-page.scss
+++ b/frontend/packages/otr/src/styles/pages/_not-found-page.scss
@@ -1,0 +1,15 @@
+.not-found-page {
+  margin-top: 7rem;
+
+  @include phone {
+    margin: 4rem 2rem;
+  }
+
+  & &__btn {
+    margin-top: 5rem;
+
+    @include phone {
+      margin: 3rem 0 20rem;
+    }
+  }
+}

--- a/frontend/packages/otr/src/styles/styles.scss
+++ b/frontend/packages/otr/src/styles/styles.scss
@@ -19,4 +19,5 @@
 @import 'pages/clerk-new-interpreter-page';
 @import 'pages/clerk-person-search-page';
 @import 'pages/meeting-dates-page';
+@import 'pages/not-found-page';
 @import 'pages/public-homepage';


### PR DESCRIPTION
## Yhteenveto

Kun OTR:ssä valitsee jonkun muun polun kuin routeissa määritelty, näytetään "Osoitetta ei löytynyt" -näkymä.

## Huomautukset

AKR:n puolella lisätty puuttuva piste `description` lauseen loppuun kullekin kielelle. AKR näin mukana pull requestin nimessä jotta luo myös näin imagen ecs:ään kun mergetään deviin.

## Check-lista

- [x] Käännösten Excel-tiedosto päivitetty
