### PR TITLE
VKT(Backend): OPHVKTKEH-110 fixed PublicReservationService

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/BaseRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/BaseRepository.java
@@ -1,0 +1,26 @@
+package fi.oph.vkt.repository;
+
+import fi.oph.vkt.util.exception.NotFoundException;
+import java.util.List;
+import lombok.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+@NoRepositoryBean
+public interface BaseRepository<T> extends JpaRepository<T, Long> {
+  /**
+   * Overwrites `deleteById` defined by `CrudRepository`. Deletion is done via
+   * `deleteAllByIdInBatch` because overwritten `deleteById` doesn't seem functional with
+   * HSQL test database.
+   *
+   * @param id must not be {@literal null}.
+   */
+  @Override
+  default void deleteById(final @NonNull Long id) {
+    if (!this.existsById(id)) {
+      throw new NotFoundException(String.format("Entity by id: %d not found", id));
+    }
+
+    this.deleteAllByIdInBatch(List.of(id));
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/EmailAttachmentRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/EmailAttachmentRepository.java
@@ -1,8 +1,7 @@
 package fi.oph.vkt.repository;
 
 import fi.oph.vkt.model.EmailAttachment;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EmailAttachmentRepository extends JpaRepository<EmailAttachment, Long> {}
+public interface EmailAttachmentRepository extends BaseRepository<EmailAttachment> {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/EmailRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/EmailRepository.java
@@ -3,12 +3,11 @@ package fi.oph.vkt.repository;
 import fi.oph.vkt.model.Email;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EmailRepository extends JpaRepository<Email, Long> {
+public interface EmailRepository extends BaseRepository<Email> {
   @Query("SELECT e.id FROM Email e WHERE e.sentAt IS NULL ORDER BY e.modifiedAt asc")
   List<Long> findEmailsToSend(PageRequest pageRequest);
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/EnrollmentRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/EnrollmentRepository.java
@@ -1,8 +1,7 @@
 package fi.oph.vkt.repository;
 
 import fi.oph.vkt.model.Enrollment;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {}
+public interface EnrollmentRepository extends BaseRepository<Enrollment> {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/ExamEventRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/ExamEventRepository.java
@@ -4,12 +4,11 @@ import fi.oph.vkt.model.ExamEvent;
 import fi.oph.vkt.model.type.ExamLevel;
 import java.util.List;
 import java.util.Set;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ExamEventRepository extends JpaRepository<ExamEvent, Long> {
+public interface ExamEventRepository extends BaseRepository<ExamEvent> {
   @Query(
     "SELECT new fi.oph.vkt.repository.PublicExamEventProjection(e.id, e.language, e.date, e.registrationCloses," +
     " COUNT(en), e.maxParticipants)" +

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/PersonRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/PersonRepository.java
@@ -2,10 +2,9 @@ package fi.oph.vkt.repository;
 
 import fi.oph.vkt.model.Person;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PersonRepository extends JpaRepository<Person, Long> {
+public interface PersonRepository extends BaseRepository<Person> {
   Optional<Person> findByIdentityNumber(String identityNumber);
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/ReservationRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/ReservationRepository.java
@@ -8,12 +8,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.persistence.Tuple;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+public interface ReservationRepository extends BaseRepository<Reservation> {
   @Query(
     "SELECT e.id as examEventId, COUNT(r) as count FROM Reservation r" +
     " JOIN r.examEvent e" +

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicReservationService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicReservationService.java
@@ -1,8 +1,6 @@
 package fi.oph.vkt.service;
 
 import fi.oph.vkt.repository.ReservationRepository;
-import fi.oph.vkt.util.exception.NotFoundException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,10 +13,6 @@ public class PublicReservationService {
 
   @Transactional
   public void deleteReservation(final long reservationId) {
-    if (!reservationRepository.existsById(reservationId)) {
-      throw new NotFoundException(String.format("Reservation by id: %d not found", reservationId));
-    }
-
-    reservationRepository.deleteAllByIdInBatch(List.of(reservationId));
+    reservationRepository.deleteById(reservationId);
   }
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicReservationService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicReservationService.java
@@ -2,6 +2,7 @@ package fi.oph.vkt.service;
 
 import fi.oph.vkt.repository.ReservationRepository;
 import fi.oph.vkt.util.exception.NotFoundException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,10 +15,10 @@ public class PublicReservationService {
 
   @Transactional
   public void deleteReservation(final long reservationId) {
-    try {
-      reservationRepository.deleteById(reservationId);
-    } catch (final Exception e) {
-      throw new NotFoundException(String.format("Reservation by id:%d not found", reservationId));
+    if (!reservationRepository.existsById(reservationId)) {
+      throw new NotFoundException(String.format("Reservation by id: %d not found", reservationId));
     }
+
+    reservationRepository.deleteAllByIdInBatch(List.of(reservationId));
   }
 }


### PR DESCRIPTION
Korjattu PublicReservationServicen koodi siten, että VKT:n testit menevät CI:ssä läpi.

JPA repositoryn `deleteById` toteutuksen kanssa ollut aiemminkin ongelmaa siten, että testeissä entiteettiä ei aina poisteta muistinvaraisesta tietokannasta. Ajossa ko. toteutus on tainnut kuitenkin toimia ok. Sen sijaan `deleteAllByIdInBatch(List.of(id));` tyyppistä ratkaisua käytetty muuallakin yksittäisen entiteetin poistoon sen id:n perusteella ja toimii myös täällä vaikkei kaikista siistein ratkaisu olekaan.