### PR TITLE
AKR(Backend): OPHAKRKEH-479 updated old link in authorisation expiry mail template

### DIFF
--- a/backend/akr/src/main/resources/email-templates/authorisation-expiry.html
+++ b/backend/akr/src/main/resources/email-templates/authorisation-expiry.html
@@ -16,7 +16,7 @@
             Jos et uusi oikeuttasi, et voi toimia auktorisoituna kääntäjänä. Tietosi poistuvat julkisesta auktorisoitujen kääntäjien rekisteristä oikeutesi päättymisen jälkeen.
         </p>
         <p>
-            Auktorisoidun kääntäjän oikeuden uusiminen tapahtuu sille tarkoitetulla hakemuksella. Hakemusmenettelyn tiedot löytyvät täältä: <a href="https://www.oph.fi/fi/koulutus-ja-tutkinnot/auktorisoinnin-uusiminen">https://www.oph.fi/fi/koulutus-ja-tutkinnot/auktorisoinnin-uusiminen</a>. Sivun lopussa on tulostettava hakemuslomake.
+            Auktorisoidun kääntäjän oikeuden uusiminen tapahtuu sille tarkoitetulla hakemuksella. Hakemusmenettelyn tiedot löytyvät täältä: <a href="https://www.oph.fi/fi/palvelut/kaantajien-auktorisointi">https://www.oph.fi/fi/palvelut/kaantajien-auktorisointi</a>. Sivun lopussa on tulostettava hakemuslomake.
         </p>
         <p>
             Täytetty ja allekirjoitettu hakemuslomake lähetetään postitse tai skannattuna osoitteeseen: Kirjaamo Opetushallitus, PL 380, 00531 Helsinki tai <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a>
@@ -56,7 +56,7 @@
             Om du inte förnyar din rätt, kan du inte verka som auktoriserad translator och ditt namn tas bort från offentliga registret över auktoriserade translatorer.
         </p>
         <p>
-            Ansökningsblanketten samt rådgivning för ansökningsprocessen för att förnya rätten att verka som auktoriserad translator finns här: <a href="https://www.oph.fi/sv/utbildning-och-examina/ansokan-om-att-fornya-ratten-att-verka-som-auktoriserad-translator">https://www.oph.fi/sv/utbildning-och-examina/ansokan-om-att-fornya-ratten-att-verka-som-auktoriserad-translator</a>. Ansökningsblanketten kan printas ut i slutet på sidan.
+            Ansökningsblanketten samt rådgivning för ansökningsprocessen för att förnya rätten att verka som auktoriserad translator finns här: <a href="https://www.oph.fi/sv/tjanster/auktorisering-av-translatorer">https://www.oph.fi/sv/tjanster/auktorisering-av-translatorer</a>. Ansökningsblanketten kan printas ut i slutet på sidan.
         </p>
         <p>
             En ifylld och underskriven ansökningsblankett samt bilagan (utdrag ur befolkningsdatasystemet) skickas per post eller skannad till adressen: Registratur, Utbildningsstyrelsen, PB 380, 00531 Helsingfors eller <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a>


### PR DESCRIPTION
En testannut muutosta, mutta kun alkuperäinen todettu toimivaksi niin ei liene siihen suurempaa tarvetta. Voisi ehkä kyllä varmuuden vuoksi testiopintopolussa luoda jonkun umpeutuvan auktorisoinnin ja käydä tämän sinne viennin jälkeen tsekkaamassa että näyttää maili oikealta.
