### PR TITLE
OPHVKTKEH-78: maksamaan siirryttäessä luodaan toistaiseksi ilmoittautuminen ilman maksamista

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/api/PublicController.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/PublicController.java
@@ -1,20 +1,24 @@
 package fi.oph.vkt.api;
 
+import fi.oph.vkt.api.dto.PublicEnrollmentCreateDTO;
 import fi.oph.vkt.api.dto.PublicExamEventDTO;
 import fi.oph.vkt.api.dto.PublicReservationDTO;
 import fi.oph.vkt.model.Person;
 import fi.oph.vkt.model.type.ExamLevel;
+import fi.oph.vkt.service.PublicEnrollmentService;
 import fi.oph.vkt.service.PublicExamEventService;
 import fi.oph.vkt.service.PublicIdentificationService;
 import fi.oph.vkt.service.PublicReservationService;
 import java.util.List;
 import javax.annotation.Resource;
+import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +26,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(value = "/api/v1/examEvent", produces = MediaType.APPLICATION_JSON_VALUE)
 public class PublicController {
+
+  @Resource
+  private PublicEnrollmentService publicEnrollmentService;
 
   @Resource
   private PublicExamEventService publicExamEventService;
@@ -48,5 +55,14 @@ public class PublicController {
   @DeleteMapping(path = "/reservation/{reservationId:\\d+}")
   public void deleteReservation(@PathVariable final long reservationId) {
     publicReservationService.deleteReservation(reservationId);
+  }
+
+  @PostMapping(path = "/reservation/{reservationId:\\d+}/enrollment")
+  @ResponseStatus(HttpStatus.CREATED)
+  public void createEnrollment(
+    @RequestBody @Valid PublicEnrollmentCreateDTO dto,
+    @PathVariable final long reservationId
+  ) {
+    publicEnrollmentService.createEnrollment(dto, reservationId);
   }
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/PublicEnrollmentCreateDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/PublicEnrollmentCreateDTO.java
@@ -1,0 +1,26 @@
+package fi.oph.vkt.api.dto;
+
+import java.time.LocalDate;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+public record PublicEnrollmentCreateDTO(
+  @NonNull @NotNull Boolean oralSkill,
+  @NonNull @NotNull Boolean textualSkill,
+  @NonNull @NotNull Boolean understandingSkill,
+  @NonNull @NotNull Boolean speakingPartialExam,
+  @NonNull @NotNull Boolean speechComprehensionPartialExam,
+  @NonNull @NotNull Boolean writingPartialExam,
+  @NonNull @NotNull Boolean readingComprehensionPartialExam,
+  LocalDate previousEnrollmentDate,
+  @NonNull @NotNull Boolean digitalCertificateConsent,
+  @NonNull @NotBlank String email,
+  @NonNull @NotBlank String phoneNumber,
+  String street,
+  String postalCode,
+  String town,
+  String country
+) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentService.java
@@ -1,0 +1,48 @@
+package fi.oph.vkt.service;
+
+import fi.oph.vkt.api.dto.PublicEnrollmentCreateDTO;
+import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.model.Reservation;
+import fi.oph.vkt.model.type.EnrollmentStatus;
+import fi.oph.vkt.repository.EnrollmentRepository;
+import fi.oph.vkt.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PublicEnrollmentService {
+
+  private final EnrollmentRepository enrollmentRepository;
+  private final ReservationRepository reservationRepository;
+
+  @Transactional
+  public void createEnrollment(final PublicEnrollmentCreateDTO dto, final long reservationId) {
+    final Reservation reservation = reservationRepository.getReferenceById(reservationId);
+
+    final Enrollment enrollment = new Enrollment();
+    enrollment.setExamEvent(reservation.getExamEvent());
+    enrollment.setPerson(reservation.getPerson());
+    enrollment.setStatus(EnrollmentStatus.PAID);
+
+    enrollment.setOralSkill(dto.oralSkill());
+    enrollment.setTextualSkill(dto.textualSkill());
+    enrollment.setUnderstandingSkill(dto.understandingSkill());
+    enrollment.setSpeakingPartialExam(dto.speakingPartialExam());
+    enrollment.setSpeechComprehensionPartialExam(dto.speechComprehensionPartialExam());
+    enrollment.setWritingPartialExam(dto.writingPartialExam());
+    enrollment.setReadingComprehensionPartialExam(dto.readingComprehensionPartialExam());
+    enrollment.setPreviousEnrollmentDate(dto.previousEnrollmentDate());
+    enrollment.setDigitalCertificateConsent(dto.digitalCertificateConsent());
+    enrollment.setEmail(dto.email());
+    enrollment.setPhoneNumber(dto.phoneNumber());
+    enrollment.setStreet(!dto.digitalCertificateConsent() ? dto.street() : null);
+    enrollment.setPostalCode(!dto.digitalCertificateConsent() ? dto.postalCode() : null);
+    enrollment.setTown(!dto.digitalCertificateConsent() ? dto.town() : null);
+    enrollment.setCountry(!dto.digitalCertificateConsent() ? dto.country() : null);
+
+    enrollmentRepository.saveAndFlush(enrollment);
+    reservationRepository.deleteById(reservationId);
+  }
+}

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentServiceTest.java
@@ -46,8 +46,8 @@ public class PublicEnrollmentServiceTest {
     final PublicEnrollmentCreateDTO dto = createDTOBuilder().digitalCertificateConsent(true).build();
 
     publicEnrollmentService.createEnrollment(dto, reservation.getId());
-
     assertCreatedEnrollment(dto);
+
     assertEquals(0, reservationRepository.count());
   }
 
@@ -57,9 +57,7 @@ public class PublicEnrollmentServiceTest {
     final PublicEnrollmentCreateDTO dto = createDTOBuilder().digitalCertificateConsent(false).build();
 
     publicEnrollmentService.createEnrollment(dto, reservation.getId());
-
     assertCreatedEnrollment(dto);
-    assertEquals(0, reservationRepository.count());
   }
 
   private Reservation createReservation() {

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentServiceTest.java
@@ -1,0 +1,126 @@
+package fi.oph.vkt.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import fi.oph.vkt.Factory;
+import fi.oph.vkt.api.dto.PublicEnrollmentCreateDTO;
+import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Person;
+import fi.oph.vkt.model.Reservation;
+import fi.oph.vkt.repository.EnrollmentRepository;
+import fi.oph.vkt.repository.ReservationRepository;
+import java.time.LocalDate;
+import java.util.List;
+import javax.annotation.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WithMockUser
+@DataJpaTest
+public class PublicEnrollmentServiceTest {
+
+  @Resource
+  private EnrollmentRepository enrollmentRepository;
+
+  @Resource
+  private ReservationRepository reservationRepository;
+
+  @Resource
+  private TestEntityManager entityManager;
+
+  private PublicEnrollmentService publicEnrollmentService;
+
+  @BeforeEach
+  public void setup() {
+    publicEnrollmentService = new PublicEnrollmentService(enrollmentRepository, reservationRepository);
+  }
+
+  @Test
+  public void testCreateEnrollmentWithDigitalCertificateConsent() {
+    final Reservation reservation = createReservation();
+    final PublicEnrollmentCreateDTO dto = createDTOBuilder().digitalCertificateConsent(true).build();
+
+    publicEnrollmentService.createEnrollment(dto, reservation.getId());
+
+    assertCreatedEnrollment(dto);
+    assertEquals(0, reservationRepository.count());
+  }
+
+  @Test
+  public void testCreateEnrollmentWithoutDigitalCertificateConsent() {
+    final Reservation reservation = createReservation();
+    final PublicEnrollmentCreateDTO dto = createDTOBuilder().digitalCertificateConsent(false).build();
+
+    publicEnrollmentService.createEnrollment(dto, reservation.getId());
+
+    assertCreatedEnrollment(dto);
+    assertEquals(0, reservationRepository.count());
+  }
+
+  private Reservation createReservation() {
+    final ExamEvent examEvent = Factory.examEvent();
+    final Person person = Factory.person();
+    final Reservation reservation = Factory.reservation(examEvent, person);
+
+    entityManager.persist(examEvent);
+    entityManager.persist(person);
+    entityManager.persist(reservation);
+
+    return reservation;
+  }
+
+  private PublicEnrollmentCreateDTO.PublicEnrollmentCreateDTOBuilder createDTOBuilder() {
+    return PublicEnrollmentCreateDTO
+      .builder()
+      .oralSkill(true)
+      .textualSkill(false)
+      .understandingSkill(true)
+      .speakingPartialExam(true)
+      .speechComprehensionPartialExam(true)
+      .writingPartialExam(false)
+      .readingComprehensionPartialExam(false)
+      .previousEnrollmentDate(LocalDate.now().minusYears(1))
+      .email("test@tester")
+      .phoneNumber("+358000111")
+      .street("Katu 1")
+      .postalCode("00000")
+      .town("Kaupunki")
+      .country("Maa");
+  }
+
+  private void assertCreatedEnrollment(final PublicEnrollmentCreateDTO dto) {
+    final List<Enrollment> enrollments = enrollmentRepository.findAll();
+    assertEquals(1, enrollments.size());
+
+    final Enrollment enrollment = enrollments.get(0);
+    assertEquals(0L, enrollment.getVersion());
+    assertEquals(dto.oralSkill(), enrollment.isOralSkill());
+    assertEquals(dto.textualSkill(), enrollment.isTextualSkill());
+    assertEquals(dto.understandingSkill(), enrollment.isUnderstandingSkill());
+    assertEquals(dto.speakingPartialExam(), enrollment.isSpeakingPartialExam());
+    assertEquals(dto.speechComprehensionPartialExam(), enrollment.isSpeechComprehensionPartialExam());
+    assertEquals(dto.writingPartialExam(), enrollment.isWritingPartialExam());
+    assertEquals(dto.readingComprehensionPartialExam(), enrollment.isReadingComprehensionPartialExam());
+    assertEquals(dto.previousEnrollmentDate(), enrollment.getPreviousEnrollmentDate());
+    assertEquals(dto.digitalCertificateConsent(), enrollment.isDigitalCertificateConsent());
+    assertEquals(dto.email(), enrollment.getEmail());
+    assertEquals(dto.phoneNumber(), enrollment.getPhoneNumber());
+
+    if (dto.digitalCertificateConsent()) {
+      assertNull(enrollment.getStreet());
+      assertNull(enrollment.getPostalCode());
+      assertNull(enrollment.getTown());
+      assertNull(enrollment.getCountry());
+    } else {
+      assertEquals(dto.street(), enrollment.getStreet());
+      assertEquals(dto.postalCode(), enrollment.getPostalCode());
+      assertEquals(dto.town(), enrollment.getTown());
+      assertEquals(dto.country(), enrollment.getCountry());
+    }
+  }
+}

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
@@ -9,20 +9,24 @@ import { useDialog } from 'shared/hooks';
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
+import { PublicEnrollment } from 'interfaces/publicEnrollment';
 import {
   cancelPublicEnrollment,
   cancelPublicEnrollmentAndRemoveReservation,
   decreaseActiveStep,
   increaseActiveStep,
+  loadPublicEnrollmentSave,
 } from 'redux/reducers/publicEnrollment';
 import { publicReservationSelector } from 'redux/selectors/publicReservation';
 
 export const PublicEnrollmentControlButtons = ({
   activeStep,
+  enrollment,
   isLoading,
   disableNext,
 }: {
   activeStep: PublicEnrollmentFormStep;
+  enrollment: PublicEnrollment;
   isLoading: boolean;
   disableNext: boolean;
 }) => {
@@ -68,6 +72,17 @@ export const PublicEnrollmentControlButtons = ({
 
   const handleNextBtnClick = () => {
     dispatch(increaseActiveStep());
+  };
+
+  const handleSubmitBtnClick = () => {
+    if (reservation) {
+      dispatch(
+        loadPublicEnrollmentSave({
+          ...enrollment,
+          reservationId: reservation.id,
+        })
+      );
+    }
   };
 
   const CancelButton = () => (
@@ -116,6 +131,7 @@ export const PublicEnrollmentControlButtons = ({
     <CustomButton
       variant={Variant.Contained}
       color={Color.Secondary}
+      onClick={handleSubmitBtnClick}
       data-testid="public-enrollment__controlButtons__submit"
       endIcon={<ArrowForwardIcon />}
       disabled={disableNext || isLoading}

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -41,6 +41,7 @@ export const PublicEnrollmentGrid = () => {
               />
               <PublicEnrollmentControlButtons
                 activeStep={activeStep}
+                enrollment={enrollment}
                 isLoading={isLoading}
                 disableNext={disableNext}
               />

--- a/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
@@ -27,4 +27,5 @@ export interface PublicEnrollment
     PublicEnrollmentAddress {
   digitalCertificateConsent: boolean;
   privacyStatementConfirmation: boolean;
+  reservationId?: number;
 }

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -63,6 +63,15 @@ const publicEnrollmentSlice = createSlice({
     ) {
       state.enrollment = { ...state.enrollment, ...action.payload };
     },
+    loadPublicEnrollmentSave(state, _action: PayloadAction<PublicEnrollment>) {
+      state.status = APIResponseStatus.InProgress;
+    },
+    rejectPublicEnrollmentSave(state) {
+      state.status = APIResponseStatus.Error;
+    },
+    storePublicEnrollmentSave(state) {
+      state.status = APIResponseStatus.Success;
+    },
   },
 });
 
@@ -74,4 +83,7 @@ export const {
   increaseActiveStep,
   resetPublicEnrollment,
   updatePublicEnrollment,
+  loadPublicEnrollmentSave,
+  rejectPublicEnrollmentSave,
+  storePublicEnrollmentSave,
 } = publicEnrollmentSlice.actions;


### PR DESCRIPTION
## Yhteenveto

Kun ilmoittautumisen esikatselunäkymässä klikkaa "Siirry maksamaan", luodaan toistaiseksi ilmoittautuminen suoraan. Ilmoittautuminen tallentuu tietokantaan, mutta frontendissä ei tehdä vielä onnistuneen ilmoittautumisen luonnin jälkeen mitään / näytetä onnistuneen ilmoittautumisen näkymää.

Onnistuneen ilmoittautumisen näkymä toteutettu tämän päälle omana PR:ään: https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/357
