### PR TITLE
OTR(Backend): OPHOTRKEH-197 BaseRepository added

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/repository/BaseRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/BaseRepository.java
@@ -1,0 +1,26 @@
+package fi.oph.otr.repository;
+
+import fi.oph.otr.util.exception.NotFoundException;
+import java.util.List;
+import lombok.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+@NoRepositoryBean
+public interface BaseRepository<T> extends JpaRepository<T, Long> {
+  /**
+   * Overwrites `deleteById` defined by `CrudRepository`. Deletion is done via
+   * `deleteAllByIdInBatch` because overwritten `deleteById` doesn't seem functional with
+   * HSQL test database.
+   *
+   * @param id must not be {@literal null}.
+   */
+  @Override
+  default void deleteById(final @NonNull Long id) {
+    if (!this.existsById(id)) {
+      throw new NotFoundException(String.format("Entity by id: %d not found", id));
+    }
+
+    this.deleteAllByIdInBatch(List.of(id));
+  }
+}

--- a/backend/otr/src/main/java/fi/oph/otr/repository/EmailRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/EmailRepository.java
@@ -3,12 +3,11 @@ package fi.oph.otr.repository;
 import fi.oph.otr.model.Email;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EmailRepository extends JpaRepository<Email, Long> {
+public interface EmailRepository extends BaseRepository<Email> {
   @Query("SELECT e.id FROM Email e WHERE e.sentAt IS NULL ORDER BY e.modifiedAt asc")
   List<Long> findEmailsToSend(PageRequest pageRequest);
 }

--- a/backend/otr/src/main/java/fi/oph/otr/repository/InterpreterRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/InterpreterRepository.java
@@ -2,12 +2,11 @@ package fi.oph.otr.repository;
 
 import fi.oph.otr.model.Interpreter;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface InterpreterRepository extends JpaRepository<Interpreter, Long> {
+public interface InterpreterRepository extends BaseRepository<Interpreter> {
   @Query("SELECT i.onrId FROM Interpreter i")
   List<String> listAllOnrIds();
 }

--- a/backend/otr/src/main/java/fi/oph/otr/repository/MeetingDateRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/MeetingDateRepository.java
@@ -2,10 +2,9 @@ package fi.oph.otr.repository;
 
 import fi.oph.otr.model.MeetingDate;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MeetingDateRepository extends JpaRepository<MeetingDate, Long> {
+public interface MeetingDateRepository extends BaseRepository<MeetingDate> {
   List<MeetingDate> findAllByOrderByDateDesc();
 }

--- a/backend/otr/src/main/java/fi/oph/otr/repository/QualificationReminderRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/QualificationReminderRepository.java
@@ -1,8 +1,7 @@
 package fi.oph.otr.repository;
 
 import fi.oph.otr.model.QualificationReminder;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface QualificationReminderRepository extends JpaRepository<QualificationReminder, Long> {}
+public interface QualificationReminderRepository extends BaseRepository<QualificationReminder> {}

--- a/backend/otr/src/main/java/fi/oph/otr/repository/QualificationRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/QualificationRepository.java
@@ -5,12 +5,11 @@ import fi.oph.otr.model.Qualification;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface QualificationRepository extends JpaRepository<Qualification, Long> {
+public interface QualificationRepository extends BaseRepository<Qualification> {
   @Query(
     "SELECT q" +
     " FROM Qualification q" +

--- a/backend/otr/src/main/java/fi/oph/otr/repository/RegionRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/RegionRepository.java
@@ -2,12 +2,11 @@ package fi.oph.otr.repository;
 
 import fi.oph.otr.model.Region;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RegionRepository extends JpaRepository<Region, Long> {
+public interface RegionRepository extends BaseRepository<Region> {
   @Query(
     "SELECT new fi.oph.otr.repository.InterpreterRegionProjection(i.id, r.code)" +
     " FROM Interpreter i" +

--- a/backend/otr/src/main/java/fi/oph/otr/service/MeetingDateService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/MeetingDateService.java
@@ -75,7 +75,7 @@ public class MeetingDateService {
     if (!meetingDate.getQualifications().isEmpty()) {
       throw new APIException(APIExceptionType.MEETING_DATE_DELETE_HAS_QUALIFICATIONS);
     }
-    meetingDateRepository.deleteAllByIdInBatch(List.of(meetingDateId));
+    meetingDateRepository.deleteById(meetingDateId);
 
     auditService.logById(OtrOperation.DELETE_MEETING_DATE, meetingDateId);
   }


### PR DESCRIPTION
## Yhteenveto

Vastaava toteutus kuin AKR:ää varten avattu PR https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/384.
OTR:ssä tulkin ja rekisteröintien poisto toteutettu soft deletenä, sillä nykyisessä rekisterissä nämä myös soft deletellä merkitty, jotka poistettu. Näin ollen uusi `deleteById` toteutus otettu vain kokouspäivien osalta käyttöön vs. AKR:n PR:ssä myös auktorisointien ja kääntäjän poistorajapinnoissa.