### PR TITLE
OPHVKTKEH-94 proper ordering for skills and partial exams

### DIFF
--- a/frontend/packages/vkt/src/components/clerkEnrollment/listing/ChangeEnrollmentStatusButton.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/listing/ChangeEnrollmentStatusButton.tsx
@@ -61,6 +61,7 @@ export const ChangeEnrollmentStatusButton = ({
   return (
     <LoadingProgressIndicator isLoading={isLoading}>
       <CustomButton
+        sx={{ padding: 0 }}
         data-testid={`clerk-exam-event-overview__enrollment-list-${enrollment.id}__change-status-button`}
         variant={Variant.Text}
         color={Color.Secondary}

--- a/frontend/packages/vkt/src/components/clerkEnrollment/listing/ClerkEnrollmentListingRow.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/listing/ClerkEnrollmentListingRow.tsx
@@ -11,10 +11,10 @@ import { ClerkEnrollment } from 'interfaces/clerkExamEvent';
 import { storeClerkEnrollmentDetails } from 'redux/reducers/clerkEnrollmentDetails';
 
 const examCodes = {
+  writingPartialExam: 'KI',
   readingComprehensionPartialExam: 'TY',
   speakingPartialExam: 'PU',
   speechComprehensionPartialExam: 'PY',
-  writingPartialExam: 'KI',
 };
 
 function pick<T extends object, K extends keyof T>(object: T, keys: Array<K>) {
@@ -43,10 +43,10 @@ export const ClerkEnrollmentListingRow = ({
 
   const getSelectedPartialExamsText = () => {
     const partialExams = pick(enrollment, [
-      'speakingPartialExam',
-      'speechComprehensionPartialExam',
       'writingPartialExam',
       'readingComprehensionPartialExam',
+      'speakingPartialExam',
+      'speechComprehensionPartialExam',
     ]);
 
     if (Object.values(partialExams).some((value) => !value)) {
@@ -89,7 +89,7 @@ export const ClerkEnrollmentListingRow = ({
             {DateUtils.formatOptionalDateTime(enrollment.enrollmentTime)}
           </Text>
         </TableCell>
-        <TableCell align="right">
+        <TableCell sx={{ width: '20%' }} align="right">
           {[
             EnrollmentStatus.EXPECTING_PAYMENT,
             EnrollmentStatus.QUEUED,

--- a/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
@@ -279,13 +279,13 @@ export const ClerkEnrollmentDetailsFields = ({
             <div className="rows clerk-enrollment-details-fields__skills__checkboxes">
               <CheckboxField
                 enrollment={enrollment}
-                fieldName={'oralSkill'}
+                fieldName={'textualSkill'}
                 onClick={toggleSkill}
                 disabled={editDisabled}
               />
               <CheckboxField
                 enrollment={enrollment}
-                fieldName={'textualSkill'}
+                fieldName={'oralSkill'}
                 onClick={toggleSkill}
                 disabled={editDisabled}
               />
@@ -302,21 +302,6 @@ export const ClerkEnrollmentDetailsFields = ({
             <div className="rows clerk-enrollment-details-fields__skills__checkboxes">
               <CheckboxField
                 enrollment={enrollment}
-                fieldName={'speakingPartialExam'}
-                onClick={togglePartialExam}
-                disabled={!enrollment.oralSkill || editDisabled}
-              />
-              <CheckboxField
-                enrollment={enrollment}
-                fieldName={'speechComprehensionPartialExam'}
-                onClick={togglePartialExam}
-                disabled={
-                  (!enrollment.oralSkill && !enrollment.understandingSkill) ||
-                  editDisabled
-                }
-              />
-              <CheckboxField
-                enrollment={enrollment}
                 fieldName={'writingPartialExam'}
                 onClick={togglePartialExam}
                 disabled={!enrollment.textualSkill || editDisabled}
@@ -328,6 +313,21 @@ export const ClerkEnrollmentDetailsFields = ({
                 disabled={
                   (!enrollment.textualSkill &&
                     !enrollment.understandingSkill) ||
+                  editDisabled
+                }
+              />
+              <CheckboxField
+                enrollment={enrollment}
+                fieldName={'speakingPartialExam'}
+                onClick={togglePartialExam}
+                disabled={!enrollment.oralSkill || editDisabled}
+              />
+              <CheckboxField
+                enrollment={enrollment}
+                fieldName={'speechComprehensionPartialExam'}
+                onClick={togglePartialExam}
+                disabled={
+                  (!enrollment.oralSkill && !enrollment.understandingSkill) ||
                   editDisabled
                 }
               />

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/PartialExamsSelection.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/PartialExamsSelection.tsx
@@ -114,13 +114,13 @@ export const PartialExamsSelection = ({
         <div className="public-enrollment__grid__partial-exam-selection rows">
           <CheckboxField
             enrollment={enrollment}
-            fieldName={'oralSkill'}
+            fieldName={'textualSkill'}
             onClick={toggleSkill}
             disabled={editingDisabled}
           />
           <CheckboxField
             enrollment={enrollment}
-            fieldName={'textualSkill'}
+            fieldName={'oralSkill'}
             onClick={toggleSkill}
             disabled={editingDisabled}
           />
@@ -138,21 +138,6 @@ export const PartialExamsSelection = ({
           <div className="grid-columns">
             <CheckboxField
               enrollment={enrollment}
-              fieldName={'speakingPartialExam'}
-              onClick={togglePartialExam}
-              disabled={!enrollment.oralSkill || editingDisabled}
-            />
-            <CheckboxField
-              enrollment={enrollment}
-              fieldName={'speechComprehensionPartialExam'}
-              onClick={togglePartialExam}
-              disabled={
-                (!enrollment.oralSkill && !enrollment.understandingSkill) ||
-                editingDisabled
-              }
-            />
-            <CheckboxField
-              enrollment={enrollment}
               fieldName={'writingPartialExam'}
               onClick={togglePartialExam}
               disabled={!enrollment.textualSkill || editingDisabled}
@@ -163,6 +148,21 @@ export const PartialExamsSelection = ({
               onClick={togglePartialExam}
               disabled={
                 (!enrollment.textualSkill && !enrollment.understandingSkill) ||
+                editingDisabled
+              }
+            />
+            <CheckboxField
+              enrollment={enrollment}
+              fieldName={'speakingPartialExam'}
+              onClick={togglePartialExam}
+              disabled={!enrollment.oralSkill || editingDisabled}
+            />
+            <CheckboxField
+              enrollment={enrollment}
+              fieldName={'speechComprehensionPartialExam'}
+              onClick={togglePartialExam}
+              disabled={
+                (!enrollment.oralSkill && !enrollment.understandingSkill) ||
                 editingDisabled
               }
             />


### PR DESCRIPTION
Muutettu myös tyylityksiä ilmoittautumisrivien näyttämiseen liittyen jotta sarakkeet kaikissa taulukoissa samalla leveystasolla ja siirtonappula ei tee ylimääräistä paddingiä keskimmäisiin taulukoihin