### PR TITLE
AKR(Frontend): OPHAKRKEH-468 Safari clerk filters bug fix

### DIFF
--- a/frontend/packages/akr/src/styles/pages/_clerk-homepage.scss
+++ b/frontend/packages/akr/src/styles/pages/_clerk-homepage.scss
@@ -2,6 +2,7 @@
   flex: 1;
 
   & &__grid-container {
+    display: grid;
     gap: 2rem;
     padding: 2.5rem;
     padding-bottom: 4rem;


### PR DESCRIPTION
## Yhteenveto

Korjaa rikkoutuneen filtterinäkymän Safarilla

- [x] Testattu docker-compose:lla

## Ennen:

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/99322729/201338567-9221e1a1-bfba-4e58-8059-180426734b78.png">

##Jälkeen

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/99322729/201338660-fc5aed5f-fa87-4e7e-9a45-e314b4218994.png">


