### PR TITLE
VKT(Frontend): OPHVKTKEH-51 ilmoittautumisstepit ja Täytä yhteystietosi -sivu

### DIFF
--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.5.1",
+  "version": "1.5.0",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/vkt/public/i18n/fi-FI/common.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/common.json
@@ -18,6 +18,13 @@
           "generic": "Toiminto epäonnistui, yritä myöhemmin uudelleen",
           "invalidVersion": "Toiminto epäonnistui, koska yritit muuttaa vanhentunutta dataa. Päivitä sivu ja yritä tarvittaessa uudelleen."
         },
+        "customTextField": {
+          "emailFormat": "Sähköpostiosoite on virheellinen",
+          "maxLength": "Teksti on liian pitkä",
+          "personalIdentityCodeFormat": "Henkilötunnuksen muotoa ei tunnistettu",
+          "required": "Tieto on pakollinen",
+          "telFormat": "Puhelinnumero on virheellinen"
+        },
         "loadingFailed": "Tietojen lataus epäonnistui, yritä myöhemmin uudelleen."
       },
       "examLanguage": {
@@ -43,6 +50,7 @@
         "FI": "Näytä vain suomi",
         "SV": "Näytä vain ruotsi"
       },
+      "next": "Seuraava",
       "no": "Ei",
       "ophLogo": "Opetushallituksen logo",
       "rowsPerPageLabel": "Tulokset per sivu",

--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -31,6 +31,60 @@
           }
         }
       },
+      "publicEnrollment": {
+        "controlButtons": {
+          "cancelDialog": {
+            "description": "Haluatko peruuttaa ilmoittautumisen? Menetät täyttämäsi tiedot.",
+            "title": "Peruuta ilmoittautuminen"
+          },
+          "pay": "Siirry maksamaan"
+        },
+        "reservationDetails": {
+          "examDate": "Tutkintopäivä",
+          "openings": "Paikkoja vapaana",
+          "registrationCloses": "Ilmoittautuminen sulkeutuu"
+        },
+        "stepper": {
+          "active": "Aktiivinen",
+          "completed": "Suoritettu",
+          "phase": "Vaihe",
+          "step": {
+            "Identify": "Tunnistaudu",
+            "FillContactDetails": "Täytä yhteystietosi",
+            "SelectExam": "Valitse tutkinto",
+            "Preview": "Esikatsele",
+            "Pay": "Siirry maksamaan"
+          }
+        },
+        "steps": {
+          "fillContactDetails": {
+            "email": "Sähköpostiosoite",
+            "emailConfirmation": "Vahvista sähköpostiosoite",
+            "mismatchingEmailsError": "Sähköpostiosoitekenttien sisällöt eivät vastaa toisiaan",
+            "phoneNumber": "Puhelinnumero",
+            "title": "Yhteystiedot"
+          },
+          "personDetails": {
+            "firstName": "Etunimet",
+            "identityNumber": "Henkilötunnus",
+            "lastName": "Sukunimi",
+            "title": "Nimi ja henkilötunnus"
+          }
+        }
+      },
+      "publicExamEventGrid": {
+        "description": {
+          "linkName": "Opetushallituksen verkkopalvelusta",
+          "text": "Valtionhallinnon kielitutkinnot (VKT) on tarkoitettu julkishallinnon henkilöstön toisen kotimaisen kielen hallinnan osoittamiseen. Tutkinnoilla osoitetaan suomen tai ruotsin kielen suullinen, kirjallinen ja ymmärtämisen taito. Lisätietoa tutkinnosta"
+        },
+        "examinationDates": {
+          "description": "Tutkintomaksu on <strong>454 euroa</strong>, jos suullisen ja kirjallisen taidon tutkinnot suoritetaan samalla kerralla. (Tutkinnot osoittavat myös vastaavan tasoista ymmärtämisen taitoa.) Jos tutkinnot suoritetaan yksittäin, kukin tutkinto, suullisen, kirjallisen tai ymmärtämisen taidon tutkinto, maksaa <strong>227 euroa</strong>.",
+          "title": "Tutkintomaksut"
+        },
+        "noSearchResults": "Ei hakutuloksia",
+        "note": "Tietoa peruutuspaikoista Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.",
+        "title": "Valtionhallinnon kielitutkinnot (VKT) – ilmoittautuminen erinomaisen taidon tutkintoihin"
+      },
       "publicExamEventListing": {
         "accessibility": {
           "checkboxSelectedAriaLabel": "Poista valinta",
@@ -51,21 +105,6 @@
           "none": "Tutkinto täynnä. Voit ilmottautua jonoon."
         },
         "title": "Tulevat tutkintotilaisuudet"
-      }
-    },
-    "pages": {
-      "homepage": {
-        "description": {
-          "linkName": "Opetushallituksen verkkopalvelusta",
-          "text": "Valtionhallinnon kielitutkinnot (VKT) on tarkoitettu julkishallinnon henkilöstön toisen kotimaisen kielen hallinnan osoittamiseen. Tutkinnoilla osoitetaan suomen tai ruotsin kielen suullinen, kirjallinen ja ymmärtämisen taito. Lisätietoa tutkinnosta"
-        },
-        "examinationDates": {
-          "description": "Tutkintomaksu on <strong>454 euroa</strong>, jos suullisen ja kirjallisen taidon tutkinnot suoritetaan samalla kerralla. (Tutkinnot osoittavat myös vastaavan tasoista ymmärtämisen taitoa.) Jos tutkinnot suoritetaan yksittäin, kukin tutkinto, suullisen, kirjallisen tai ymmärtämisen taidon tutkinto, maksaa <strong>227 euroa</strong>.",
-          "title": "Tutkintomaksut"
-        },
-        "noSearchResults": "Ei hakutuloksia",
-        "note": "Tietoa peruutuspaikoista Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.",
-        "title": "Valtionhallinnon kielitutkinnot (VKT) – ilmoittautuminen erinomaisen taidon tutkintoihin"
       }
     }
   }

--- a/frontend/packages/vkt/src/components/clerkExamEvent/listing/ClerkExamEventListingRow.tsx
+++ b/frontend/packages/vkt/src/components/clerkExamEvent/listing/ClerkExamEventListingRow.tsx
@@ -1,7 +1,7 @@
 import { TableCell, TableRow } from '@mui/material';
-import { Dayjs } from 'dayjs';
 import { Link } from 'react-router-dom';
 import { Text } from 'shared/components';
+import { DateUtils } from 'shared/utils';
 
 import { useCommonTranslation } from 'configs/i18n';
 import { AppRoutes } from 'enums/app';
@@ -19,8 +19,6 @@ export const ClerkExamEventListingRow = ({
     /:examEventId$/,
     `${examEvent.id}`
   );
-
-  const formatDate = (date: Dayjs) => date.format('DD.MM.YYYY');
 
   return (
     <>
@@ -43,10 +41,12 @@ export const ClerkExamEventListingRow = ({
           </Link>
         </TableCell>
         <TableCell>
-          <Text>{formatDate(examEvent.date)}</Text>
+          <Text>{DateUtils.formatOptionalDate(examEvent.date)}</Text>
         </TableCell>
         <TableCell>
-          <Text>{formatDate(examEvent.registrationCloses)}</Text>
+          <Text>
+            {DateUtils.formatOptionalDate(examEvent.registrationCloses)}
+          </Text>
         </TableCell>
         <TableCell>
           <Text>{`${examEvent.participants} / ${examEvent.maxParticipants}`}</Text>

--- a/frontend/packages/vkt/src/components/layouts/Footer.tsx
+++ b/frontend/packages/vkt/src/components/layouts/Footer.tsx
@@ -28,7 +28,7 @@ export const Footer = () => {
   const { isAuthenticated } = useAuthentication();
   const { currentView } = useAppSelector(publicUIViewSelector);
   const showFooter =
-    !isAuthenticated && currentView !== PublicUIViews.Reservation;
+    !isAuthenticated && currentView !== PublicUIViews.Enrollment;
 
   return (
     <footer>

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
@@ -1,0 +1,144 @@
+import {
+  ArrowBackOutlined as ArrowBackIcon,
+  ArrowForwardOutlined as ArrowForwardIcon,
+} from '@mui/icons-material';
+import { CustomButton } from 'shared/components';
+import { Color, Severity, Variant } from 'shared/enums';
+import { useDialog } from 'shared/hooks';
+
+import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
+import {
+  cancelPublicEnrollment,
+  cancelPublicEnrollmentAndRemoveReservation,
+  decreaseActiveStep,
+  increaseActiveStep,
+} from 'redux/reducers/publicEnrollment';
+import { publicReservationSelector } from 'redux/selectors/publicReservation';
+
+export const PublicEnrollmentControlButtons = ({
+  activeStep,
+  isLoading,
+  disableNext,
+}: {
+  activeStep: PublicEnrollmentFormStep;
+  isLoading: boolean;
+  disableNext: boolean;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'vkt.component.publicEnrollment.controlButtons',
+  });
+  const translateCommon = useCommonTranslation();
+
+  const { reservation } = useAppSelector(publicReservationSelector);
+  const dispatch = useAppDispatch();
+
+  const { showDialog } = useDialog();
+
+  const handleCancelBtnClick = () => {
+    if (activeStep === PublicEnrollmentFormStep.Identify || !reservation) {
+      dispatch(cancelPublicEnrollment());
+    } else {
+      showDialog({
+        title: t('cancelDialog.title'),
+        severity: Severity.Info,
+        description: t('cancelDialog.description'),
+        actions: [
+          {
+            title: translateCommon('back'),
+            variant: Variant.Outlined,
+          },
+          {
+            title: translateCommon('yes'),
+            variant: Variant.Contained,
+            action: () =>
+              dispatch(
+                cancelPublicEnrollmentAndRemoveReservation(reservation.id)
+              ),
+          },
+        ],
+      });
+    }
+  };
+
+  const handleBackBtnClick = () => {
+    dispatch(decreaseActiveStep());
+  };
+
+  const handleNextBtnClick = () => {
+    dispatch(increaseActiveStep());
+  };
+
+  const CancelButton = () => (
+    <>
+      <CustomButton
+        variant={Variant.Text}
+        color={Color.Secondary}
+        onClick={handleCancelBtnClick}
+        data-testid="public-enrollment__controlButtons__cancel"
+        disabled={isLoading}
+      >
+        {translateCommon('cancel')}
+      </CustomButton>
+    </>
+  );
+
+  const BackButton = () => (
+    <CustomButton
+      variant={Variant.Outlined}
+      color={Color.Secondary}
+      onClick={handleBackBtnClick}
+      data-testid="public-enrollment__controlButtons__back"
+      startIcon={<ArrowBackIcon />}
+      disabled={
+        activeStep == PublicEnrollmentFormStep.FillContactDetails || isLoading
+      }
+    >
+      {translateCommon('back')}
+    </CustomButton>
+  );
+
+  const NextButton = () => (
+    <CustomButton
+      variant={Variant.Contained}
+      color={Color.Secondary}
+      onClick={handleNextBtnClick}
+      data-testid="public-enrollment__controlButtons__next"
+      endIcon={<ArrowForwardIcon />}
+      disabled={disableNext || isLoading}
+    >
+      {translateCommon('next')}
+    </CustomButton>
+  );
+
+  const SubmitButton = () => (
+    <CustomButton
+      variant={Variant.Contained}
+      color={Color.Secondary}
+      data-testid="public-enrollment__controlButtons__submit"
+      endIcon={<ArrowForwardIcon />}
+      disabled={disableNext || isLoading}
+    >
+      {t('pay')}
+    </CustomButton>
+  );
+
+  const renderBack = activeStep !== PublicEnrollmentFormStep.Identify;
+
+  const renderNext = [
+    PublicEnrollmentFormStep.FillContactDetails,
+    PublicEnrollmentFormStep.SelectExam,
+  ].includes(activeStep);
+
+  const renderSubmit = activeStep === PublicEnrollmentFormStep.Preview;
+
+  return (
+    <div className="columns flex-end gapped margin-top-xxl">
+      {CancelButton()}
+      {renderBack && BackButton()}
+      {renderNext && NextButton()}
+      {renderSubmit && SubmitButton()}
+    </div>
+  );
+};

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -1,0 +1,56 @@
+import { Grid, Paper } from '@mui/material';
+import { useState } from 'react';
+import { LoadingProgressIndicator } from 'shared/components';
+import { APIResponseStatus } from 'shared/enums';
+
+import { PublicEnrollmentControlButtons } from 'components/publicEnrollment/PublicEnrollmentControlButtons';
+import { PublicEnrollmentReservationDetails } from 'components/publicEnrollment/PublicEnrollmentReservationDetails';
+import { PublicEnrollmentStepContents } from 'components/publicEnrollment/PublicEnrollmentStepContents';
+import { PublicEnrollmentStepper } from 'components/publicEnrollment/PublicEnrollmentStepper';
+import { useAppSelector } from 'configs/redux';
+import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
+
+export const PublicEnrollmentGrid = () => {
+  const [disableNext, setDisableNext] = useState(true);
+
+  const disableNextCb = (disabled: boolean) => setDisableNext(disabled);
+
+  const { status, activeStep } = useAppSelector(publicEnrollmentSelector);
+  const isLoading = status === APIResponseStatus.InProgress;
+
+  const renderDesktopView = () => (
+    <>
+      <Grid className="public-enrollment__grid" item>
+        <Paper elevation={3}>
+          <LoadingProgressIndicator isLoading={isLoading}>
+            <div className="public-enrollment__grid__form-container">
+              <PublicEnrollmentStepper activeStep={activeStep} />
+              <PublicEnrollmentReservationDetails />
+              <PublicEnrollmentStepContents
+                activeStep={activeStep}
+                isLoading={isLoading}
+                disableNext={disableNextCb}
+              />
+              <PublicEnrollmentControlButtons
+                activeStep={activeStep}
+                isLoading={isLoading}
+                disableNext={disableNext}
+              />
+            </div>
+          </LoadingProgressIndicator>
+        </Paper>
+      </Grid>
+    </>
+  );
+
+  return (
+    <Grid
+      container
+      rowSpacing={4}
+      direction="column"
+      className="public-enrollment"
+    >
+      {renderDesktopView()}
+    </Grid>
+  );
+};

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentReservationDetails.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentReservationDetails.tsx
@@ -1,0 +1,48 @@
+import { H2, HeaderSeparator, Text } from 'shared/components';
+import { DateUtils } from 'shared/utils';
+
+import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
+import { useAppSelector } from 'configs/redux';
+import { ExamLevel } from 'enums/app';
+import { publicReservationSelector } from 'redux/selectors/publicReservation';
+import { ExamEventUtils } from 'utils/examEvent';
+
+export const PublicEnrollmentReservationDetails = () => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'vkt.component.publicEnrollment.reservationDetails',
+  });
+  const translateCommon = useCommonTranslation();
+
+  const { reservation } = useAppSelector(publicReservationSelector);
+  const examEvent = reservation?.examEvent;
+
+  if (!examEvent) {
+    return null;
+  }
+
+  return (
+    <div className="margin-top-xxl rows">
+      <div className="rows gapped-xs">
+        <H2>
+          {ExamEventUtils.languageAndLevelText(
+            examEvent.language,
+            ExamLevel.EXCELLENT,
+            translateCommon
+          )}
+        </H2>
+        <HeaderSeparator />
+      </div>
+      <div className="rows-gapped-xxs">
+        <Text>{`${t('examDate')}: ${DateUtils.formatOptionalDate(
+          examEvent.date
+        )}`}</Text>
+        <Text>{`${t('registrationCloses')}: ${DateUtils.formatOptionalDate(
+          examEvent.registrationCloses
+        )}`}</Text>
+        <Text>{`${t('openings')}: ${
+          examEvent.maxParticipants - examEvent.participants
+        }`}</Text>
+      </div>
+    </div>
+  );
+};

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
@@ -1,0 +1,29 @@
+import { FillContactDetails } from 'components/publicEnrollment/steps/FillContactDetails';
+import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
+
+export const PublicEnrollmentStepContents = ({
+  activeStep,
+  isLoading,
+  disableNext,
+}: {
+  activeStep: PublicEnrollmentFormStep;
+  isLoading: boolean;
+  disableNext: (disabled: boolean) => void;
+}) => {
+  switch (activeStep) {
+    case PublicEnrollmentFormStep.Identify:
+      return <></>;
+    case PublicEnrollmentFormStep.FillContactDetails:
+      return (
+        <FillContactDetails isLoading={isLoading} disableNext={disableNext} />
+      );
+    case PublicEnrollmentFormStep.SelectExam:
+      return <></>;
+    case PublicEnrollmentFormStep.Preview:
+      return <></>;
+    case PublicEnrollmentFormStep.Pay:
+      return <></>;
+    default:
+      return <> </>;
+  }
+};

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepper.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepper.tsx
@@ -1,0 +1,59 @@
+import { Step, StepLabel, Stepper } from '@mui/material';
+
+import { usePublicTranslation } from 'configs/i18n';
+import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
+
+export const PublicEnrollmentStepper = ({
+  activeStep,
+}: {
+  activeStep: PublicEnrollmentFormStep;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'vkt.component.publicEnrollment.stepper',
+  });
+
+  const getStepNumbers = Object.values(PublicEnrollmentFormStep)
+    .filter((i) => !isNaN(Number(i)))
+    .map(Number);
+
+  const getStatusText = (stepNumber: number) => {
+    if (stepNumber < activeStep) {
+      return t('completed');
+    } else if (stepNumber === activeStep) {
+      return t('active');
+    }
+  };
+
+  const getDescription = (stepNumber: number) =>
+    t(`step.${PublicEnrollmentFormStep[stepNumber]}`);
+
+  const getStepAriaLabel = (stepNumber: number) => {
+    const part = `${stepNumber}/${Math.max(...getStepNumbers)}`;
+    const statusText = getStatusText(stepNumber);
+    const partStatus = statusText ? `${part}, ${statusText}` : part;
+
+    return `${t('phase')} ${partStatus}: ${getDescription(stepNumber)}`;
+  };
+
+  return (
+    <Stepper
+      className="public-enrollment__grid__stepper"
+      activeStep={activeStep - 1}
+    >
+      {getStepNumbers.map((i) => (
+        <Step key={i}>
+          <StepLabel
+            aria-label={getStepAriaLabel(i)}
+            className={
+              activeStep < i
+                ? 'public-enrollment__grid__stepper__step-disabled'
+                : undefined
+            }
+          >
+            {getDescription(i)}
+          </StepLabel>
+        </Step>
+      ))}
+    </Stepper>
+  );
+};

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/FillContactDetails.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/FillContactDetails.tsx
@@ -1,0 +1,132 @@
+import { ChangeEvent, useEffect, useState } from 'react';
+import { CustomTextField, H3 } from 'shared/components';
+import { TextFieldTypes } from 'shared/enums';
+import { InputFieldUtils, StringUtils } from 'shared/utils';
+
+import { PersonDetails } from 'components/publicEnrollment/steps/PersonDetails';
+import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { PublicEnrollment } from 'interfaces/publicEnrollment';
+import { updatePublicEnrollment } from 'redux/reducers/publicEnrollment';
+import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
+
+export const FillContactDetails = ({
+  isLoading,
+  disableNext,
+}: {
+  isLoading: boolean;
+  disableNext: (disabled: boolean) => void;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'vkt.component.publicEnrollment.steps.fillContactDetails',
+  });
+  const translateCommon = useCommonTranslation();
+
+  const [fieldErrors, setFieldErrors] = useState({
+    email: '',
+    emailConfirmation: '',
+    phoneNumber: '',
+  });
+
+  const { enrollment } = useAppSelector(publicEnrollmentSelector);
+
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const hasFieldErrors = !!(fieldErrors.email || fieldErrors.phoneNumber);
+
+    const hasBlankFieldValues = [enrollment.email, enrollment.phoneNumber].some(
+      (v) => StringUtils.isBlankString(v)
+    );
+    const mismatchingEmails = enrollment.email !== enrollment.emailConfirmation;
+
+    disableNext(hasFieldErrors || hasBlankFieldValues || mismatchingEmails);
+  }, [fieldErrors, disableNext, enrollment]);
+
+  const handleChange =
+    (fieldName: keyof PublicEnrollment) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (fieldErrors[fieldName]) {
+        handleErrors(fieldName)(event);
+      }
+
+      dispatch(
+        updatePublicEnrollment({
+          [fieldName]: event.target.value,
+        })
+      );
+    };
+
+  const handleErrors =
+    (fieldName: keyof PublicEnrollment) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { type, value, required } = event.target;
+
+      const error = InputFieldUtils.inspectCustomTextFieldErrors(
+        type as TextFieldTypes,
+        value,
+        required
+      );
+
+      const fieldErrorMessage = error ? translateCommon(error) : '';
+
+      const emailConfirmationErrorMessage =
+        enrollment.emailConfirmation &&
+        enrollment.email !== enrollment.emailConfirmation
+          ? t('mismatchingEmailsError')
+          : '';
+
+      setFieldErrors({
+        ...fieldErrors,
+        [fieldName]: fieldErrorMessage,
+        ['emailConfirmation']: emailConfirmationErrorMessage,
+      });
+    };
+
+  const showCustomTextFieldError = (fieldName: keyof PublicEnrollment) => {
+    return fieldErrors[fieldName]?.length > 0;
+  };
+
+  const getCustomTextFieldAttributes = (fieldName: keyof PublicEnrollment) => ({
+    id: `public-enrollment__contact-details__${fieldName}-field`,
+    label: t(fieldName),
+    onBlur: handleErrors(fieldName),
+    onChange: handleChange(fieldName),
+    error: showCustomTextFieldError(fieldName),
+    helperText: fieldErrors[fieldName],
+    required: true,
+    disabled: isLoading,
+  });
+
+  return (
+    <div className="margin-top-xxl rows gapped">
+      <PersonDetails />
+      <div className="margin-top-sm rows gapped">
+        <H3>{t('title')}</H3>
+        <div className="grid-columns gapped">
+          <CustomTextField
+            {...getCustomTextFieldAttributes('email')}
+            type={TextFieldTypes.Email}
+            value={enrollment.email}
+          />
+          <CustomTextField
+            {...getCustomTextFieldAttributes('emailConfirmation')}
+            type={TextFieldTypes.Email}
+            value={enrollment.emailConfirmation}
+            onPaste={(e) => {
+              e.preventDefault();
+
+              return false;
+            }}
+          />
+        </div>
+      </div>
+      <CustomTextField
+        {...getCustomTextFieldAttributes('phoneNumber')}
+        className="phone-number"
+        value={enrollment.phoneNumber}
+        type={TextFieldTypes.PhoneNumber}
+      />
+    </div>
+  );
+};

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/PersonDetails.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/PersonDetails.tsx
@@ -1,0 +1,41 @@
+import { CustomTextField, H3 } from 'shared/components';
+
+import { usePublicTranslation } from 'configs/i18n';
+import { useAppSelector } from 'configs/redux';
+import { publicReservationSelector } from 'redux/selectors/publicReservation';
+
+export const PersonDetails = () => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'vkt.component.publicEnrollment.steps.personDetails',
+  });
+
+  const { reservation } = useAppSelector(publicReservationSelector);
+  const person = reservation?.person;
+
+  if (!person) {
+    return null;
+  }
+
+  return (
+    <div className="rows gapped">
+      <H3>{t('title')}</H3>
+      <div className="grid-columns gapped">
+        <CustomTextField
+          label={t('lastName')}
+          value={person.lastName}
+          disabled
+        />
+        <CustomTextField
+          label={t('firstName')}
+          value={person.firstName}
+          disabled
+        />
+        <CustomTextField
+          label={t('identityNumber')}
+          value={person.identityNumber}
+          disabled
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/packages/vkt/src/components/publicExamEvent/PublicExamEventGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/PublicExamEventGrid.tsx
@@ -14,7 +14,9 @@ import { publicExamEventsSelector } from 'redux/selectors/publicExamEvent';
 
 export const PublicExamEventGrid = () => {
   // I18
-  const { t } = usePublicTranslation({ keyPrefix: 'vkt.pages.homepage' });
+  const { t } = usePublicTranslation({
+    keyPrefix: 'vkt.component.publicExamEventGrid',
+  });
   const translateCommon = useCommonTranslation();
 
   // Redux

--- a/frontend/packages/vkt/src/components/publicExamEvent/listing/row/PublicExamEventCells.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/listing/row/PublicExamEventCells.tsx
@@ -1,5 +1,4 @@
 import { Checkbox, TableCell } from '@mui/material';
-import { Dayjs } from 'dayjs';
 import { H2, Text } from 'shared/components';
 import { Color } from 'shared/enums';
 import { DateUtils } from 'shared/utils';
@@ -67,8 +66,6 @@ export const PublicExamEventDesktopCells = ({
     return <Text>{`${maxParticipants - participants}`}</Text>;
   };
 
-  const formatDate = (date: Dayjs) => date.format('DD.MM.YYYY');
-
   return (
     <>
       <TableCell padding="checkbox">
@@ -91,10 +88,12 @@ export const PublicExamEventDesktopCells = ({
         </Text>
       </TableCell>
       <TableCell>
-        <Text>{formatDate(examEvent.date)}</Text>
+        <Text>{DateUtils.formatOptionalDate(examEvent.date)}</Text>
       </TableCell>
       <TableCell>
-        <Text>{formatDate(examEvent.registrationCloses)}</Text>
+        <Text>
+          {DateUtils.formatOptionalDate(examEvent.registrationCloses)}
+        </Text>
       </TableCell>
       <TableCell>{getOpeningsText()}</TableCell>
       <TableCell />

--- a/frontend/packages/vkt/src/enums/api.ts
+++ b/frontend/packages/vkt/src/enums/api.ts
@@ -1,5 +1,6 @@
 export enum APIEndpoints {
   PublicExamEvent = '/vkt/api/v1/examEvent',
+  PublicReservation = '/vkt/api/v1/examEvent/reservation',
   ClerkExamEvent = '/vkt/api/v1/clerk/examEvent',
   ClerkUser = '/vkt/api/v1/clerk/user',
 }

--- a/frontend/packages/vkt/src/enums/app.ts
+++ b/frontend/packages/vkt/src/enums/app.ts
@@ -13,8 +13,8 @@ export enum AppRoutes {
 }
 
 export enum PublicUIViews {
+  Enrollment = 'Enrollment',
   ExamEventListing = 'ExamEventListing',
-  Reservation = 'Reservation',
 }
 
 export enum ExamLanguage {

--- a/frontend/packages/vkt/src/enums/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/enums/publicEnrollment.ts
@@ -1,0 +1,7 @@
+export enum PublicEnrollmentFormStep {
+  Identify = 1,
+  FillContactDetails,
+  SelectExam,
+  Preview,
+  Pay,
+}

--- a/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
@@ -1,0 +1,5 @@
+export interface PublicEnrollment {
+  email: string;
+  emailConfirmation: string;
+  phoneNumber: string;
+}

--- a/frontend/packages/vkt/src/interfaces/publicReservation.ts
+++ b/frontend/packages/vkt/src/interfaces/publicReservation.ts
@@ -1,16 +1,20 @@
 import { Dayjs } from 'dayjs';
 
-import { PublicExamEvent } from 'interfaces/publicExamEvent';
+import {
+  PublicExamEvent,
+  PublicExamEventResponse,
+} from 'interfaces/publicExamEvent';
 import { PublicPerson } from 'interfaces/publicPerson';
 
 export interface PublicReservation
-  extends Omit<PublicReservationResponse, 'expiresAt'> {
+  extends Omit<PublicReservationResponse, 'expiresAt' | 'examEvent'> {
   expiresAt: Dayjs;
+  examEvent: PublicExamEvent;
 }
 
 export interface PublicReservationResponse {
   id: number;
   expiresAt: string;
-  examEvent: PublicExamEvent;
+  examEvent: PublicExamEventResponse;
   person: PublicPerson;
 }

--- a/frontend/packages/vkt/src/pages/PublicHomePage.tsx
+++ b/frontend/packages/vkt/src/pages/PublicHomePage.tsx
@@ -1,6 +1,7 @@
 import { Box, Grid } from '@mui/material';
 import { FC } from 'react';
 
+import { PublicEnrollmentGrid } from 'components/publicEnrollment/PublicEnrollmentGrid';
 import { PublicExamEventGrid } from 'components/publicExamEvent/PublicExamEventGrid';
 import { useAppSelector } from 'configs/redux';
 import { PublicUIViews } from 'enums/app';
@@ -17,7 +18,9 @@ export const PublicHomePage: FC = () => {
         direction="column"
         className="public-homepage__grid-container"
       >
-        {currentView === PublicUIViews.Reservation ? null : (
+        {currentView === PublicUIViews.Enrollment ? (
+          <PublicEnrollmentGrid />
+        ) : (
           <PublicExamEventGrid />
         )}
       </Grid>

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -1,0 +1,64 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { APIResponseStatus } from 'shared/enums';
+
+import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
+import { PublicEnrollment } from 'interfaces/publicEnrollment';
+
+interface PublicEnrollmentState {
+  status: APIResponseStatus;
+  activeStep: PublicEnrollmentFormStep;
+  enrollment: PublicEnrollment;
+}
+
+const initialState: PublicEnrollmentState = {
+  status: APIResponseStatus.NotStarted,
+  activeStep: PublicEnrollmentFormStep.FillContactDetails,
+  enrollment: {
+    email: '',
+    emailConfirmation: '',
+    phoneNumber: '',
+  },
+};
+
+const publicEnrollmentSlice = createSlice({
+  name: 'publicEnrollment',
+  initialState,
+  reducers: {
+    cancelPublicEnrollment(state) {
+      state.status = APIResponseStatus.InProgress;
+    },
+    cancelPublicEnrollmentAndRemoveReservation(
+      state,
+      _action: PayloadAction<number>
+    ) {
+      state.status = APIResponseStatus.InProgress;
+    },
+    decreaseActiveStep(state) {
+      state.activeStep = --state.activeStep;
+    },
+    increaseActiveStep(state) {
+      state.activeStep = ++state.activeStep;
+    },
+    resetPublicEnrollment(state) {
+      state.status = initialState.status;
+      state.activeStep = initialState.activeStep;
+      state.enrollment = initialState.enrollment;
+    },
+    updatePublicEnrollment(
+      state,
+      action: PayloadAction<Partial<PublicEnrollment>>
+    ) {
+      state.enrollment = { ...state.enrollment, ...action.payload };
+    },
+  },
+});
+
+export const publicEnrollmentReducer = publicEnrollmentSlice.reducer;
+export const {
+  cancelPublicEnrollment,
+  cancelPublicEnrollmentAndRemoveReservation,
+  decreaseActiveStep,
+  increaseActiveStep,
+  resetPublicEnrollment,
+  updatePublicEnrollment,
+} = publicEnrollmentSlice.actions;

--- a/frontend/packages/vkt/src/redux/reducers/publicReservation.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicReservation.ts
@@ -1,25 +1,16 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Dayjs } from 'dayjs';
 import { APIResponseStatus } from 'shared/enums';
 
-import { PublicExamEvent } from 'interfaces/publicExamEvent';
-import { PublicPerson } from 'interfaces/publicPerson';
 import { PublicReservation } from 'interfaces/publicReservation';
 
 interface PublicReservationState {
   status: APIResponseStatus;
-  id?: number;
-  expiresAt?: Dayjs;
-  examEvent?: PublicExamEvent;
-  person?: PublicPerson;
+  reservation?: PublicReservation;
 }
 
 const initialState: PublicReservationState = {
   status: APIResponseStatus.NotStarted,
-  id: undefined,
-  expiresAt: undefined,
-  examEvent: undefined,
-  person: undefined,
+  reservation: undefined,
 };
 
 const publicReservationSlice = createSlice({
@@ -34,10 +25,7 @@ const publicReservationSlice = createSlice({
     },
     storeReservation(state, action: PayloadAction<PublicReservation>) {
       state.status = APIResponseStatus.Success;
-      state.id = action.payload.id;
-      state.expiresAt = action.payload.expiresAt;
-      state.examEvent = action.payload.examEvent;
-      state.person = action.payload.person;
+      state.reservation = action.payload;
     },
   },
 });

--- a/frontend/packages/vkt/src/redux/sagas/index.ts
+++ b/frontend/packages/vkt/src/redux/sagas/index.ts
@@ -3,6 +3,7 @@ import { all } from 'redux-saga/effects';
 import { watchClerkExamEventOverview } from 'redux/sagas/clerkExamEventOverview';
 import { watchListExamEvents } from 'redux/sagas/clerkListExamEvent';
 import { watchClerkUser } from 'redux/sagas/clerkUser';
+import { watchPublicEnrollments } from 'redux/sagas/publicEnrollment';
 import { watchPublicExamEvents } from 'redux/sagas/publicExamEvent';
 import { watchPublicReservations } from 'redux/sagas/publicReservation';
 
@@ -10,6 +11,7 @@ export default function* rootSaga() {
   yield all([
     watchListExamEvents(),
     watchClerkUser(),
+    watchPublicEnrollments(),
     watchPublicExamEvents(),
     watchPublicReservations(),
     watchClerkExamEventOverview(),

--- a/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
@@ -1,0 +1,41 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import { call, put, takeLatest } from 'redux-saga/effects';
+
+import axiosInstance from 'configs/axios';
+import { APIEndpoints } from 'enums/api';
+import { PublicUIViews } from 'enums/app';
+import {
+  cancelPublicEnrollment,
+  cancelPublicEnrollmentAndRemoveReservation,
+  resetPublicEnrollment,
+} from 'redux/reducers/publicEnrollment';
+import { setPublicUIView } from 'redux/reducers/publicUIView';
+
+function* cancelPublicEnrollmentSaga() {
+  yield put(setPublicUIView(PublicUIViews.ExamEventListing));
+  yield put(resetPublicEnrollment());
+}
+
+function* cancelPublicEnrollmentAndRemoveReservationSaga(
+  action: PayloadAction<number>
+) {
+  try {
+    yield call(
+      axiosInstance.delete,
+      `${APIEndpoints.PublicReservation}/${action.payload}`
+    );
+  } catch (error) {
+    // If deletion of reservation fails, it will expire in 30 mins
+  } finally {
+    yield put(setPublicUIView(PublicUIViews.ExamEventListing));
+    yield put(resetPublicEnrollment());
+  }
+}
+
+export function* watchPublicEnrollments() {
+  yield takeLatest(cancelPublicEnrollment, cancelPublicEnrollmentSaga);
+  yield takeLatest(
+    cancelPublicEnrollmentAndRemoveReservation,
+    cancelPublicEnrollmentAndRemoveReservationSaga
+  );
+}

--- a/frontend/packages/vkt/src/redux/sagas/publicReservation.ts
+++ b/frontend/packages/vkt/src/redux/sagas/publicReservation.ts
@@ -28,7 +28,7 @@ function* loadReservationSaga(action: PayloadAction<number>) {
     );
 
     yield put(storeReservation(publicReservation));
-    yield put(setPublicUIView(PublicUIViews.Reservation));
+    yield put(setPublicUIView(PublicUIViews.Enrollment));
   } catch (error) {
     const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
     yield put(setAPIError(errorMessage));

--- a/frontend/packages/vkt/src/redux/selectors/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/selectors/publicEnrollment.ts
@@ -1,0 +1,4 @@
+import { RootState } from 'configs/redux';
+
+export const publicEnrollmentSelector = (state: RootState) =>
+  state.publicEnrollment;

--- a/frontend/packages/vkt/src/redux/selectors/publicReservation.ts
+++ b/frontend/packages/vkt/src/redux/selectors/publicReservation.ts
@@ -1,4 +1,4 @@
 import { RootState } from 'configs/redux';
 
 export const publicReservationSelector = (state: RootState) =>
-  state.publicReservationReducer;
+  state.publicReservation;

--- a/frontend/packages/vkt/src/redux/store/index.ts
+++ b/frontend/packages/vkt/src/redux/store/index.ts
@@ -5,6 +5,7 @@ import { APIErrorReducer } from 'redux/reducers/APIError';
 import { clerkExamEventOverviewReducer } from 'redux/reducers/clerkExamEventOverview';
 import { clerkListExamEventReducer } from 'redux/reducers/clerkListExamEvent';
 import { clerkUserReducer } from 'redux/reducers/clerkUser';
+import { publicEnrollmentReducer } from 'redux/reducers/publicEnrollment';
 import { publicExamEventReducer } from 'redux/reducers/publicExamEvent';
 import { publicReservationReducer } from 'redux/reducers/publicReservation';
 import { publicUIViewReducer } from 'redux/reducers/publicUIView';
@@ -17,8 +18,9 @@ const store = configureStore({
     APIError: APIErrorReducer,
     clerkListExamEvent: clerkListExamEventReducer,
     clerkUser: clerkUserReducer,
+    publicEnrollment: publicEnrollmentReducer,
     publicExamEvent: publicExamEventReducer,
-    publicReservationReducer: publicReservationReducer,
+    publicReservation: publicReservationReducer,
     publicUIView: publicUIViewReducer,
     clerkExamEventOverview: clerkExamEventOverviewReducer,
   },

--- a/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
+++ b/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
@@ -1,0 +1,27 @@
+.public-enrollment {
+  & &__grid {
+    &__form-container {
+      padding: 3rem;
+    }
+
+    &__stepper {
+      margin-left: 13rem;
+      margin-right: 13rem;
+
+      &__step-disabled {
+        span,
+        svg {
+          color: $color-grey-700;
+        }
+      }
+    }
+
+    .phone-number {
+      max-width: calc(50% - 1rem);
+
+      @include phone {
+        max-width: 100%;
+      }
+    }
+  }
+}

--- a/frontend/packages/vkt/src/styles/styles.scss
+++ b/frontend/packages/vkt/src/styles/styles.scss
@@ -10,6 +10,7 @@
 @import 'components/i18n/lang-selector';
 @import 'components/layouts/header';
 @import 'components/layouts/footer';
+@import 'components/publicEnrollment/public-enrollment';
 @import 'components/publicExamEvent/public-exam-event-listing';
 
 // Pages

--- a/frontend/packages/vkt/src/utils/serialization.ts
+++ b/frontend/packages/vkt/src/utils/serialization.ts
@@ -37,6 +37,9 @@ export class SerializationUtils {
     return {
       ...publicReservation,
       expiresAt: dayjs(publicReservation.expiresAt),
+      examEvent: SerializationUtils.deserializePublicExamEvent(
+        publicReservation.examEvent
+      ),
     };
   }
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2616,7 +2616,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.1":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -11169,13 +11169,6 @@ __metadata:
   version: 1.5.0
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.5.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.5.0%2Fb1a960e2047253c91cb0e7c89fbf8a99e0dd6f8b"
   checksum: 6cd82af9f0afdfbb9cf4fa62cdcbfbe9f126c86cc8fe490879172b6852e842143635d42473a5e71638652d9ebac5c295728fd8320294cf501f83ae78fa3898a7
-  languageName: node
-  linkType: hard
-
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.1":
-  version: 1.5.1
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.5.1::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.5.1%2F1d07fc4e8b2e496c010bdf851b69f8919870c16e"
-  checksum: 18f8da9a913a88f44a22ebdf20fe8acd56a577fc9270f7767e4748e0425968eb818e50d3b99242789e0d28b31a208e3676a333f40dbb7f1d997e67efd926d466
   languageName: node
   linkType: hard
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2616,7 +2616,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.1":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -11169,6 +11169,13 @@ __metadata:
   version: 1.5.0
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.5.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.5.0%2Fb1a960e2047253c91cb0e7c89fbf8a99e0dd6f8b"
   checksum: 6cd82af9f0afdfbb9cf4fa62cdcbfbe9f126c86cc8fe490879172b6852e842143635d42473a5e71638652d9ebac5c295728fd8320294cf501f83ae78fa3898a7
+  languageName: node
+  linkType: hard
+
+"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.1":
+  version: 1.5.1
+  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.5.1::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.5.1%2F1d07fc4e8b2e496c010bdf851b69f8919870c16e"
+  checksum: 18f8da9a913a88f44a22ebdf20fe8acd56a577fc9270f7767e4748e0425968eb818e50d3b99242789e0d28b31a208e3676a333f40dbb7f1d997e67efd926d466
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Ilmoittaudu-napin painamisen jälkeen käyttäjä siirretään Täytä yhteystietosi -sivulle, jossa pääsee tarkastelemaan tunnisteeseen liittyviä henkilötietojaan sekä täyttämään yhteystiedot (sähköpostiosoite, sähköpostiosoitevarmistus ja puh. nro.) jatkaakseen seuraavaan vaiheeseen. Stepperi, rekisteröinnin tiedot (pl. paikkavarauksen ajastin) sekä napit (Peruuta, Takaisin, Seuraava, Siirry maksamaan) ovat omina yleiskäyttöisinä komponentteinaan. Myös henkilötiedot ovat jo omassa komponentissaan ja niitä uusiokäytetään Esikatselu-sivulla.

## Huomautukset

Aika paljon koodia on siirretty AKR:stä copy pastena ja muokattu sitä sen jälkeen VKT:n tarpeisiin. Muita huomioita alla:

- Puhelinnumero kenttä vie parhaillaan koko rivin mitan vaikka pitäisi olla samankokoinen kuin sähköpostiosoitekenttä
- Vahvista sähköpostiosoite -kentän virheilmoitusta pyritty hieman kustomoimaan commitissa c5d66ee se halutaanko tehdä jotain about tuollaista vai ei jää nähtäväksi
- Kenttien väliset marginit toteutettu ehkä vähän kökösti
