### PR TITLE
OPHOTRKEH-194: puuttuvat julkisen UI:n käännökset

### DIFF
--- a/frontend/packages/otr/public/i18n/en-GB/common.json
+++ b/frontend/packages/otr/public/i18n/en-GB/common.json
@@ -3,11 +3,12 @@
     "common": {
       "add": "Add",
       "addQualification": null,
-      "allRegions": null,
+      "allRegions": "Whole Finland",
       "appNameAbbreviation": "OTR",
+      "appTitle": "Register of legal interpreters | Finnish National Agency for Education",
       "back": "Back",
       "cancel": "Cancel",
-      "clerk": "Clerk",
+      "clerk": "Administrator",
       "contactEmail": "oikeustulkkirekisteri@oph.fi",
       "delete": "Delete",
       "edit": "Edit",
@@ -24,11 +25,11 @@
       },
       "no": "No",
       "ophLogo": "Logo of Finnish National Agency for Education",
-      "permissionToPublish": null,
+      "permissionToPublish": "May be published",
       "register": "Register",
       "rowsPerPageLabel": "Results per page",
       "save": "Save",
-      "searchResults": null,
+      "searchResults": "Search results",
       "yes": "Yes"
     }
   }

--- a/frontend/packages/otr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/otr/public/i18n/en-GB/translation.json
@@ -43,6 +43,7 @@
           "name": "Name",
           "languagePairs": "Language pairs",
           "permissionToPublish": "Permission to publish",
+          "title": "Search results",
           "valid": "Valid"
         }
       },
@@ -65,7 +66,7 @@
             "identityNumber": "Finnish personal identity code",
             "lastName": "Last name",
             "nickName": null,
-            "otherContactInfo": null,
+            "otherContactInfo": "Other contact detail",
             "phoneNumber": "Telephone number",
             "postalCode": "Postal code",
             "street": "Street address",
@@ -76,24 +77,25 @@
             "contactInformation": "Contact details",
             "extraInformation": "Additional information",
             "personalInformation": "Personal data",
-            "regions": null
-          }
+            "regions": "Operating area"
+          },
+          "individualisedInformation": null
         },
         "qualifications": {
           "actions": {
             "changePermissionToPublish": {
               "ariaLabel": "Change the permission to publish",
               "dialog": {
-                "description": "This will change the visibility of the language pair in the public register.",
+                "description": null,
                 "header": "Are you sure you want to change the permission to publish?"
               }
             },
             "removal": {
-              "ariaLabel": "Delete the language pair",
+              "ariaLabel": null,
               "dialog": {
                 "description": "This action cannot be undone!",
-                "confirmButton": "Delete the language pair",
-                "header": "Are you sure you want to delete the language pair?"
+                "confirmButton": null,
+                "header": null
               }
             }
           },
@@ -105,7 +107,7 @@
             "permissionToPublish": "Permission to publish",
             "startDate": "Start date"
           },
-          "header": "Language pairs",
+          "header": null,
           "noQualifications": "No qualifications meeting the selected criteria were found",
           "toasts": {
             "addingSucceeded": null,
@@ -119,6 +121,12 @@
         },
         "toasts": {
           "updated": "The information was saved"
+        }
+      },
+      "clerkNewInterpreterDetails": {
+        "title": {
+          "existingPerson": null,
+          "newPerson": null
         }
       },
       "footer": {
@@ -139,6 +147,9 @@
         "links": {
           "accessibility": {
             "text": "Accessibility statement (in Finnish)"
+          },
+          "contact": {
+            "title": "Feedback and development suggestions"
           },
           "otrHomepage": {
             "ariaLabel": "Register of legal interpreters (oph.fi), open in a new tab",
@@ -244,7 +255,7 @@
           },
           "ariaLabel": "Open additional information"
         },
-        "searchResultsInfo": null
+        "searchResultsInfo": "Click the results to view interpreters' contact information"
       },
       "table": {
         "pagination": {
@@ -256,6 +267,7 @@
       "api": {
         "generic": "The action failed, please try again later",
         "interpreterInvalidNickName": null,
+        "invalidVersion": "The action failed because you tried to modify outdated data. Please refresh the page and try again later if necessary.",
         "meetingDateCreateDuplicateDate": "Failed to add the meeting day because the selected date is already a meeting day",
         "meetingDateDeleteHasQualifications": null,
         "meetingDateUpdateDuplicateDate": "Failed to modify the meeting day failed because the selected date is already a meeting day",
@@ -323,8 +335,8 @@
       "meetingDatesPage": {
         "title": "Meeting days",
         "toasts": {
-          "addingSucceeded": null,
-          "removingSucceeded": null
+          "addingSucceeded": "Meeting date {{date}} added successfully",
+          "removingSucceeded": "Meeting date {{date}} deleted"
         }
       },
       "notFoundPage": {

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -255,7 +255,7 @@
           },
           "ariaLabel": "Avaa lisätiedot"
         },
-        "searchResultsInfo": "Klikkaa riviä näyttääksesi yhteystiedot"
+        "searchResultsInfo": "Klikkaa riviä nähdäksesi yhteystiedot"
       },
       "table": {
         "pagination": {

--- a/frontend/packages/otr/public/i18n/sv-SE/common.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/common.json
@@ -3,11 +3,12 @@
     "common": {
       "add": "Lägg till",
       "addQualification": null,
-      "allRegions": null,
+      "allRegions": "Hela Finland",
       "appNameAbbreviation": "OTR",
+      "appTitle": "Registret över rättstolkar | Utbildningsstyrelsen",
       "back": "Tillbaka",
       "cancel": "Avbryt",
-      "clerk": null,
+      "clerk": "Administratör",
       "contactEmail": "oikeustulkkirekisteri@oph.fi",
       "delete": "Ta bort",
       "edit": "Ändra",
@@ -24,11 +25,11 @@
       },
       "no": "Nej",
       "ophLogo": "Utbildningsstyrelsens logo",
-      "permissionToPublish": null,
+      "permissionToPublish": "Får publiceras",
       "register": "Register",
       "rowsPerPageLabel": "Resultat per sida",
       "save": "Spara",
-      "searchResults": null,
+      "searchResults": "Sökresultat",
       "yes": "Ja"
     }
   }

--- a/frontend/packages/otr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/translation.json
@@ -32,7 +32,7 @@
         "qualificationStatus": {
           "effective": null,
           "expiredDeduplicated": "Löpt ut",
-          "expiring": null
+          "expiring": "Löper ut"
         }
       },
       "clerkInterpreterListing": {
@@ -43,6 +43,7 @@
           "name": "Namn",
           "languagePairs": "Språkpar",
           "permissionToPublish": "Publiceringstillstånd",
+          "title": "Sökresultat",
           "valid": "I kraft"
         }
       },
@@ -65,7 +66,7 @@
             "identityNumber": "Personbeteckning",
             "lastName": "Efternamn",
             "nickName": null,
-            "otherContactInfo": null,
+            "otherContactInfo": "Annan kontaktinformation",
             "phoneNumber": "Telefonnummer",
             "postalCode": "Postnummer",
             "street": "Gatuadress",
@@ -76,24 +77,25 @@
             "contactInformation": "Kontaktuppgifter",
             "extraInformation": "Ytterligare information",
             "personalInformation": "Personuppgifter",
-            "regions": null
-          }
+            "regions": "Verksamhetsområde"
+          },
+          "individualisedInformation": null
         },
         "qualifications": {
           "actions": {
             "changePermissionToPublish": {
               "ariaLabel": "Ändra publiceringstillstånd",
               "dialog": {
-                "description": "Detta ändrar hur språkparet syns i det offentliga registret.",
+                "description": null,
                 "header": "Är du säker på att du vill byta publiceringstillstånd?"
               }
             },
             "removal": {
-              "ariaLabel": "Ta bort språkpar",
+              "ariaLabel": null,
               "dialog": {
                 "description": "Denna funktion kan inte ångras!",
-                "confirmButton": "Ta bort språkpar",
-                "header": "Är du säker på att du vill ta bort språkparet?"
+                "confirmButton": null,
+                "header": null
               }
             }
           },
@@ -105,7 +107,7 @@
             "permissionToPublish": "Publiceringstillstånd",
             "startDate": "Startdatum"
           },
-          "header": "Språkpar",
+          "header": null,
           "noQualifications": "Inga examina hittades för de valda kriterierna",
           "toasts": {
             "addingSucceeded": null,
@@ -119,6 +121,12 @@
         },
         "toasts": {
           "updated": "Uppgifterna sparades"
+        }
+      },
+      "clerkNewInterpreterDetails": {
+        "title": {
+          "existingPerson": null,
+          "newPerson": null
         }
       },
       "footer": {
@@ -139,6 +147,9 @@
         "links": {
           "accessibility": {
             "text": "Tillgänglighetsdirektiv"
+          },
+          "contact": {
+            "title": "Respons och utvecklingsidéer"
           },
           "otrHomepage": {
             "ariaLabel": "Registret över rättstolkar (oph.fi), öppna i en ny flik",
@@ -244,7 +255,7 @@
           },
           "ariaLabel": "Öppna tilläggsuppgifterna"
         },
-        "searchResultsInfo": null
+        "searchResultsInfo": "Klicka på raden för att se kontaktuppgifter"
       },
       "table": {
         "pagination": {
@@ -256,6 +267,7 @@
       "api": {
         "generic": "Funktionen misslyckades, försök på nytt senare",
         "interpreterInvalidNickName": null,
+        "invalidVersion": "Funktionen misslyckades därför att du försökte att ändra förlegad data. Uppdatera sidan och försöka vid behov igen.",
         "meetingDateCreateDuplicateDate": "Det gick inte lägga till mötesdagen eftersom det valda datumet redan är ett mötesdatum",
         "meetingDateDeleteHasQualifications": null,
         "meetingDateUpdateDuplicateDate": "Mötesdagen kunde inte redigeras eftersom det valda datumet redan är en mötesdag",
@@ -323,8 +335,8 @@
       "meetingDatesPage": {
         "title": "Mötesdagar",
         "toasts": {
-          "addingSucceeded": null,
-          "removingSucceeded": null
+          "addingSucceeded": "Mötedagen {{date}} har lagts till",
+          "removingSucceeded": "Mötedagen {{date}} har tagits bort"
         }
       },
       "notFoundPage": {


### PR DESCRIPTION
## Yhteenveto

Julkisen UI:n viimeiset puuttuvat käännökset lisätty Sharepointissa sijaitsevaan taulukkoon (https://knowit.sharepoint.com/sites/Proj-OPH-yki-otr-akt-vkt). Ko. taulukkoon oli jo aiemmin myös lisätty erinäisiä käännöksiä mm. virkailijan UI:hin kopioimalla näiden vastineita AKR:stä.

Taulukko tuli ladattua koneelle excel-taulukkona ja se muunnettua json-lokalisaatiotiedostoiksi `docs/otr.md` alla mainitulla tavalla.

Lokalisaatiotiedostoissa on yhä jonkin verran täydentämättömiä käännöksiä ruotsin ja englannin osalta, mutta nuo koskevat vain virkailijan UI:ta ja eivät estä tuotantoonmenoa ensi vuoden puolella.