### PR TITLE
VKT:Shared(Frontend): OPHVKTKEH-77 LoadingProgressIndicator not shrinking size of enrollment views

### DIFF
--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.5.2] - 2022-11-30
+
+### Fixed
+
+- LoadingProgressIndicator useable for block display
+
 ## [1.5.1] - 2022-11-16
 
 ### Fixed

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/components/LoadingProgressIndicator/LoadingProgressIndicator.scss
+++ b/frontend/packages/shared/src/components/LoadingProgressIndicator/LoadingProgressIndicator.scss
@@ -1,10 +1,18 @@
 .loading-progress-indicator {
-  display: inline-flex;
+  &__inline-flex {
+    display: inline-flex;
+  }
 
   &__container {
-    display: inline-flex;
-    position: relative;
-    width: 100%;
+    &__block {
+      position: relative;
+    }
+
+    &__inline-flex {
+      display: inline-flex;
+      position: relative;
+      width: 100%;
+    }
 
     &__spinner-box {
       left: 50%;

--- a/frontend/packages/shared/src/components/LoadingProgressIndicator/LoadingProgressIndicator.tsx
+++ b/frontend/packages/shared/src/components/LoadingProgressIndicator/LoadingProgressIndicator.tsx
@@ -5,14 +5,17 @@ import './LoadingProgressIndicator.scss';
 
 interface LoadingProgressIndicatorProps {
   isLoading: boolean;
+  displayBlock?: boolean;
 }
 
 export const LoadingProgressIndicator: FC<
   PropsWithChildren<LoadingProgressIndicatorProps>
-> = ({ isLoading, children }) => {
+> = ({ isLoading, displayBlock, children }) => {
+  const classSuffix = displayBlock ? '__block' : '__inline-flex';
+
   return (
-    <div className="loading-progress-indicator">
-      <div className="loading-progress-indicator__container">
+    <div className={`loading-progress-indicator${classSuffix}`}>
+      <div className={`loading-progress-indicator__container${classSuffix}`}>
         {children}
         <div className="loading-progress-indicator__container__spinner-box">
           {isLoading && (

--- a/frontend/packages/shared/src/components/LoadingProgressIndicator/__snapshots__/LoadingProgressIndicator.test.tsx.snap
+++ b/frontend/packages/shared/src/components/LoadingProgressIndicator/__snapshots__/LoadingProgressIndicator.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`LoadingProgressIndicator should render LoadingProgressIndicator correctly 1`] = `
 <div
-  className="loading-progress-indicator"
+  className="loading-progress-indicator__inline-flex"
 >
   <div
-    className="loading-progress-indicator__container"
+    className="loading-progress-indicator__container__inline-flex"
   >
     <div
       className="loading-progress-indicator__container__spinner-box"

--- a/frontend/packages/vkt/package.json
+++ b/frontend/packages/vkt/package.json
@@ -25,6 +25,6 @@
     "vkt:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.1"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.2"
   }
 }

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -22,7 +22,7 @@ export const PublicEnrollmentGrid = () => {
     <>
       <Grid className="public-enrollment__grid" item>
         <Paper elevation={3}>
-          <LoadingProgressIndicator isLoading={isLoading}>
+          <LoadingProgressIndicator isLoading={isLoading} displayBlock={true}>
             <div className="public-enrollment__grid__form-container">
               <PublicEnrollmentStepper activeStep={activeStep} />
               <PublicEnrollmentReservationDetails />

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2616,7 +2616,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.1":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.2":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -2626,7 +2626,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.vkt@workspace:packages/vkt"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.1"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Yhteenveto

LoadingProgressIndicatorin tyylityksissä pakotettu `display: inline-flex` johti siihen, että ko. elementin lisääminen ei mm. ilmoittautumisflown yhteyteen toimi suoraan fiksusti, kun display tulisi tässä tapauksessa periytyä parentilta / olla block. Muokattu elementtiä siten, että sitä voi hyödyntää myös tällaisiin tapauksiin.
