### PR TITLE
AKR(Backend): OPHAKRKEH-481 BaseRepository added

### DIFF
--- a/backend/akr/src/main/java/fi/oph/akr/repository/AuthorisationRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/AuthorisationRepository.java
@@ -5,12 +5,11 @@ import fi.oph.akr.model.AuthorisationBasis;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AuthorisationRepository extends JpaRepository<Authorisation, Long> {
+public interface AuthorisationRepository extends BaseRepository<Authorisation> {
   @Query(
     "SELECT new fi.oph.akr.repository.AuthorisationProjection(a.id, a.version, a.translator.id, a.basis," +
     " a.diaryNumber, a.fromLang, a.toLang, a.permissionToPublish, a.termBeginDate, a.termEndDate, e.date)" +

--- a/backend/akr/src/main/java/fi/oph/akr/repository/AuthorisationTermReminderRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/AuthorisationTermReminderRepository.java
@@ -1,8 +1,7 @@
 package fi.oph.akr.repository;
 
 import fi.oph.akr.model.AuthorisationTermReminder;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AuthorisationTermReminderRepository extends JpaRepository<AuthorisationTermReminder, Long> {}
+public interface AuthorisationTermReminderRepository extends BaseRepository<AuthorisationTermReminder> {}

--- a/backend/akr/src/main/java/fi/oph/akr/repository/BaseRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/BaseRepository.java
@@ -1,0 +1,26 @@
+package fi.oph.akr.repository;
+
+import fi.oph.akr.util.exception.NotFoundException;
+import java.util.List;
+import lombok.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+@NoRepositoryBean
+public interface BaseRepository<T> extends JpaRepository<T, Long> {
+  /**
+   * Overwrites `deleteById` defined by `CrudRepository`. Deletion is done via
+   * `deleteAllByIdInBatch` because overwritten `deleteById` doesn't seem functional with
+   * HSQL test database.
+   *
+   * @param id must not be {@literal null}.
+   */
+  @Override
+  default void deleteById(final @NonNull Long id) {
+    if (!this.existsById(id)) {
+      throw new NotFoundException(String.format("Entity by id: %d not found", id));
+    }
+
+    this.deleteAllByIdInBatch(List.of(id));
+  }
+}

--- a/backend/akr/src/main/java/fi/oph/akr/repository/ContactRequestRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/ContactRequestRepository.java
@@ -3,12 +3,11 @@ package fi.oph.akr.repository;
 import fi.oph.akr.model.ContactRequest;
 import java.time.LocalDateTime;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ContactRequestRepository extends JpaRepository<ContactRequest, Long> {
+public interface ContactRequestRepository extends BaseRepository<ContactRequest> {
   @Query("SELECT cr FROM ContactRequest cr WHERE cr.createdAt < ?1")
   List<ContactRequest> findObsoleteContactRequests(LocalDateTime createdBefore);
 }

--- a/backend/akr/src/main/java/fi/oph/akr/repository/ContactRequestStatisticRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/ContactRequestStatisticRepository.java
@@ -5,12 +5,11 @@ import fi.oph.akr.model.ContactRequestStatistic;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Triple;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ContactRequestStatisticRepository extends JpaRepository<ContactRequestStatistic, Long> {
+public interface ContactRequestStatisticRepository extends BaseRepository<ContactRequestStatistic> {
   @Query(
     "SELECT new org.apache.commons.lang3.tuple.ImmutableTriple(c.year, c.month, c.day) FROM ContactRequestStatistic c"
   )

--- a/backend/akr/src/main/java/fi/oph/akr/repository/ContactRequestTranslatorRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/ContactRequestTranslatorRepository.java
@@ -1,8 +1,7 @@
 package fi.oph.akr.repository;
 
 import fi.oph.akr.model.ContactRequestTranslator;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ContactRequestTranslatorRepository extends JpaRepository<ContactRequestTranslator, Long> {}
+public interface ContactRequestTranslatorRepository extends BaseRepository<ContactRequestTranslator> {}

--- a/backend/akr/src/main/java/fi/oph/akr/repository/EmailRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/EmailRepository.java
@@ -5,12 +5,11 @@ import fi.oph.akr.model.EmailType;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EmailRepository extends JpaRepository<Email, Long> {
+public interface EmailRepository extends BaseRepository<Email> {
   @Query("SELECT e.id FROM Email e WHERE e.sentAt IS NULL ORDER BY e.modifiedAt asc")
   List<Long> findEmailsToSend(PageRequest pageRequest);
 

--- a/backend/akr/src/main/java/fi/oph/akr/repository/EmailStatisticRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/EmailStatisticRepository.java
@@ -5,12 +5,11 @@ import fi.oph.akr.model.EmailStatistic;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Triple;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EmailStatisticRepository extends JpaRepository<EmailStatistic, Long> {
+public interface EmailStatisticRepository extends BaseRepository<EmailStatistic> {
   @Query("SELECT new org.apache.commons.lang3.tuple.ImmutableTriple(c.year, c.month, c.day) FROM EmailStatistic c")
   Set<Triple<Integer, Integer, Integer>> listExistingStatisticDates();
 

--- a/backend/akr/src/main/java/fi/oph/akr/repository/ExaminationDateRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/ExaminationDateRepository.java
@@ -2,10 +2,9 @@ package fi.oph.akr.repository;
 
 import fi.oph.akr.model.ExaminationDate;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ExaminationDateRepository extends JpaRepository<ExaminationDate, Long> {
+public interface ExaminationDateRepository extends BaseRepository<ExaminationDate> {
   List<ExaminationDate> findAllByOrderByDateDesc();
 }

--- a/backend/akr/src/main/java/fi/oph/akr/repository/MeetingDateRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/MeetingDateRepository.java
@@ -2,11 +2,10 @@ package fi.oph.akr.repository;
 
 import fi.oph.akr.model.MeetingDate;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MeetingDateRepository extends JpaRepository<MeetingDate, Long> {
+public interface MeetingDateRepository extends BaseRepository<MeetingDate> {
   List<MeetingDate> findAllByOrderByDateAsc();
   List<MeetingDate> findAllByOrderByDateDesc();
 }

--- a/backend/akr/src/main/java/fi/oph/akr/repository/TranslatorRepository.java
+++ b/backend/akr/src/main/java/fi/oph/akr/repository/TranslatorRepository.java
@@ -2,10 +2,9 @@ package fi.oph.akr.repository;
 
 import fi.oph.akr.model.Translator;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TranslatorRepository extends JpaRepository<Translator, Long> {
+public interface TranslatorRepository extends BaseRepository<Translator> {
   List<Translator> findAllByOrderByLastNameAscFirstNameAsc();
 }

--- a/backend/akr/src/main/java/fi/oph/akr/service/ClerkTranslatorService.java
+++ b/backend/akr/src/main/java/fi/oph/akr/service/ClerkTranslatorService.java
@@ -301,7 +301,7 @@ public class ClerkTranslatorService {
 
     authorisationTermReminderRepository.deleteAllInBatch(reminders);
     authorisationRepository.deleteAllInBatch(authorisations);
-    translatorRepository.deleteAllInBatch(List.of(translator));
+    translatorRepository.deleteById(translatorId);
 
     auditService.logById(AkrOperation.DELETE_TRANSLATOR, translatorId);
   }
@@ -420,7 +420,7 @@ public class ClerkTranslatorService {
     final Collection<AuthorisationTermReminder> reminders = authorisation.getReminders();
 
     authorisationTermReminderRepository.deleteAllInBatch(reminders);
-    authorisationRepository.deleteAllInBatch(List.of(authorisation));
+    authorisationRepository.deleteById(authorisationId);
 
     final ClerkTranslatorDTO result = getTranslatorWithoutAudit(translator.getId());
     auditService.logAuthorisation(AkrOperation.DELETE_AUTHORISATION, translator, authorisationId);

--- a/backend/akr/src/main/java/fi/oph/akr/service/ExaminationDateService.java
+++ b/backend/akr/src/main/java/fi/oph/akr/service/ExaminationDateService.java
@@ -49,7 +49,7 @@ public class ExaminationDateService {
     if (!examinationDate.getAuthorisations().isEmpty()) {
       throw new APIException(APIExceptionType.EXAMINATION_DATE_DELETE_HAS_AUTHORISATIONS);
     }
-    examinationDateRepository.deleteAllByIdInBatch(List.of(examinationDateId));
+    examinationDateRepository.deleteById(examinationDateId);
 
     auditService.logById(AkrOperation.DELETE_EXAMINATION_DATE, examinationDateId);
   }

--- a/backend/akr/src/main/java/fi/oph/akr/service/MeetingDateService.java
+++ b/backend/akr/src/main/java/fi/oph/akr/service/MeetingDateService.java
@@ -71,7 +71,7 @@ public class MeetingDateService {
     if (!meetingDate.getAuthorisations().isEmpty()) {
       throw new APIException(APIExceptionType.MEETING_DATE_DELETE_HAS_AUTHORISATIONS);
     }
-    meetingDateRepository.deleteAllByIdInBatch(List.of(meetingDateId));
+    meetingDateRepository.deleteById(meetingDateId);
 
     auditService.logById(AkrOperation.DELETE_MEETING_DATE, meetingDateId);
   }


### PR DESCRIPTION
## Yhteenveto

Samanlainen BaseRepositoryn lisäys kuin tehty VKT:n päähän: https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/commit/a59f10894b833c1df6b645e5b1035e30d2330eb0. Tuolla korjattiin ongelma CrudRepositoryn `deleteById`:n kanssa, jota ei AKR:ssä aiemmin käytettykään. Ei siis aiheuta funktionaalisia muutoksia.