### PR TITLE
VKT(Frontend): OPHVKTKEH-95 refaktorointia ja parannuksia ilmoittautumisen tarkastelunäkymään

### DIFF
--- a/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetails.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetails.tsx
@@ -10,16 +10,15 @@ import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { UIMode } from 'enums/app';
 import { ClerkEnrollmentTextFieldEnum } from 'enums/clerkEnrollment';
 import { useNavigationProtection } from 'hooks/useNavigationProtection';
-import {
-  ClerkEnrollment,
-  PartialExamsAndSkills,
-} from 'interfaces/clerkExamEvent';
+import { ClerkEnrollment } from 'interfaces/clerkExamEvent';
+import { PartialExamsAndSkills } from 'interfaces/common/enrollment';
 import {
   resetClerkEnrollmentDetailsUpdate,
   updateClerkEnrollmentDetails,
 } from 'redux/reducers/clerkEnrollmentDetails';
 import { clerkEnrollmentDetailsSelector } from 'redux/selectors/clerkEnrollmentDetails';
 import { clerkExamEventOverviewSelector } from 'redux/selectors/clerkExamEventOverview';
+import { EnrollmentUtils } from 'utils/enrollment';
 
 export const ClerkEnrollmentDetails = () => {
   // Redux
@@ -71,19 +70,10 @@ export const ClerkEnrollmentDetails = () => {
     return null;
   }
 
-  const hasPartialExamSelected = (enrollmentDetails: ClerkEnrollment) => {
-    return (
-      enrollmentDetails.speakingPartialExam ||
-      enrollmentDetails.speechComprehensionPartialExam ||
-      enrollmentDetails.writingPartialExam ||
-      enrollmentDetails.readingComprehensionPartialExam
-    );
-  };
-
   const hasRequiredDetails =
     StringUtils.isNonBlankString(enrollmentDetails.email) &&
     StringUtils.isNonBlankString(enrollmentDetails.phoneNumber) &&
-    hasPartialExamSelected(enrollmentDetails);
+    EnrollmentUtils.isValidPartialExamsAndSkills(enrollmentDetails);
 
   const handleTextFieldChange =
     (field: ClerkEnrollmentTextFieldEnum) =>

--- a/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
@@ -7,10 +7,8 @@ import { DateUtils, InputFieldUtils } from 'shared/utils';
 import { translateOutsideComponent, useClerkTranslation } from 'configs/i18n';
 import { ClerkEnrollmentTextFieldEnum } from 'enums/clerkEnrollment';
 import { ClerkEnrollmentTextFieldProps } from 'interfaces/clerkEnrollmentTextField';
-import {
-  ClerkEnrollment,
-  PartialExamsAndSkills,
-} from 'interfaces/clerkExamEvent';
+import { ClerkEnrollment } from 'interfaces/clerkExamEvent';
+import { PartialExamsAndSkills } from 'interfaces/common/enrollment';
 
 const CheckboxField = ({
   enrollment,

--- a/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
@@ -271,12 +271,12 @@ export const ClerkEnrollmentDetailsFields = ({
             true
           )}
         />
-        <div className="columns align-items-start gapped">
+        <div className="columns align-items-start clerk-enrollment-details-fields__skills">
           <div className="rows gapped-xs">
             <div className="margin-top-sm columns gapped">
               <H3>{t('header.selectedSkills')}</H3>
             </div>
-            <div className="rows">
+            <div className="rows clerk-enrollment-details-fields__skills__checkboxes">
               <CheckboxField
                 enrollment={enrollment}
                 fieldName={'oralSkill'}
@@ -297,62 +297,63 @@ export const ClerkEnrollmentDetailsFields = ({
               />
             </div>
           </div>
-          <div className="rows gapped-xs">
-            <div className="margin-top-sm columns gapped">
-              <H3>{t('header.selectedPartialExams')}</H3>
+          <div className="rows gapped-xs margin-top-sm">
+            <H3>{t('header.selectedPartialExams')}</H3>
+            <div className="rows clerk-enrollment-details-fields__skills__checkboxes">
+              <CheckboxField
+                enrollment={enrollment}
+                fieldName={'speakingPartialExam'}
+                onClick={togglePartialExam}
+                disabled={!enrollment.oralSkill || editDisabled}
+              />
+              <CheckboxField
+                enrollment={enrollment}
+                fieldName={'speechComprehensionPartialExam'}
+                onClick={togglePartialExam}
+                disabled={
+                  (!enrollment.oralSkill && !enrollment.understandingSkill) ||
+                  editDisabled
+                }
+              />
+              <CheckboxField
+                enrollment={enrollment}
+                fieldName={'writingPartialExam'}
+                onClick={togglePartialExam}
+                disabled={!enrollment.textualSkill || editDisabled}
+              />
+              <CheckboxField
+                enrollment={enrollment}
+                fieldName={'readingComprehensionPartialExam'}
+                onClick={togglePartialExam}
+                disabled={
+                  (!enrollment.textualSkill &&
+                    !enrollment.understandingSkill) ||
+                  editDisabled
+                }
+              />
             </div>
-            <CheckboxField
-              enrollment={enrollment}
-              fieldName={'speakingPartialExam'}
-              onClick={togglePartialExam}
-              disabled={!enrollment.oralSkill || editDisabled}
-            />
-            <CheckboxField
-              enrollment={enrollment}
-              fieldName={'speechComprehensionPartialExam'}
-              onClick={togglePartialExam}
-              disabled={
-                (!enrollment.oralSkill && !enrollment.understandingSkill) ||
-                editDisabled
-              }
-            />
-            <CheckboxField
-              enrollment={enrollment}
-              fieldName={'writingPartialExam'}
-              onClick={togglePartialExam}
-              disabled={!enrollment.textualSkill || editDisabled}
-            />
-            <CheckboxField
-              enrollment={enrollment}
-              fieldName={'readingComprehensionPartialExam'}
-              onClick={togglePartialExam}
-              disabled={
-                (!enrollment.textualSkill && !enrollment.understandingSkill) ||
-                editDisabled
-              }
-            />
           </div>
         </div>
-        <div className="margin-top-lg columns gapped">
+        <div className="rows gapped-sm margin-top-lg">
           <H3>{t('header.digitalCertificateConsent')}</H3>
-        </div>
-        <div className="columns">
-          <FormControlLabel
-            control={
-              <Checkbox
-                onClick={() =>
-                  onCheckboxFieldChange(
-                    'digitalCertificateConsent',
-                    !enrollment.digitalCertificateConsent
-                  )
-                }
-                color={Color.Secondary}
-                checked={enrollment.digitalCertificateConsent}
-                disabled={editDisabled}
-              />
-            }
-            label={t('checkbox.digitalCertificateConsent')}
-          />
+          <div className="clerk-enrollment-details-fields__certificate-shipping__consent">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  onClick={() =>
+                    onCheckboxFieldChange(
+                      'digitalCertificateConsent',
+                      !enrollment.digitalCertificateConsent
+                    )
+                  }
+                  color={Color.Secondary}
+                  checked={enrollment.digitalCertificateConsent}
+                  disabled={editDisabled}
+                />
+              }
+              label={t('checkbox.digitalCertificateConsent')}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/PartialExamsSelection.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/PartialExamsSelection.tsx
@@ -5,11 +5,10 @@ import { Color } from 'shared/enums';
 
 import { usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch } from 'configs/redux';
-import {
-  PublicEnrollment,
-  PublicEnrollmentPartialExamSelection,
-} from 'interfaces/publicEnrollment';
+import { PartialExamsAndSkills } from 'interfaces/common/enrollment';
+import { PublicEnrollment } from 'interfaces/publicEnrollment';
 import { updatePublicEnrollment } from 'redux/reducers/publicEnrollment';
+import { EnrollmentUtils } from 'utils/enrollment';
 
 const CheckboxField = ({
   enrollment,
@@ -18,8 +17,8 @@ const CheckboxField = ({
   disabled,
 }: {
   enrollment: PublicEnrollment;
-  fieldName: keyof PublicEnrollmentPartialExamSelection;
-  onClick: (fieldName: keyof PublicEnrollmentPartialExamSelection) => void;
+  fieldName: keyof PartialExamsAndSkills;
+  onClick: (fieldName: keyof PartialExamsAndSkills) => void;
   disabled: boolean;
 }) => {
   const { t } = usePublicTranslation({
@@ -59,41 +58,12 @@ export const PartialExamsSelection = ({
 
   useEffect(() => {
     if (setValid) {
-      const isSkillsSelected =
-        enrollment.oralSkill ||
-        enrollment.textualSkill ||
-        enrollment.understandingSkill;
-
-      const isOralExamsSelected = enrollment.oralSkill
-        ? enrollment.speakingPartialExam ||
-          enrollment.speechComprehensionPartialExam
-        : true;
-
-      const isTextualExamsSelected = enrollment.textualSkill
-        ? enrollment.writingPartialExam ||
-          enrollment.readingComprehensionPartialExam
-        : true;
-
-      const isUnderstandingExamsSelected = enrollment.understandingSkill
-        ? enrollment.speechComprehensionPartialExam ||
-          enrollment.readingComprehensionPartialExam
-        : true;
-
-      setValid(
-        isSkillsSelected &&
-          isOralExamsSelected &&
-          isTextualExamsSelected &&
-          isUnderstandingExamsSelected
-      );
+      setValid(EnrollmentUtils.isValidPartialExamsAndSkills(enrollment));
     }
   }, [setValid, enrollment]);
 
-  const toggleSkill = (
-    fieldName: keyof PublicEnrollmentPartialExamSelection
-  ) => {
-    const partialExamsToUncheck: Array<
-      keyof PublicEnrollmentPartialExamSelection
-    > = [];
+  const toggleSkill = (fieldName: keyof PartialExamsAndSkills) => {
+    const partialExamsToUncheck: Array<keyof PartialExamsAndSkills> = [];
 
     if (fieldName === 'oralSkill' && enrollment.oralSkill) {
       partialExamsToUncheck.push('speakingPartialExam');
@@ -121,9 +91,7 @@ export const PartialExamsSelection = ({
     partialExamsToUncheck.forEach(uncheckPartialExam);
   };
 
-  const togglePartialExam = (
-    fieldName: keyof PublicEnrollmentPartialExamSelection
-  ) => {
+  const togglePartialExam = (fieldName: keyof PartialExamsAndSkills) => {
     dispatch(
       updatePublicEnrollment({
         [fieldName]: !enrollment[fieldName],
@@ -131,9 +99,7 @@ export const PartialExamsSelection = ({
     );
   };
 
-  const uncheckPartialExam = (
-    fieldName: keyof PublicEnrollmentPartialExamSelection
-  ) => {
+  const uncheckPartialExam = (fieldName: keyof PartialExamsAndSkills) => {
     dispatch(
       updatePublicEnrollment({
         [fieldName]: false,

--- a/frontend/packages/vkt/src/interfaces/clerkExamEvent.ts
+++ b/frontend/packages/vkt/src/interfaces/clerkExamEvent.ts
@@ -1,6 +1,7 @@
 import { Dayjs } from 'dayjs';
 
 import { EnrollmentStatus, ExamLanguage, ExamLevel } from 'enums/app';
+import { PartialExamsAndSkills } from 'interfaces/common/enrollment';
 import { WithId, WithVersion } from 'interfaces/with';
 
 interface Person extends WithId, WithVersion {
@@ -13,16 +14,6 @@ export interface ClerkEnrollmentResponse
   extends Omit<ClerkEnrollment, 'enrollmentTime' | 'previousEnrollmentDate'> {
   enrollmentTime: string;
   previousEnrollmentDate?: string;
-}
-
-export interface PartialExamsAndSkills {
-  oralSkill: boolean;
-  textualSkill: boolean;
-  understandingSkill: boolean;
-  speakingPartialExam: boolean;
-  speechComprehensionPartialExam: boolean;
-  writingPartialExam: boolean;
-  readingComprehensionPartialExam: boolean;
 }
 
 export interface ClerkEnrollment

--- a/frontend/packages/vkt/src/interfaces/common/enrollment.ts
+++ b/frontend/packages/vkt/src/interfaces/common/enrollment.ts
@@ -1,0 +1,9 @@
+export interface PartialExamsAndSkills {
+  oralSkill: boolean;
+  textualSkill: boolean;
+  understandingSkill: boolean;
+  speakingPartialExam: boolean;
+  speechComprehensionPartialExam: boolean;
+  writingPartialExam: boolean;
+  readingComprehensionPartialExam: boolean;
+}

--- a/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
@@ -1,17 +1,9 @@
+import { PartialExamsAndSkills } from 'interfaces/common/enrollment';
+
 export interface PublicEnrollmentContactDetails {
   email: string;
   emailConfirmation: string;
   phoneNumber: string;
-}
-
-export interface PublicEnrollmentPartialExamSelection {
-  oralSkill: boolean;
-  textualSkill: boolean;
-  understandingSkill: boolean;
-  speakingPartialExam: boolean;
-  speechComprehensionPartialExam: boolean;
-  writingPartialExam: boolean;
-  readingComprehensionPartialExam: boolean;
 }
 
 export interface PublicEnrollmentAddress {
@@ -23,7 +15,7 @@ export interface PublicEnrollmentAddress {
 
 export interface PublicEnrollment
   extends PublicEnrollmentContactDetails,
-    PublicEnrollmentPartialExamSelection,
+    PartialExamsAndSkills,
     PublicEnrollmentAddress {
   digitalCertificateConsent: boolean;
   privacyStatementConfirmation: boolean;

--- a/frontend/packages/vkt/src/styles/components/clerkEnrollment/_clerk-enrollment-details-fields.scss
+++ b/frontend/packages/vkt/src/styles/components/clerkEnrollment/_clerk-enrollment-details-fields.scss
@@ -2,4 +2,19 @@
   .previous-enrollment {
     width: calc(50% - 1rem);
   }
+
+  &__skills {
+    justify-content: space-between;
+    width: calc(50% - 1rem);
+
+    &__checkboxes {
+      padding-left: 1rem;
+    }
+  }
+
+  &__certificate-shipping {
+    &__consent {
+      padding-left: 1rem;
+    }
+  }
 }

--- a/frontend/packages/vkt/src/utils/enrollment.ts
+++ b/frontend/packages/vkt/src/utils/enrollment.ts
@@ -1,0 +1,28 @@
+import { PartialExamsAndSkills } from 'interfaces/common/enrollment';
+
+export class EnrollmentUtils {
+  static isValidPartialExamsAndSkills(skills: PartialExamsAndSkills) {
+    const isSkillsSelected =
+      skills.oralSkill || skills.textualSkill || skills.understandingSkill;
+
+    const isOralExamsSelected = skills.oralSkill
+      ? skills.speakingPartialExam || skills.speechComprehensionPartialExam
+      : true;
+
+    const isTextualExamsSelected = skills.textualSkill
+      ? skills.writingPartialExam || skills.readingComprehensionPartialExam
+      : true;
+
+    const isUnderstandingExamsSelected = skills.understandingSkill
+      ? skills.speechComprehensionPartialExam ||
+        skills.readingComprehensionPartialExam
+      : true;
+
+    return (
+      isSkillsSelected &&
+      isOralExamsSelected &&
+      isTextualExamsSelected &&
+      isUnderstandingExamsSelected
+    );
+  }
+}


### PR DESCRIPTION
## Yhteenveto

Alustava ajatus tiketissä oli toteuttaa yhteiskäyttöisiä komponentteja julkisen ja virkailijaUI:n ilmoittautumistietojen tarkastelua ja muokkausta varten. Tämä vaikutti hankalalta ja työläältä hommalta, joten koin että ehkä sitä ei ole mielekästä lähteä oikeasti tekemään. Tähän liittyen toteutin tässä tosin nyt sellaisen homman, että tuo eräs jaettu interface `PartialExamsAndSkills` on käytössä nyt sekä julkisella että virkailijapuolella ja utils alla on logiikkaa siihen, jolla tarkistetaan, onko valitut taidot ja osakokeet keskenään valideja. Virkailijan näkymässä olikin tämän osalta aiemmin bugi, kun tuota validointia ei tehty ja oli mahdollisuus tallentaa ilmoittautuminen virheellisillä tiedoilla näiden osalta.

Samalla kun katselin tuota virkailijan ilmoittautumisen näkymää havaitsin, että tyylittelyn osalta nuo checkboxit eivät olleet ihan sillä lailla kuin figmaan speksattu. Tein pieniä tyylitysmuutoksia lopuksi vielä niihin. Mutta alun perin suunniteltua yhteiskäyttöisiä komponentteja en lähtenyt muodostamaan. Sekin vielä vähän auki näihin liittyen että miten toteutetaan se, että virkailija voi tehdä ilmoittautumisen jonkun toisen puolesta, joka maksaa esim. laskulla jälkeenpäin. Itsellä käynyt mielessä olisiko hyvä, jos lisättäisiin virkailijan UI:hin yksinkertaisesti "Luo ilmoittautuminen" painike, jolla täytettäisiin nuo arvot jotka tuolta ovat ilmoittautumista kohti muokattavissakin ja ilmo menisi täten esim. jono- tai odottaa maksua-statukseen (ellei statusta erikseen tuossa määriteltäisi myös). Mutta tuokin huomioonottaen ehkei suurta jumppaa yhteiskäyttöisten palikoiden kanssa kannata tehdä just nyt?

Tein tuohon yo. pohdintaan liittyen tiketin https://jira.eduuni.fi/browse/OPHVKTKEH-102
