### PR TITLE
VKT(Backend): OPHVKTKEH-79 Upgrade to spring boot 2.7.6

### DIFF
--- a/backend/akr/src/main/java/fi/oph/akr/config/security/WebSecurityConfig.java
+++ b/backend/akr/src/main/java/fi/oph/akr/config/security/WebSecurityConfig.java
@@ -20,7 +20,6 @@ import org.springframework.security.cas.authentication.CasAuthenticationProvider
 import org.springframework.security.cas.web.CasAuthenticationEntryPoint;
 import org.springframework.security.cas.web.CasAuthenticationFilter;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -29,7 +28,6 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Profile("!dev")
 @Configuration
-@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -145,10 +143,10 @@ public class WebSecurityConfig {
 
   public static HttpSecurity commonConfig(final HttpSecurity http) throws Exception {
     return configCsrf(http)
-      .authorizeRequests()
+      .authorizeHttpRequests()
       .mvcMatchers("/api/v1/clerk/**", "/virkailija/**", "/virkailija")
       .hasRole(Constants.APP_ROLE)
-      .antMatchers("/", "/**")
+      .mvcMatchers("/", "/**")
       .permitAll()
       .anyRequest()
       .authenticated()

--- a/backend/akr/src/main/java/fi/oph/akr/config/security/WebSecurityConfigDev.java
+++ b/backend/akr/src/main/java/fi/oph/akr/config/security/WebSecurityConfigDev.java
@@ -53,8 +53,8 @@ public class WebSecurityConfigDev {
       LOG.warn("Web security is OFF");
       return WebSecurityConfig
         .configCsrf(http)
-        .authorizeRequests()
-        .antMatchers("/", "/**")
+        .authorizeHttpRequests()
+        .mvcMatchers("/", "/**")
         .permitAll()
         .anyRequest()
         .authenticated()

--- a/backend/otr/src/main/java/fi/oph/otr/config/security/WebSecurityConfig.java
+++ b/backend/otr/src/main/java/fi/oph/otr/config/security/WebSecurityConfig.java
@@ -20,7 +20,6 @@ import org.springframework.security.cas.authentication.CasAuthenticationProvider
 import org.springframework.security.cas.web.CasAuthenticationEntryPoint;
 import org.springframework.security.cas.web.CasAuthenticationFilter;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -29,7 +28,6 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Profile("!dev")
 @Configuration
-@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -145,10 +143,10 @@ public class WebSecurityConfig {
 
   public static HttpSecurity commonConfig(final HttpSecurity http) throws Exception {
     return configCsrf(http)
-      .authorizeRequests()
+      .authorizeHttpRequests()
       .mvcMatchers("/api/v1/clerk/**", "/virkailija/**", "/virkailija")
       .hasRole(Constants.APP_ROLE)
-      .antMatchers("/", "/**")
+      .mvcMatchers("/", "/**")
       .permitAll()
       .anyRequest()
       .authenticated()

--- a/backend/otr/src/main/java/fi/oph/otr/config/security/WebSecurityConfigDev.java
+++ b/backend/otr/src/main/java/fi/oph/otr/config/security/WebSecurityConfigDev.java
@@ -53,8 +53,8 @@ public class WebSecurityConfigDev {
       LOG.warn("Web security is OFF");
       return WebSecurityConfig
         .configCsrf(http)
-        .authorizeRequests()
-        .antMatchers("/", "/**")
+        .authorizeHttpRequests()
+        .mvcMatchers("/", "/**")
         .permitAll()
         .anyRequest()
         .authenticated()

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.6</version>
     <relativePath/>
   </parent>
   <!-- lookup parent from repository -->

--- a/backend/vkt/src/main/java/fi/oph/vkt/config/security/WebSecurityConfig.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/config/security/WebSecurityConfig.java
@@ -20,7 +20,6 @@ import org.springframework.security.cas.authentication.CasAuthenticationProvider
 import org.springframework.security.cas.web.CasAuthenticationEntryPoint;
 import org.springframework.security.cas.web.CasAuthenticationFilter;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -29,7 +28,6 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Profile("!dev")
 @Configuration
-@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -145,10 +143,10 @@ public class WebSecurityConfig {
 
   public static HttpSecurity commonConfig(final HttpSecurity http) throws Exception {
     return configCsrf(http)
-      .authorizeRequests()
+      .authorizeHttpRequests()
       .mvcMatchers("/api/v1/clerk/**", "/virkailija/**", "/virkailija")
       .hasRole(Constants.APP_ROLE)
-      .antMatchers("/", "/**")
+      .mvcMatchers("/", "/**")
       .permitAll()
       .anyRequest()
       .authenticated()

--- a/backend/vkt/src/main/java/fi/oph/vkt/config/security/WebSecurityConfigDev.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/config/security/WebSecurityConfigDev.java
@@ -53,8 +53,8 @@ public class WebSecurityConfigDev {
       LOG.warn("Web security is OFF");
       return WebSecurityConfig
         .configCsrf(http)
-        .authorizeRequests()
-        .antMatchers("/", "/**")
+        .authorizeHttpRequests()
+        .mvcMatchers("/", "/**")
         .permitAll()
         .anyRequest()
         .authenticated()


### PR DESCRIPTION
## Yhteenveto

Spring Boot päivitys tuoreimpaan 2.7.x versioon. Samalla muutettu WebSecurityConfig kutsuja niin että tuoreemmassa spring security:ssä deprekoituja metodeja ei kutsuta.

Jos tämä OK, niin jatkoksi samat muutokset OTR:ään ja AKR:ään.

## Check-lista

- [ ] Testattu docker-compose:lla
