### PR TITLE
Small changes

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>com.hubspot.maven.plugins</groupId>
         <artifactId>prettier-maven-plugin</artifactId>
-        <version>0.16</version>
+        <version>0.18</version>
         <configuration>
           <prettierJavaVersion>1.5.0</prettierJavaVersion>
           <ignoreConfigFile>true</ignoreConfigFile>

--- a/docs/shared_frontend.md
+++ b/docs/shared_frontend.md
@@ -35,7 +35,7 @@ In this project directory, you can run:
 
 ## How to install the package?
 
-1. Create an access token as instructed [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), and select ONLY `read:packages` as the scope
+1. Create an access token as instructed [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), and select ONLY `read:packages` as the scope (must create classic token, not fine grained).
 2. Add created token to your bash profile:
 
    ```sh


### PR DESCRIPTION
## Yhteenveto

- Shared ohjeeseen huomatus classic tokenin luonnista. Fine grained token ei vaikuttanu toimivan.
- Prettier maven plugari antoi virhettä väärästä CPU:sta. Varmaankin ko. versio ei toimi applen m1 prossulla. Ehkä. Versionosto näytti ainakin korjaavan virheen mutta en tiedä varmasti johtuiko siitä.

## Check-lista

- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] Testattu docker-compose:lla
