### PR TITLE
VKT(Frontend): OPHVKTKEH-54 public enrollment complete view

### DIFF
--- a/frontend/packages/vkt/public/i18n/fi-FI/common.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/common.json
@@ -41,6 +41,7 @@
       "examLevel": {
         "EXCELLENT": "Erinomainen"
       },
+      "frontPage": "Etusivu",
       "header": {
         "accessibility": {
           "continueToMain": "Jatka sisältöön",

--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -32,6 +32,14 @@
         }
       },
       "publicEnrollment": {
+        "complete": {
+          "description": {
+            "part1": "Sinulle lähetetään vahvistus osoitteeseen",
+            "part2": "Tämä sivu ohjaa sinut automaattisesti takaisin etusivulle. Jos mitään ei tapahdu voit klikata alla olevasta napista."
+          },
+          "successToast": "Ilmoittautuminen onnistui!",
+          "title": "Maksu on suoritettu."
+        },
         "controlButtons": {
           "cancelDialog": {
             "description": "Haluatko peruuttaa ilmoittautumisen? Menetät täyttämäsi tiedot.",

--- a/frontend/packages/vkt/src/components/layouts/Footer.tsx
+++ b/frontend/packages/vkt/src/components/layouts/Footer.tsx
@@ -28,7 +28,9 @@ export const Footer = () => {
   const { isAuthenticated } = useAuthentication();
   const { currentView } = useAppSelector(publicUIViewSelector);
   const showFooter =
-    !isAuthenticated && currentView !== PublicUIViews.Enrollment;
+    !isAuthenticated &&
+    currentView !== PublicUIViews.Enrollment &&
+    currentView !== PublicUIViews.EnrollmentComplete;
 
   return (
     <footer>

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentComplete.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentComplete.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useEffect } from 'react';
+import { CustomButton, H2, Text } from 'shared/components';
+import { Duration, Severity } from 'shared/enums';
+import { useToast } from 'shared/hooks';
+
+import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { PublicUIViews } from 'enums/app';
+import { resetPublicEnrollment } from 'redux/reducers/publicEnrollment';
+import { resetPublicExamEventSelections } from 'redux/reducers/publicExamEvent';
+import { setPublicUIView } from 'redux/reducers/publicUIView';
+import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
+
+export const PublicEnrollmentComplete = () => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'vkt.component.publicEnrollment.complete',
+  });
+  const translateCommon = useCommonTranslation();
+
+  const {
+    enrollment: { email },
+  } = useAppSelector(publicEnrollmentSelector);
+
+  const dispatch = useAppDispatch();
+  const { showToast } = useToast();
+
+  const resetAndRedirect = useCallback(() => {
+    dispatch(resetPublicExamEventSelections());
+    dispatch(setPublicUIView(PublicUIViews.ExamEventListing));
+    dispatch(resetPublicEnrollment());
+  }, [dispatch]);
+
+  useEffect(() => {
+    showToast({
+      severity: Severity.Success,
+      description: t('successToast'),
+    });
+
+    const timer = setTimeout(() => {
+      resetAndRedirect();
+    }, Duration.MediumExtra);
+
+    return () => clearTimeout(timer);
+  }, [t, showToast, resetAndRedirect]);
+
+  return (
+    <div className="rows gapped">
+      <H2>{t('title')}</H2>
+      <Text>
+        <strong>{`${t('description.part1')}: ${email}`}</strong>
+      </Text>
+      <Text>{t('description.part2')}</Text>
+      <CustomButton
+        className="align-self-start margin-top-lg"
+        color="secondary"
+        variant="contained"
+        onClick={resetAndRedirect}
+      >
+        {translateCommon('frontPage')}
+      </CustomButton>
+    </div>
+  );
+};

--- a/frontend/packages/vkt/src/enums/app.ts
+++ b/frontend/packages/vkt/src/enums/app.ts
@@ -14,6 +14,7 @@ export enum AppRoutes {
 
 export enum PublicUIViews {
   Enrollment = 'Enrollment',
+  EnrollmentComplete = 'EnrollmentComplete',
   ExamEventListing = 'ExamEventListing',
 }
 

--- a/frontend/packages/vkt/src/pages/PublicHomePage.tsx
+++ b/frontend/packages/vkt/src/pages/PublicHomePage.tsx
@@ -1,6 +1,7 @@
 import { Box, Grid } from '@mui/material';
 import { FC } from 'react';
 
+import { PublicEnrollmentComplete } from 'components/publicEnrollment/PublicEnrollmentComplete';
 import { PublicEnrollmentGrid } from 'components/publicEnrollment/PublicEnrollmentGrid';
 import { PublicExamEventGrid } from 'components/publicExamEvent/PublicExamEventGrid';
 import { useAppSelector } from 'configs/redux';
@@ -10,6 +11,16 @@ import { publicUIViewSelector } from 'redux/selectors/publicUIView';
 export const PublicHomePage: FC = () => {
   const { currentView } = useAppSelector(publicUIViewSelector);
 
+  const renderView = () => {
+    if (currentView === PublicUIViews.Enrollment) {
+      return <PublicEnrollmentGrid />;
+    } else if (currentView === PublicUIViews.EnrollmentComplete) {
+      return <PublicEnrollmentComplete />;
+    }
+
+    return <PublicExamEventGrid />;
+  };
+
   return (
     <Box className="public-homepage">
       <Grid
@@ -18,11 +29,7 @@ export const PublicHomePage: FC = () => {
         direction="column"
         className="public-homepage__grid-container"
       >
-        {currentView === PublicUIViews.Enrollment ? (
-          <PublicEnrollmentGrid />
-        ) : (
-          <PublicExamEventGrid />
-        )}
+        {renderView()}
       </Grid>
     </Box>
   );

--- a/frontend/packages/vkt/src/redux/reducers/publicExamEvent.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicExamEvent.ts
@@ -28,6 +28,10 @@ const publicExamEventSlice = createSlice({
     rejectPublicExamEvents(state) {
       state.status = APIResponseStatus.Error;
     },
+    resetPublicExamEventSelections(state) {
+      state.selectedExamEvent = initialState.selectedExamEvent;
+      state.languageFilter = initialState.languageFilter;
+    },
     storePublicExamEvents(
       state,
       action: PayloadAction<Array<PublicExamEvent>>
@@ -58,6 +62,7 @@ export const publicExamEventReducer = publicExamEventSlice.reducer;
 export const {
   loadPublicExamEvents,
   rejectPublicExamEvents,
+  resetPublicExamEventSelections,
   storePublicExamEvents,
   setPublicExamEventLanguageFilter,
   setSelectedPublicExamEvent,

--- a/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
@@ -59,6 +59,7 @@ function* loadPublicEnrollmentSaveSaga(
       `${APIEndpoints.PublicReservation}/${reservationId}/enrollment`,
       body
     );
+    yield put(setPublicUIView(PublicUIViews.EnrollmentComplete));
     yield put(storePublicEnrollmentSave());
   } catch (error) {
     const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);


### PR DESCRIPTION
## Yhteenveto

Onnistuneen maksun / toistaiseksi ilmoittautumisen luonnin jälkeen näytetään `Maksu on suoritettu` näkymä, josta automaattinen uudelleenohjaus etusivulle samalla lailla kuin AKR:ssä yhteydenottopyynnön jättämisen jälkeen. Koska täällä ei käytössä stepperiä tms. ilmoittautumisessa hyödynnettyjä komponentteja tehty tämä omaksi PublicUIViewikseen.

## Check-lista
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
