### PR TITLE
VKT(Backend): OPHVKTKEH-100 Receipt PDF generation

### DIFF
--- a/.github/workflows/common-backend.yml
+++ b/.github/workflows/common-backend.yml
@@ -36,6 +36,14 @@ jobs:
       - uses: szenius/set-timezone@v1.1
         with:
           timezoneLinux: "Europe/Helsinki"
+      - name: Install wkhtmltopdf
+        run: |
+          echo 'Installing wkhtmltopdf'
+          sudo apt-get install wkhtmltopdf
+          echo 'Installed wkhtmltopdf, check that it works'
+          wkhtmltopdf --version
+          echo 'Installation of wkhtmltopdf completed'
+        shell: bash
       - name: Build with Maven
         working-directory: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}
         run: mvn clean install -Dplugin.prettier.goal=check

--- a/.github/workflows/common-backend.yml
+++ b/.github/workflows/common-backend.yml
@@ -7,6 +7,11 @@ on:
         description: "Application name"
         required: true
         type: string
+      with-wkhtmltopdf:
+        description: "Should wkhtmltopdf be installed or not"
+        required: true
+        type: boolean
+        default: false
 
 env:
   BACKEND_DIR: ./backend
@@ -37,7 +42,10 @@ jobs:
         with:
           timezoneLinux: "Europe/Helsinki"
       - name: Install wkhtmltopdf
+        if: inputs.with-wkhtmltopdf
         run: |
+          echo 'Updating apt-get package information'
+          sudo apt-get update
           echo 'Installing wkhtmltopdf'
           sudo apt-get install wkhtmltopdf
           echo 'Installed wkhtmltopdf, check that it works'

--- a/.github/workflows/common-deploy.yml
+++ b/.github/workflows/common-deploy.yml
@@ -11,6 +11,11 @@ on:
         description: "Image name in ECR"
         required: true
         type: string
+      with-wkhtmltopdf:
+        description: "Should wkhtmltopdf be available in container"
+        required: true
+        type: boolean
+        default: false
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -35,7 +40,26 @@ jobs:
           path: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}/target/${{ inputs.app-name }}-*.jar
           key: ${{ runner.os }}-${{ inputs.app-name }}-backend-build-${{ github.sha }}
       - name: Build Docker container
+        if: ${{ !inputs.with-wkhtmltopdf }}
         working-directory: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          git clone https://github.com/Opetushallitus/ci-tools.git
+          source ci-tools/common/setup-tools.sh
+          export ARTIFACT_NAME=${{ inputs.image-name }}
+          mv target/${{ inputs.app-name }}-*.jar $DOCKER_BUILD_DIR/artifact/${ARTIFACT_NAME}.jar
+          cp -vr src/main/resources/oph-configuration $DOCKER_BUILD_DIR/config/
+          export BASE_IMAGE="baseimage-fatjar-openjdk17:master"
+          ./ci-tools/common/pull-image.sh
+          ./ci-tools/github-build/build-fatjar.sh $ARTIFACT_NAME
+          ./ci-tools/github-build/upload-image.sh $ARTIFACT_NAME
+          ./ci-tools/common/clean-docker-build-dir.sh
+      - name: Build Docker container with wkhtmltopdf
+        working-directory: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}
+        if: inputs.with-wkhtmltopdf
         shell: bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/common-deploy.yml
+++ b/.github/workflows/common-deploy.yml
@@ -41,7 +41,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          git clone https://github.com/Opetushallitus/ci-tools.git
+          git clone -b wkhtmltopdfDockerfile https://github.com/Opetushallitus/ci-tools.git
+          cat ./ci-tools/build/Dockerfile_wkhtmltopdf_template > ./ci-tools/build/Dockerfile
           source ci-tools/common/setup-tools.sh
           export ARTIFACT_NAME=${{ inputs.image-name }}
           mv target/${{ inputs.app-name }}-*.jar $DOCKER_BUILD_DIR/artifact/${ARTIFACT_NAME}.jar

--- a/.github/workflows/vkt.yml
+++ b/.github/workflows/vkt.yml
@@ -26,12 +26,14 @@ jobs:
     uses: ./.github/workflows/common-backend.yml
     with:
       app-name: "vkt"
+      with-wkhtmltopdf: true
   deploy:
     needs: backend
     uses: ./.github/workflows/common-deploy.yml
     with:
       app-name: "vkt"
       image-name: "vkt"
+      with-wkhtmltopdf: true
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/backend/Dockerfile.vkt
+++ b/backend/Dockerfile.vkt
@@ -1,5 +1,8 @@
 FROM eclipse-temurin:17-jdk
 
+RUN apt-get update && apt-get install -y \
+     wkhtmltopdf
+
 WORKDIR /app
 
 ADD ./pom.xml .

--- a/backend/vkt/pom.xml
+++ b/backend/vkt/pom.xml
@@ -18,4 +18,12 @@
   <name>vkt</name>
   <description>Valtionhallinnon kielitutkinnot</description>
 
+  <dependencies>
+    <dependency>
+      <groupId>com.github.jhonnymertz</groupId>
+      <artifactId>java-wkhtmltopdf-wrapper</artifactId>
+      <version>1.1.14-RELEASE</version>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptData.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptData.java
@@ -1,0 +1,13 @@
+package fi.oph.vkt.service.receipt;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+public record ReceiptData(
+  @NonNull String dateOfReceipt,
+  @NonNull String payerName,
+  @NonNull String paymentDate,
+  @NonNull String totalAmount,
+  @NonNull ReceiptItem item
+) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptItem.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptItem.java
@@ -1,0 +1,8 @@
+package fi.oph.vkt.service.receipt;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+public record ReceiptItem(@NonNull String name, @NonNull String value, @NonNull List<String> additionalInfos) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
@@ -1,0 +1,88 @@
+package fi.oph.vkt.service.receipt;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.jhonnymertz.wkhtmltopdf.wrapper.Pdf;
+import com.github.jhonnymertz.wkhtmltopdf.wrapper.configurations.WrapperConfig;
+import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.repository.EnrollmentRepository;
+import fi.oph.vkt.util.EnrollmentUtil;
+import fi.oph.vkt.util.TemplateRenderer;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ReceiptRenderer {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+  public static final TypeReference<Map<String, Object>> TYPE_REF = new TypeReference<>() {};
+  private final TemplateRenderer templateRenderer;
+  private final EnrollmentRepository enrollmentRepository;
+
+  @Transactional(readOnly = true)
+  public ReceiptData getReceiptData(final long enrollmentId) {
+    final Enrollment enrollment = enrollmentRepository.getReferenceById(enrollmentId);
+    final String personName = enrollment.getPerson().getLastName() + ", " + enrollment.getPerson().getFirstName();
+    final String dateOfReceipt = DATE_FORMAT.format(LocalDate.now());
+    // TODO Payment date should be taken from actual payment
+    final String paymentDate = "24.12.1987";
+    // TODO Paid amount should be taken from actual payment
+    final String totalAmount = String.format("%d €", EnrollmentUtil.calculateExaminationPaymentSum(enrollment));
+
+    final String additionalInfo1 = String.format(
+      "%s, %s, %s",
+      getLang(enrollment),
+      getLevel(enrollment),
+      DATE_FORMAT.format(enrollment.getExamEvent().getDate())
+    );
+    final String additionalInfo2 = "Osallistuja: " + personName;
+    return ReceiptData
+      .builder()
+      .dateOfReceipt(dateOfReceipt)
+      .payerName(personName)
+      .paymentDate(paymentDate)
+      .totalAmount(totalAmount)
+      .item(
+        ReceiptItem
+          .builder()
+          .name("Valtionhallinnon kielitutkinnot (VKT) tutkintomaksu")
+          .value(totalAmount)
+          .additionalInfos(List.of(additionalInfo1, additionalInfo2))
+          .build()
+      )
+      .build();
+  }
+
+  private static String getLang(final Enrollment enrollment) {
+    return switch (enrollment.getExamEvent().getLanguage()) {
+      case FI -> "Suomi";
+      case SV -> "Ruotsi";
+    };
+  }
+
+  private static String getLevel(final Enrollment enrollment) {
+    return switch (enrollment.getExamEvent().getLevel()) {
+      case EXCELLENT -> "Erinomainen";
+    };
+  }
+
+  public byte[] getReceiptPdfBytes(final ReceiptData data) throws IOException, InterruptedException {
+    final String html = getReceiptHtml(data);
+    final Pdf pdf = new Pdf(new WrapperConfig("wkhtmltopdf"));
+    pdf.addPageFromString(html);
+    return pdf.getPDF();
+  }
+
+  protected String getReceiptHtml(final ReceiptData data) {
+    final Map<String, Object> params = OBJECT_MAPPER.convertValue(data, TYPE_REF);
+    return templateRenderer.renderReceipt(params);
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/EnrollmentUtil.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/EnrollmentUtil.java
@@ -1,0 +1,15 @@
+package fi.oph.vkt.util;
+
+import fi.oph.vkt.model.Enrollment;
+
+public class EnrollmentUtil {
+
+  public static int calculateExaminationPaymentSum(final Enrollment enrollment) {
+    final int baseValue = 227;
+    final int count =
+      (enrollment.isOralSkill() ? 1 : 0) +
+      (enrollment.isTextualSkill() ? 1 : 0) +
+      (enrollment.isUnderstandingSkill() ? 1 : 0);
+    return baseValue * Math.min(count, 2);
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/TemplateRenderer.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/TemplateRenderer.java
@@ -12,8 +12,8 @@ public class TemplateRenderer {
 
   private final TemplateEngine templateEngine;
 
-  public String renderExample(final Map<String, Object> params) {
-    return renderTemplate("example", params);
+  public String renderReceipt(final Map<String, Object> params) {
+    return renderTemplate("receipt", params);
   }
 
   private String renderTemplate(final String template, final Map<String, Object> params) {

--- a/backend/vkt/src/main/resources/email-templates/example.html
+++ b/backend/vkt/src/main/resources/email-templates/example.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html lang="fi">
-    <body>
-        <p>
-            This is a placeholder [[${key}]], just for an example.
-        </p>
-    </body>
-</html>

--- a/backend/vkt/src/main/resources/email-templates/receipt.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt.html
@@ -95,7 +95,7 @@
 
 <div style="font-size: 14px;">
     <p>Hinnat ALV 0%</p>
-    <p>Valtionhallinnon kielitutkinnon tutkintomaksut ovat opetus- ja kulttuuriministeriön asetuksella Opetushallituksen suoritteiden maksullisuudesta (xxxx/202x) määrättyjä maksuja, joista ei peritä arvonlisäveroa.</p>
+    <p>Valtionhallinnon kielitutkinnon tutkintomaksut ovat opetus- ja kulttuuriministeriön asetuksella Opetushallituksen suoritteiden maksullisuudesta (1223/2022) määrättyjä maksuja, joista ei peritä arvonlisäveroa.</p>
 </div>
 
 <table class="footer">

--- a/backend/vkt/src/main/resources/email-templates/receipt.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="fi">
+<head>
+    <meta charset="UTF-8"/>
+    <style>
+        body {
+            margin: 30px;
+        }
+
+        .header {
+            width: 100%;
+            color: #808080;
+            border-bottom: 1px solid #d3d3d3;
+        }
+
+        .footer {
+            width: 100%;
+            color: #808080;
+            border-top: 1px solid #d3d3d3;
+            margin-top: 200px;
+        }
+
+        .hf_center {
+            text-align: center;
+        }
+
+        .hf_right {
+            text-align: right;
+        }
+
+        .cell {
+            padding: 5px;
+            border-style: solid;
+            border-color: #d3d3d3;
+        }
+    </style>
+</head>
+<body>
+
+<table class="header">
+    <tr>
+        <td>
+            <svg width="51" height="50" fill="none"
+                 xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" clip-rule="evenodd"
+                      d="M14.474 14.389c1.267-2.56 2.742-5.014 4.024-7.15 2.679-4.46 4.518-7.522 1.873-7.218-2.224.283-4.382.95-6.38 1.971A22.745 22.745 0 0 1 16.776.851S8.657 4.2 5.625 13.765a24.817 24.817 0 0 1 4.017-3.146c3.941-2.504 3.228-.611 1.658 3.558-1.113 2.955-2.657 7.053-3.28 11.541 1.067-1.377 2.35-3.355 3.797-5.585.392-.605.796-1.227 1.211-1.861.356-1.34.84-2.643 1.446-3.89v.007zm21.237-1.103c-1.57-.45-3.202.467-4.846 2.227a88.322 88.322 0 0 0-1.8 4.835c-.463 1.345-.945 2.893-1.452 4.52-2.368 7.605-5.277 16.947-9.21 15.506a5.83 5.83 0 0 1-1.186-.584c-.716 1.188-1.379 2.124-1.98 2.697a6.367 6.367 0 0 1-1.798 1.233c9.048 8.934 25.713 8.555 24.765-2.545-1.124-13.132-1.052-18.694-.951-26.432l.01-.823a5.908 5.908 0 0 0-1.55-.626l-.002-.008zm14.61 5.78c.423 1.868.645 3.775.66 5.69l.008.003c-.019.255-.238 1.756-1.57 1.478a2.31 2.31 0 0 1-1.087-.51C46.32 12.477 38.715-3.092 37.465 9.397a52.389 52.389 0 0 0-1.876-2.51c1.708-2.022 2.964-2.26 3.683-2.372 3.41-.533 9.475 7.63 11.049 14.553z"
+                      fill="#5FC82B"/>
+                <path d="M32.169 3.516C20.635-3.528 5.958 36.063 4.859 26.11 2.023 6.925 16.776.85 16.776.85 7.289 3.997-.166 13.673.003 24.847c.17 11.228 6.418 17.667 8.67 18.783 2.852 1.416 5.343.072 6.572-1.14 4.727-4.508 13.268-31.265 20.467-29.192 8.056 1.944 6.988 18.978 7.378 22.244.775 6.51 2.591 5.732 5.121.949 1.696-3.206 2.8-6.9 2.774-11.773 0 0-.12 1.824-1.574 1.519-1.305-.272-1.793-1.02-5.077-6.173C40.895 14.671 35.64 5.641 32.17 3.522"
+                      fill="#0C48D8"/>
+            </svg>
+        </td>
+        <td>
+            <div class="hf_center">Opetushallitus</div>
+        </td>
+        <td>
+            <div class="hf_right">Kuitti</div>
+        </td>
+    </tr>
+</table>
+
+<p>
+    [[${dateOfReceipt}]]
+</p>
+<p>
+    Maksupäivä: [[${paymentDate}]]
+</p>
+<p>
+    [[${payerName}]]
+</p>
+
+<table style="width: 100%;border-spacing: 0;">
+    <tr>
+        <td colspan="4" class="cell" style="font-weight: bold; border-width: 1px 1px 0 1px;">
+            [[${item.name}]]
+        </td>
+        <td class="cell" style="border-width: 1px 1px 0 0;">
+            [[${item.value}]]
+        </td>
+    </tr>
+    <tr th:each="additionalInfo : ${item.additionalInfos}">
+        <td colspan="4" class="cell" style="border-width: 0 1px 0 1px;">
+            [[${additionalInfo}]]
+        </td>
+        <td class="cell" style="border-width: 0 1px 0 0;"></td>
+    </tr>
+    <tr style="font-weight: bold">
+        <td class="cell" colspan="4" style="font-weight: bold; border-width: 1px 1px 1px 1px;">
+            Yhteensä
+        </td>
+        <td class="cell" style="border-width: 1px 1px 1px 0;">
+            [[${totalAmount}]]
+        </td>
+    </tr>
+</table>
+
+<div style="font-size: 14px;">
+    <p>Hinnat ALV 0%</p>
+    <p>Yleisen kielitutkinnon tutkintomaksu on opetus- ja kulttuuriministeriön asetuksella määrätty maksu, johon ei
+        lisätä arvonlisäveroa.</p>
+</div>
+
+<table class="footer">
+    <tr>
+        <td>
+            <div>
+                <div><strong>Opetushallitus</strong></div>
+                <div>Hakaniemenranta 6</div>
+                <div>PL 380, 00531 Helsinki</div>
+            </div>
+        </td>
+        <td>
+            <div class="hf_center">
+                <div>Sähköposti: kirjaamo@oph.fi</div>
+                <div>Puhelin: +358 29 533 1000</div>
+                <div>&nbsp;</div>
+            </div>
+        </td>
+        <td>
+            <div class="hf_right">
+                <div>Y-tunnus: 2769790-1</div>
+                <div>&nbsp;</div>
+                <div>&nbsp;</div>
+            </div>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/backend/vkt/src/main/resources/email-templates/receipt.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt.html
@@ -95,8 +95,7 @@
 
 <div style="font-size: 14px;">
     <p>Hinnat ALV 0%</p>
-    <p>Yleisen kielitutkinnon tutkintomaksu on opetus- ja kulttuuriministeriön asetuksella määrätty maksu, johon ei
-        lisätä arvonlisäveroa.</p>
+    <p>Valtionhallinnon kielitutkinnon tutkintomaksut ovat opetus- ja kulttuuriministeriön asetuksella Opetushallituksen suoritteiden maksullisuudesta (xxxx/202x) määrättyjä maksuja, joista ei peritä arvonlisäveroa.</p>
 </div>
 
 <table class="footer">

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererIntegrationTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererIntegrationTest.java
@@ -1,0 +1,66 @@
+package fi.oph.vkt.service.receipt;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Resource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test-hsql")
+class ReceiptRendererIntegrationTest {
+
+  @Resource
+  private ReceiptRenderer receiptRenderer;
+
+  @Test
+  public void testHtml() {
+    final String html = receiptRenderer.getReceiptHtml(
+      ReceiptData
+        .builder()
+        .dateOfReceipt("24.12.2013")
+        .payerName("Raimo Rahamies")
+        .paymentDate("24.12.1987")
+        .totalAmount("454 €")
+        .item(
+          ReceiptItem
+            .builder()
+            .name("Valtionhallinnon kielitutkinnot (VKT) tutkintomaksu")
+            .value("454 €")
+            .additionalInfos(List.of("Suomi, erinomainen, 28.1.2023", "Osallistuja: Ainolainen, Aino"))
+            .build()
+        )
+        .build()
+    );
+    assertNotNull(html);
+    assertTrue(html.contains("<html "));
+    assertTrue(html.contains("Maksupäivä: 24.12.1987"));
+  }
+
+  @Test
+  public void testPdf() throws IOException, InterruptedException {
+    final byte[] pdfBytes = receiptRenderer.getReceiptPdfBytes(
+      ReceiptData
+        .builder()
+        .dateOfReceipt("24.12.2013")
+        .payerName("Raimo Rahamies")
+        .paymentDate("24.12.1987")
+        .totalAmount("454 €")
+        .item(
+          ReceiptItem
+            .builder()
+            .name("Valtionhallinnon kielitutkinnot (VKT) tutkintomaksu")
+            .value("454 €")
+            .additionalInfos(List.of("Suomi, erinomainen, 28.1.2023", "Osallistuja: Ainolainen, Aino"))
+            .build()
+        )
+        .build()
+    );
+    assertNotNull(pdfBytes);
+    assertTrue(pdfBytes.length > 0);
+  }
+}

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererTest.java
@@ -1,0 +1,53 @@
+package fi.oph.vkt.service.receipt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import fi.oph.vkt.Factory;
+import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Person;
+import fi.oph.vkt.repository.EnrollmentRepository;
+import fi.oph.vkt.util.TemplateRenderer;
+import javax.annotation.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WithMockUser
+@DataJpaTest
+class ReceiptRendererTest {
+
+  @MockBean
+  private TemplateRenderer templateRenderer;
+
+  @Resource
+  private EnrollmentRepository enrollmentRepository;
+
+  @Resource
+  private TestEntityManager entityManager;
+
+  private ReceiptRenderer receiptRenderer;
+
+  @BeforeEach
+  public void setup() {
+    receiptRenderer = new ReceiptRenderer(templateRenderer, enrollmentRepository);
+  }
+
+  @Test
+  public void testGetReceiptData() {
+    final ExamEvent examEvent = Factory.examEvent();
+    final Person person = Factory.person();
+    final Enrollment enrollment = Factory.enrollment(examEvent, person);
+    entityManager.persist(examEvent);
+    entityManager.persist(person);
+    entityManager.persist(enrollment);
+
+    final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId());
+    assertNotNull(receiptData);
+    assertEquals("454 €", receiptData.totalAmount());
+  }
+}

--- a/backend/vkt/src/test/java/fi/oph/vkt/util/EnrollmentUtilTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/util/EnrollmentUtilTest.java
@@ -1,0 +1,35 @@
+package fi.oph.vkt.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import fi.oph.vkt.model.Enrollment;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+
+class EnrollmentUtilTest {
+
+  @Test
+  public void testCalculateExaminationPaymentSum() {
+    assertEquals(0, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(false, false, false)));
+    assertEquals(227, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(true, false, false)));
+    assertEquals(454, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(true, true, false)));
+    assertEquals(454, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(true, false, true)));
+    assertEquals(227, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(false, true, false)));
+    assertEquals(227, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(false, false, true)));
+    assertEquals(454, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(false, true, true)));
+    assertEquals(454, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(true, true, true)));
+  }
+
+  @NonNull
+  private static Enrollment createEnrollment(
+    final boolean oralSkill,
+    final boolean textualSkill,
+    final boolean understandingSkill
+  ) {
+    final Enrollment enrollment = new Enrollment();
+    enrollment.setOralSkill(oralSkill);
+    enrollment.setTextualSkill(textualSkill);
+    enrollment.setUnderstandingSkill(understandingSkill);
+    return enrollment;
+  }
+}

--- a/backend/vkt/src/test/java/fi/oph/vkt/util/TemplateRendererTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/util/TemplateRendererTest.java
@@ -3,6 +3,7 @@ package fi.oph.vkt.util;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.Test;
@@ -17,11 +18,31 @@ class TemplateRendererTest {
   private TemplateRenderer templateRenderer;
 
   @Test
-  public void testRenderExample() {
-    final String renderedContent = templateRenderer.renderExample(Map.of("key", "value"));
+  public void testRenderReceipt() {
+    final Map<String, Object> params = Map.of(
+      "dateOfReceipt",
+      "24.12.2022",
+      "payerName",
+      "Väinöläinen, Väinö",
+      "paymentDate",
+      "24.12.1987",
+      "totalAmount",
+      "454 €",
+      "item",
+      Map.of(
+        "name",
+        "Valtionhallinnon kielitutkinnot (VKT) tutkintomaksu",
+        "value",
+        "454 €",
+        "additionalInfos",
+        List.of("Suomi, erinomainen, 28.1.2023", "Osallistuja: Ainolainen, Aino")
+      )
+    );
+
+    final String renderedContent = templateRenderer.renderReceipt(params);
 
     assertNotNull(renderedContent);
     assertTrue(renderedContent.contains("<html "));
-    assertTrue(renderedContent.contains("This is a placeholder value, just for an example."));
+    assertTrue(renderedContent.contains("Suomi, erinomainen, 28.1.2023"));
   }
 }


### PR DESCRIPTION
## Yhteenveto

Luodaan osallistumismaksusta kuitti PDF.

Rajapinta kuitin lataamiseen lisätty api/v1/clerk/enrollment/receipt/<ENROLLMENTID> testaamista varten, ei ole tiedossa tarvitaanko rajapintaa käyttöliittymään.

Kuitin tietoihin täytyy kaivaa oikeat maksutiedot sitten kun oikeat maksut ja maksun tiedot saadaan toteutettua.

## Lisätiedot


## Huomautukset


## Check-lista

- [ ] Testattu docker-compose:lla
