### PR TITLE
SHARED:AKR:OTR:VKT(Frontend): OPHVKTKEH-108 DialogBox now supports severity Warning

### DIFF
--- a/frontend/packages/akr/package.json
+++ b/frontend/packages/akr/package.json
@@ -22,6 +22,6 @@
     "akr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.5"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.7"
   }
 }

--- a/frontend/packages/akr/src/components/clerkTranslator/examinationDates/ExaminationDatesListing.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/examinationDates/ExaminationDatesListing.tsx
@@ -46,7 +46,7 @@ const ListingRow = ({
   const dispatchConfirmRemoveNotifier = () => {
     showDialog({
       title: t('dialog.header'),
-      severity: Severity.Info,
+      severity: Severity.Warning,
       description: t('dialog.description'),
       actions: [
         {
@@ -71,7 +71,7 @@ const ListingRow = ({
       </TableCell>
       <TableCell align="right">
         <CustomIconButton
-          data-testid="examination-dates-page__add-button"
+          data-testid="examination-dates-page__delete-button"
           onClick={dispatchConfirmRemoveNotifier}
           aria-label={`${t('ariaLabel')} ${formattedDate}`}
         >

--- a/frontend/packages/akr/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
@@ -43,7 +43,7 @@ const ListingRow = ({ meetingDate }: { meetingDate: MeetingDate }) => {
   const dispatchConfirmRemoveNotifier = () => {
     showDialog({
       title: t('dialog.header'),
-      severity: Severity.Info,
+      severity: Severity.Warning,
       description: t('dialog.description'),
       actions: [
         {
@@ -70,7 +70,7 @@ const ListingRow = ({ meetingDate }: { meetingDate: MeetingDate }) => {
       </TableCell>
       <TableCell align="right">
         <CustomIconButton
-          data-testid="meeting-dates-page__add-button"
+          data-testid="meeting-dates-page__delete-button"
           onClick={dispatchConfirmRemoveNotifier}
           aria-label={`${t('ariaLabel')} ${formattedDate}`}
         >

--- a/frontend/packages/akr/src/components/clerkTranslator/overview/AuthorisationDetails.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/overview/AuthorisationDetails.tsx
@@ -159,7 +159,7 @@ export const AuthorisationDetails = () => {
   const onPermissionToPublishChange = (authorisation: Authorisation) => {
     showDialog({
       title: t('actions.changePermissionToPublish.dialog.header'),
-      severity: Severity.Info,
+      severity: Severity.Warning,
       description: t('actions.changePermissionToPublish.dialog.description'),
       actions: [
         {

--- a/frontend/packages/akr/src/components/clerkTranslator/overview/AuthorisationDetails.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/overview/AuthorisationDetails.tsx
@@ -185,7 +185,7 @@ export const AuthorisationDetails = () => {
   const onAuthorisationRemove = (authorisation: Authorisation) => {
     showDialog({
       title: t('actions.removal.dialog.header'),
-      severity: Severity.Info,
+      severity: Severity.Warning,
       description: t('actions.removal.dialog.description'),
       actions: [
         {

--- a/frontend/packages/akr/src/pages/clerk/ClerkNewTranslatorPage.tsx
+++ b/frontend/packages/akr/src/pages/clerk/ClerkNewTranslatorPage.tsx
@@ -75,7 +75,7 @@ export const ClerkNewTranslatorPage = () => {
   const onAuthorisationRemove = (authorisation: Authorisation) => {
     showDialog({
       title: t('removeAuthorisationDialog.title'),
-      severity: Severity.Info,
+      severity: Severity.Warning,
       description: '',
       actions: [
         {

--- a/frontend/packages/otr/package.json
+++ b/frontend/packages/otr/package.json
@@ -25,6 +25,6 @@
     "otr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.5"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.7"
   }
 }

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationDetails.tsx
@@ -133,7 +133,7 @@ export const QualificationDetails = () => {
   const handleRemoveQualification = (qualification: Qualification) => {
     showDialog({
       title: t('actions.removal.dialog.header'),
-      severity: Severity.Info,
+      severity: Severity.Warning,
       description: t('actions.removal.dialog.description'),
       actions: [
         {

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationListing.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationListing.tsx
@@ -58,7 +58,7 @@ export const QualificationListing = ({
   const onPublishPermissionChange = (qualification: Qualification) => {
     showDialog({
       title: t('actions.changePermissionToPublish.dialog.header'),
-      severity: Severity.Info,
+      severity: Severity.Warning,
       description: t('actions.changePermissionToPublish.dialog.description'),
       actions: [
         {

--- a/frontend/packages/otr/src/components/meetingDate/MeetingDatesListing.tsx
+++ b/frontend/packages/otr/src/components/meetingDate/MeetingDatesListing.tsx
@@ -34,7 +34,7 @@ const ListingRow = ({ meetingDate }: { meetingDate: MeetingDate }) => {
   const dispatchConfirmRemoveNotifier = () => {
     showDialog({
       title: t('dialog.header'),
-      severity: Severity.Info,
+      severity: Severity.Warning,
       description: t('dialog.description'),
       actions: [
         {
@@ -59,7 +59,7 @@ const ListingRow = ({ meetingDate }: { meetingDate: MeetingDate }) => {
       </TableCell>
       <TableCell align="right">
         <CustomIconButton
-          data-testid="meeting-dates-page__add-button"
+          data-testid="meeting-dates-page__delete-button"
           onClick={dispatchConfirmRemoveNotifier}
           aria-label={`${t('ariaLabel')} ${formattedDate}`}
         >

--- a/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
@@ -116,7 +116,7 @@ export const ClerkNewInterpreterPage = () => {
   const onQualificationRemove = (qualification: Qualification) => {
     showDialog({
       title: t('removeQualificationDialog.title'),
-      severity: Severity.Info,
+      severity: Severity.Warning,
       description: '',
       actions: [
         {

--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.5.7] - 2023-01-13
+
+### Added
+
+- DialogBox now supports severity: Warning
+- warning color: Yellow-500
+
 ## [1.5.6] - 2022-12-12
 
 ### Added

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/components/Notifier/DialogBox.scss
+++ b/frontend/packages/shared/src/components/Notifier/DialogBox.scss
@@ -19,4 +19,10 @@
       @include mixins.dialog-border(colors.$color-secondary);
     }
   }
+
+  &--warning {
+    & [role='dialog'] {
+      @include mixins.dialog-border(colors.$color-yellow-500);
+    }
+  }
 }

--- a/frontend/packages/shared/src/styles/abstracts/_colors.scss
+++ b/frontend/packages/shared/src/styles/abstracts/_colors.scss
@@ -1,19 +1,15 @@
 $color-background: #f0f3f7;
 $color-primary: #ffffff;
-
-$color-divider: #e0e0e0; // not in figma specs
-
 $color-text-primary: #000a48;
 $color-secondary-dark: #000a48;
 $color-secondary: #0041dc;
-
 $color-grey-200: #f5f5f5;
 $color-grey-400: #cccccc;
 $color-grey-600: #999999;
 $color-grey-700: #666666;
-
 $color-blue-200: #f2f5fd;
-
 $color-red-500: #db2828;
-
 $color-green-600: #5fc82b;
+$color-yellow-500: #ffd024;
+
+$color-divider: #e0e0e0; // not in figma specs

--- a/frontend/packages/vkt/package.json
+++ b/frontend/packages/vkt/package.json
@@ -25,6 +25,6 @@
     "vkt:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.6"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.7"
   }
 }

--- a/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetails.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetails.tsx
@@ -186,7 +186,7 @@ export const ClerkEnrollmentDetails = () => {
 
     showDialog({
       title: t('cancelEnrollmentDialog.header'),
-      severity: Severity.Info,
+      severity: Severity.Warning,
       description: t('cancelEnrollmentDialog.description'),
       actions: [
         {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2686,7 +2686,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.akr@workspace:packages/akr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.5"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.7"
   languageName: unknown
   linkType: soft
 
@@ -2694,7 +2694,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.otr@workspace:packages/otr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.5"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.7"
   languageName: unknown
   linkType: soft
 
@@ -2786,7 +2786,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.6":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.7":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -2796,7 +2796,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.vkt@workspace:packages/vkt"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.6"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.7"
   languageName: unknown
   linkType: soft
 
@@ -11743,13 +11743,6 @@ __metadata:
   dependencies:
     kind-of: ^6.0.2
   checksum: 39b3dd9630a774aba288a680e7d2901f5c0eae7b8387fc5c8ea559918b29b3da144b7bdb990d7ccd9e11be05508ac9e459ce51d01fd65e583282f6ffafcba2e7
-  languageName: node
-  linkType: hard
-
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.5.5":
-  version: 1.5.5
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.5.5::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.5.5%2Fddfadafab220b84b1bf895532fff5ea4070037ea"
-  checksum: a8c0a0509415cbd93b4b49c0f977c77d1b98dd589ff76118b2ee74fad9cd14c1be170a1898ece4c802916be27fd4eaf03561346f7815f5a134192bf5d9708593
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Lisätty puuttuvat shared tyylit DialogBox severity: "warning". Otettu käyttöön kaikissa projekteissa. Warning -tyylinen DialogBox näytettään nyt kaikissa tapauksissa, joissa käyttäjän yrittää tehdä poisto-operaatiota.
