### PR TITLE
VKT(Frontend): OPHVKTKEH-107 jonoon ilmoittautumisen UI

### DIFF
--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -38,14 +38,18 @@
             "part2": "Tämä sivu ohjaa sinut automaattisesti takaisin etusivulle. Jos mitään ei tapahdu voit klikata alla olevasta napista."
           },
           "successToast": "Ilmoittautuminen onnistui!",
-          "title": "Maksu on suoritettu."
+          "title": {
+            "queue": "Jonopaikka on varattu.",
+            "reservation": "Maksu on suoritettu."
+          }
         },
         "controlButtons": {
           "cancelDialog": {
             "description": "Haluatko peruuttaa ilmoittautumisen? Menetät täyttämäsi tiedot.",
             "title": "Peruuta ilmoittautuminen"
           },
-          "pay": "Siirry maksamaan"
+          "pay": "Siirry maksamaan",
+          "sendForm": "Lähetä lomake"
         },
         "examEventDetails": {
           "examDate": "Tutkintopäivä",
@@ -64,7 +68,8 @@
             "FillContactDetails": "Täytä yhteystietosi",
             "SelectExam": "Valitse tutkinto",
             "Preview": "Esikatsele",
-            "Pay": "Siirry maksamaan"
+            "Payment": "Siirry maksamaan",
+            "Done": "Valmis"
           }
         },
         "steps": {

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentComplete.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentComplete.tsx
@@ -19,6 +19,7 @@ export const PublicEnrollmentComplete = () => {
 
   const {
     enrollment: { email },
+    reservationDetails,
   } = useAppSelector(publicEnrollmentSelector);
 
   const dispatch = useAppDispatch();
@@ -45,7 +46,11 @@ export const PublicEnrollmentComplete = () => {
 
   return (
     <div className="rows gapped">
-      <H2>{t('title')}</H2>
+      <H2>
+        {reservationDetails?.reservation
+          ? t('title.reservation')
+          : t('title.queue')}
+      </H2>
       <Text>
         <strong>{`${t('description.part1')}: ${email}`}</strong>
       </Text>

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
@@ -139,7 +139,7 @@ export const PublicEnrollmentControlButtons = ({
       endIcon={<ArrowForwardIcon />}
       disabled={disableNext || isLoading}
     >
-      {t('pay')}
+      {reservationDetails.reservation ? t('pay') : t('sendForm')}
     </CustomButton>
   );
 

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentExamEventDetails.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentExamEventDetails.tsx
@@ -8,8 +8,10 @@ import { ExamEventUtils } from 'utils/examEvent';
 
 export const PublicEnrollmentExamEventDetails = ({
   examEvent,
+  showOpenings,
 }: {
   examEvent: PublicExamEvent;
+  showOpenings: boolean;
 }) => {
   const { t } = usePublicTranslation({
     keyPrefix: 'vkt.component.publicEnrollment.examEventDetails',
@@ -35,7 +37,9 @@ export const PublicEnrollmentExamEventDetails = ({
         <Text>{`${t('registrationCloses')}: ${DateUtils.formatOptionalDate(
           examEvent.registrationCloses
         )}`}</Text>
-        <Text>{`${t('openings')}: ${Math.max(examEvent.openings, 0)}`}</Text>
+        {showOpenings && (
+          <Text>{`${t('openings')}: ${Math.max(examEvent.openings, 0)}`}</Text>
+        )}
       </div>
     </div>
   );

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -9,6 +9,7 @@ import { PublicEnrollmentPaymentSum } from 'components/publicEnrollment/PublicEn
 import { PublicEnrollmentStepContents } from 'components/publicEnrollment/PublicEnrollmentStepContents';
 import { PublicEnrollmentStepper } from 'components/publicEnrollment/PublicEnrollmentStepper';
 import { useAppSelector } from 'configs/redux';
+import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
 import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
 
 export const PublicEnrollmentGrid = () => {
@@ -25,6 +26,8 @@ export const PublicEnrollmentGrid = () => {
   }
 
   const isLoading = status === APIResponseStatus.InProgress;
+  const isPreviewStepActive = activeStep === PublicEnrollmentFormStep.Preview;
+  const hasReservation = !!reservationDetails.reservation;
 
   const renderDesktopView = () => (
     <>
@@ -32,9 +35,13 @@ export const PublicEnrollmentGrid = () => {
         <Paper elevation={3}>
           <LoadingProgressIndicator isLoading={isLoading} displayBlock={true}>
             <div className="public-enrollment__grid__form-container">
-              <PublicEnrollmentStepper activeStep={activeStep} />
+              <PublicEnrollmentStepper
+                activeStep={activeStep}
+                includePaymentStep={hasReservation}
+              />
               <PublicEnrollmentExamEventDetails
                 examEvent={reservationDetails.examEvent}
+                showOpenings={hasReservation}
               />
               <PublicEnrollmentStepContents
                 activeStep={activeStep}
@@ -42,10 +49,9 @@ export const PublicEnrollmentGrid = () => {
                 isLoading={isLoading}
                 disableNext={disableNextCb}
               />
-              <PublicEnrollmentPaymentSum
-                activeStep={activeStep}
-                enrollment={enrollment}
-              />
+              {isPreviewStepActive && hasReservation && (
+                <PublicEnrollmentPaymentSum enrollment={enrollment} />
+              )}
               <PublicEnrollmentControlButtons
                 activeStep={activeStep}
                 enrollment={enrollment}

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentPaymentSum.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentPaymentSum.tsx
@@ -1,15 +1,12 @@
 import { H1 } from 'shared/components';
 
 import { usePublicTranslation } from 'configs/i18n';
-import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
 import { PublicEnrollment } from 'interfaces/publicEnrollment';
 import { PublicEnrollmentUtils } from 'utils/publicEnrollment';
 
 export const PublicEnrollmentPaymentSum = ({
-  activeStep,
   enrollment,
 }: {
-  activeStep: PublicEnrollmentFormStep;
   enrollment: PublicEnrollment;
 }) => {
   const { t } = usePublicTranslation({
@@ -21,12 +18,8 @@ export const PublicEnrollmentPaymentSum = ({
   const content = `${t('title')}: ${sum.toFixed(2).replace('.', ',')} €`;
 
   return (
-    <>
-      {activeStep === PublicEnrollmentFormStep.Preview ? (
-        <div className="columns flex-end">
-          <H1 className="margin-top-lg">{content}</H1>
-        </div>
-      ) : null}
-    </>
+    <div className="columns flex-end">
+      <H1 className="margin-top-lg">{content}</H1>
+    </div>
   );
 };

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
@@ -42,7 +42,7 @@ export const PublicEnrollmentStepContents = ({
           disableNext={disableNext}
         />
       );
-    case PublicEnrollmentFormStep.Pay:
+    case PublicEnrollmentFormStep.Payment:
       return <></>;
     default:
       return <> </>;

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepper.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepper.tsx
@@ -5,16 +5,23 @@ import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
 
 export const PublicEnrollmentStepper = ({
   activeStep,
+  includePaymentStep,
 }: {
   activeStep: PublicEnrollmentFormStep;
+  includePaymentStep: boolean;
 }) => {
   const { t } = usePublicTranslation({
     keyPrefix: 'vkt.component.publicEnrollment.stepper',
   });
 
-  const getStepNumbers = Object.values(PublicEnrollmentFormStep)
+  const doneStepNumber = includePaymentStep
+    ? PublicEnrollmentFormStep.Done
+    : PublicEnrollmentFormStep.Done - 1;
+
+  const stepNumbers = Object.values(PublicEnrollmentFormStep)
     .filter((i) => !isNaN(Number(i)))
-    .map(Number);
+    .map(Number)
+    .filter((i) => i <= doneStepNumber);
 
   const getStatusText = (stepNumber: number) => {
     if (stepNumber < activeStep) {
@@ -24,11 +31,17 @@ export const PublicEnrollmentStepper = ({
     }
   };
 
-  const getDescription = (stepNumber: number) =>
-    t(`step.${PublicEnrollmentFormStep[stepNumber]}`);
+  const getDescription = (stepNumber: number) => {
+    const i =
+      !includePaymentStep && stepNumber >= PublicEnrollmentFormStep.Payment
+        ? stepNumber + 1
+        : stepNumber;
+
+    return t(`step.${PublicEnrollmentFormStep[i]}`);
+  };
 
   const getStepAriaLabel = (stepNumber: number) => {
-    const part = `${stepNumber}/${Math.max(...getStepNumbers)}`;
+    const part = `${stepNumber}/${stepNumbers.length}`;
     const statusText = getStatusText(stepNumber);
     const partStatus = statusText ? `${part}, ${statusText}` : part;
 
@@ -40,7 +53,7 @@ export const PublicEnrollmentStepper = ({
       className="public-enrollment__grid__stepper"
       activeStep={activeStep - 1}
     >
-      {getStepNumbers.map((i) => (
+      {stepNumbers.map((i) => (
         <Step key={i}>
           <StepLabel
             aria-label={getStepAriaLabel(i)}

--- a/frontend/packages/vkt/src/enums/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/enums/publicEnrollment.ts
@@ -3,5 +3,6 @@ export enum PublicEnrollmentFormStep {
   FillContactDetails,
   SelectExam,
   Preview,
-  Pay,
+  Payment,
+  Done,
 }


### PR DESCRIPTION
## Yhteenveto

Alustava käyttöliittymä jonoon ilmoittautumiseen desktopilla. Toteutettu omien Figman slideihin jättämien kommenttieni perusteella. Lisäsin myös stepin "Valmis" stepperkomponenttiin, joka näytetään myös ilmoittautuessa tutkintoon. AKR:n yhteydenottopyynnön mallin mukaisesti stepper olisi myös "Maksu on suoritettu." -näkymässä näkyvillä ja jätin tuosta myös kommentin slideihin haluaisko sen muuttaa tuollaiseen muotoon, mutta en tässä kohtaa ko. stepperiä valmis-sivulle lisännyt.
