### PR TITLE
VKT(Backend): Rethrow unmatched DataIntegrityViolationExceptions

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkExamEventService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkExamEventService.java
@@ -139,6 +139,7 @@ public class ClerkExamEventService {
       if (DataIntegrityViolationExceptionUtil.isExamEventLanguageLevelDateUniquenessException(ex)) {
         throw new APIException(APIExceptionType.EXAM_EVENT_DUPLICATE);
       }
+      throw ex;
     }
 
     auditService.logById(VktOperation.CREATE_EXAM_EVENT, examEvent.getId());
@@ -159,6 +160,7 @@ public class ClerkExamEventService {
       if (DataIntegrityViolationExceptionUtil.isExamEventLanguageLevelDateUniquenessException(ex)) {
         throw new APIException(APIExceptionType.EXAM_EVENT_DUPLICATE);
       }
+      throw ex;
     }
 
     auditService.logById(VktOperation.UPDATE_EXAM_EVENT, id);


### PR DESCRIPTION
## Yhteenveto
Heitetään poikkeus eteenpäin jota ei käsitelty.

## Check-lista

- [ ] Testattu docker-compose:lla
