### PR TITLE
VKT(Frontend): OPHVKTKEH-98 ilmoittautumisen tarkastelusivun testejä

### DIFF
--- a/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetails.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetails.tsx
@@ -69,9 +69,14 @@ export const ClerkEnrollmentDetails = () => {
       (status === APIResponseStatus.Success && currentUIMode === UIMode.Edit) ||
       clerkEnrollmentChangeStatus === APIResponseStatus.Success
     ) {
+      const description =
+        clerkEnrollmentChangeStatus === APIResponseStatus.Success
+          ? t('toasts.enrollmentCanceled')
+          : t('toasts.updated');
+
       showToast({
         severity: Severity.Success,
-        description: t('toasts.enrollmentCanceled'),
+        description,
       });
       resetToInitialState();
     }

--- a/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
@@ -31,6 +31,7 @@ const CheckboxField = ({
     <FormControlLabel
       control={
         <Checkbox
+          data-testid={`clerk-enrollment__details-fields__${fieldName}`}
           onClick={() => onClick(fieldName)}
           color={Color.Secondary}
           checked={enrollment[fieldName]}
@@ -109,6 +110,7 @@ const ClerkEnrollmentDetailsTextField = ({
 
   return (
     <CustomTextField
+      data-testid={`clerk-enrollment__details-fields__${field}`}
       value={getTextValue(enrollment, field)}
       label={translateCommon(`enrollment.textFields.${field}`)}
       onChange={onChange}
@@ -178,7 +180,6 @@ export const ClerkEnrollmentDetailsFields = ({
       showFieldError: fieldErrors[field],
       onBlur: setFieldErrorOnBlur(field),
       fullWidth: true,
-      'data-testid': `clerk-enrollment__basic-information__${field}`,
     };
   };
 
@@ -341,6 +342,7 @@ export const ClerkEnrollmentDetailsFields = ({
             className="clerk-enrollment-details-fields__certificate-shipping__consent"
             control={
               <Checkbox
+                data-testid="clerk-enrollment__details-fields__digitalCertificateConsent"
                 onClick={() =>
                   onCheckboxFieldChange(
                     'digitalCertificateConsent',

--- a/frontend/packages/vkt/src/tests/cypress/integration/enrollmentDetails/clerk_enrollment_details.spec.ts
+++ b/frontend/packages/vkt/src/tests/cypress/integration/enrollmentDetails/clerk_enrollment_details.spec.ts
@@ -6,8 +6,107 @@ import { onToast } from 'tests/cypress/support/page-objects/toast';
 import { clerkExamEvent } from 'tests/msw/fixtures/clerkExamEvent';
 
 describe('ClerkEnrollmentOverview:ClerkEnrollmentDetails', () => {
+  const nameFields = ['firstName', 'lastName'];
+  const contactDetailsFields = ['email', 'phoneNumber'];
+  const addressFields = ['street', 'postalCode', 'town', 'country'];
+  const partialsExamsAndSkillsFields = [
+    'oralSkill',
+    'textualSkill',
+    'understandingSkill',
+    'speakingPartialExam',
+    'speechComprehensionPartialExam',
+    'writingPartialExam',
+    'readingComprehensionPartialExam',
+  ];
+  const checkboxFields = [
+    ...partialsExamsAndSkillsFields,
+    'digitalCertificateConsent',
+  ];
+
   beforeEach(() => {
     onClerkExamEventOverviewPage.navigateById(clerkExamEvent.id);
+  });
+
+  it('should show disabled enrollment details', () => {
+    onClerkExamEventOverviewPage.clickEnrollmentRow(1);
+
+    const displayedTextFields = [
+      ...nameFields,
+      ...contactDetailsFields,
+      'previousEnrollmentDate',
+    ];
+
+    displayedTextFields.forEach((f) =>
+      onClerkEnrollmentOverviewPage.expectTextFieldDisabled(f)
+    );
+    addressFields.forEach((f) =>
+      onClerkEnrollmentOverviewPage.expectTextFieldNotToExist(f)
+    );
+
+    onClerkEnrollmentOverviewPage.expectTextFieldValue('firstName', 'Ella');
+    onClerkEnrollmentOverviewPage.expectTextFieldValue('lastName', 'Alanen');
+    onClerkEnrollmentOverviewPage.expectTextFieldValue(
+      'email',
+      'person1@example.invalid'
+    );
+    onClerkEnrollmentOverviewPage.expectTextFieldValue(
+      'phoneNumber',
+      '+358401000001'
+    );
+    onClerkEnrollmentOverviewPage.expectTextFieldValue(
+      'previousEnrollmentDate',
+      ''
+    );
+
+    const checkedCheckBoxFields = [
+      'textualSkill',
+      'understandingSkill',
+      'writingPartialExam',
+      'readingComprehensionPartialExam',
+      'digitalCertificateConsent',
+    ];
+
+    checkboxFields.forEach((f) => {
+      onClerkEnrollmentOverviewPage.expectCheckboxFieldDisabled(f);
+
+      checkedCheckBoxFields.includes(f)
+        ? onClerkEnrollmentOverviewPage.expectCheckboxFieldChecked(f)
+        : onClerkEnrollmentOverviewPage.expectCheckboxFieldNotChecked(f);
+    });
+  });
+
+  it('should allow modifying enrollment details', () => {
+    onClerkExamEventOverviewPage.clickEnrollmentRow(1);
+    onClerkEnrollmentOverviewPage.clickEditButton();
+
+    nameFields.forEach((f) =>
+      onClerkEnrollmentOverviewPage.expectTextFieldDisabled(f)
+    );
+    contactDetailsFields.forEach((f) =>
+      onClerkEnrollmentOverviewPage.editTextField(f, `test-${f}`)
+    );
+    onClerkEnrollmentOverviewPage.expectEnabledSaveButton();
+
+    // Remove skill and partial exam selections
+    onClerkEnrollmentOverviewPage.clickCheckBox('textualSkill');
+    onClerkEnrollmentOverviewPage.clickCheckBox('understandingSkill');
+    onClerkEnrollmentOverviewPage.expectDisabledSaveButton();
+
+    // Select some skills and partial exams
+    onClerkEnrollmentOverviewPage.clickCheckBox('oralSkill');
+    onClerkEnrollmentOverviewPage.clickCheckBox('understandingSkill');
+    onClerkEnrollmentOverviewPage.clickCheckBox('speakingPartialExam');
+    onClerkEnrollmentOverviewPage.clickCheckBox(
+      'readingComprehensionPartialExam'
+    );
+    onClerkEnrollmentOverviewPage.expectEnabledSaveButton();
+
+    onClerkEnrollmentOverviewPage.clickCheckBox('digitalCertificateConsent');
+    onClerkEnrollmentOverviewPage.expectDisabledSaveButton();
+    addressFields.forEach((f) =>
+      onClerkEnrollmentOverviewPage.editTextField(f, `test-${f}`)
+    );
+    onClerkEnrollmentOverviewPage.expectEnabledSaveButton();
   });
 
   it('should allow canceling enrollment', () => {

--- a/frontend/packages/vkt/src/tests/cypress/support/page-objects/clerkEnrollmentOverviewPage.ts
+++ b/frontend/packages/vkt/src/tests/cypress/support/page-objects/clerkEnrollmentOverviewPage.ts
@@ -2,7 +2,75 @@ class ClerkEnrollmentOverviewPage {
   elements = {
     cancelEnrollmentButton: () =>
       cy.findByTestId('clerk-enrollment-details__cancel-enrollment-button'),
+    checkboxField: (fieldName: string) =>
+      cy
+        .findByTestId(`clerk-enrollment__details-fields__${fieldName}`)
+        .should('be.visible')
+        .find('>input'),
+    editButton: () =>
+      cy.findByTestId(
+        'clerk-exam-event-overview__exam-event-details__edit-button'
+      ),
+    saveButton: () =>
+      cy.findByTestId(
+        'clerk-exam-event-overview__exam-event-details__save-button'
+      ),
+    textField: (fieldName: string) =>
+      cy
+        .findByTestId(`clerk-enrollment__details-fields__${fieldName}`)
+        .should('be.visible')
+        .find('div>input'),
   };
+
+  expectTextFieldValue(fieldName: string, value: string) {
+    this.elements.textField(fieldName).should('have.value', value);
+  }
+
+  expectTextFieldDisabled(fieldName: string) {
+    this.elements.textField(fieldName).should('be.disabled');
+  }
+
+  expectTextFieldNotToExist(fieldName: string) {
+    cy.get(`clerk-enrollment__details-fields__${fieldName}`).should(
+      'not.exist'
+    );
+  }
+
+  editTextField(fieldName: string, newValue) {
+    this.elements
+      .textField(fieldName)
+      .clear()
+      .should('have.text', '')
+      .type(`${newValue}{enter}`);
+  }
+
+  expectCheckboxFieldDisabled(fieldName: string) {
+    this.elements.checkboxField(fieldName).should('be.disabled');
+  }
+
+  expectCheckboxFieldChecked(fieldName: string) {
+    this.elements.checkboxField(fieldName).should('be.checked');
+  }
+
+  expectCheckboxFieldNotChecked(fieldName: string) {
+    this.elements.checkboxField(fieldName).should('not.be.checked');
+  }
+
+  clickCheckBox(fieldName: string) {
+    this.elements.checkboxField(fieldName).click();
+  }
+
+  clickEditButton() {
+    this.elements.editButton().should('be.visible').click();
+  }
+
+  expectDisabledSaveButton() {
+    this.elements.saveButton().should('be.disabled');
+  }
+
+  expectEnabledSaveButton() {
+    this.elements.saveButton().should('be.enabled');
+  }
 
   clickCancelEnrollmentButton() {
     this.elements.cancelEnrollmentButton().should('be.visible').click();


### PR DESCRIPTION
## Yhteenveto

Testejä ilmoittautumisen tarkastelusivulle
1) Alussa kaikki kentät disabloituja ja täytetty fixtureen määritellyillä arvoilla ja
2) Kun avaa muokkaustilan voi muokata niitä kenttiä joiden muokkaus sallittu ja tallennus-nappi aktiivinen vain kun data oikeassa tilassa

En lähtenyt tekemään testejä varsinaiselle tallennusominaisuudelle enkä myöskään testejä sille, että tsekattaisiin, milloin mitkäkin osakokeet ovat valittavissa valittuihin taitoihin perustuen.

## Huomautukset

Toteutettu https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/378 päälle
