### PR TITLE
OTR(Frontend): OPHOTRKEH-203 added missing APIErrors

### DIFF
--- a/frontend/packages/otr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/otr/public/i18n/en-GB/translation.json
@@ -267,11 +267,17 @@
       "api": {
         "generic": "The action failed, please try again later",
         "interpreterInvalidNickName": null,
+        "interpreterOnrIdAndIndividualisedMismatch": null,
+        "interpreterRegionUnknown": null,
         "invalidVersion": "The action failed because you tried to modify outdated data. Please refresh the page and try again later if necessary.",
         "meetingDateCreateDuplicateDate": "Failed to add the meeting day because the selected date is already a meeting day",
         "meetingDateDeleteHasQualifications": null,
         "meetingDateUpdateDuplicateDate": "Failed to modify the meeting day failed because the selected date is already a meeting day",
-        "meetingDateUpdateHasQualifications": null
+        "meetingDateUpdateHasQualifications": null,
+        "qualificationDeleteLastQualification": null,
+        "qualificationInvalidTerm": null,
+        "qualificationLanguageUnknown": null,
+        "qualificationMissingMeetingDate": null
       },
       "customTextField": {
         "emailFormat": "The email address is incorrect",

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -267,11 +267,17 @@
       "api": {
         "generic": "Toiminto epäonnistui, yritä myöhemmin uudelleen",
         "interpreterInvalidNickName": "Kutsumanimen tulee olla jokin etunimistä",
+        "interpreterOnrIdAndIndividualisedMismatch": "Oppijanumero ja tietojen VTJ-yksilöinti ovat ristiriidassa keskenään",
+        "interpreterRegionUnknown": "Toiminto epäonnistui, tarkista maakunnat",
         "invalidVersion": "Toiminto epäonnistui, koska yritit muuttaa vanhentunutta dataa. Päivitä sivu ja yritä tarvittaessa uudelleen.",
         "meetingDateCreateDuplicateDate": "Kokouspäivän lisäys epäonnistui, koska valitulla päivämäärällä on jo kokouspäivä",
         "meetingDateDeleteHasQualifications": "Kokouspäivän poisto epäonnistui, koska sille on kirjattu rekisteröintejä",
         "meetingDateUpdateDuplicateDate": "Kokouspäivän muokkaus epäonnistui, koska valitulla päivämäärällä on jo kokouspäivä",
-        "meetingDateUpdateHasQualifications": "Kokouspäivän muokkaus epäonnistui, koska sille on kirjattu rekisteröintejä"
+        "meetingDateUpdateHasQualifications": "Kokouspäivän muokkaus epäonnistui, koska sille on kirjattu rekisteröintejä",
+        "qualificationDeleteLastQualification": "Rekisteröinnin poisto epäonnistui, koska tulkin viimeistä rekisteröintiä ei voi poistaa",
+        "qualificationInvalidTerm": "Toiminto epäonnistui, rekisteröinnillä virheellinen voimassaoloaika",
+        "qualificationLanguageUnknown": "Toiminto epäonnistui, rekisteröinnillä tuntematon kieli",
+        "qualificationMissingMeetingDate": "Rekisteröinnin lisäys/muokkaus epäonnistui, koska valitulla päivämäärällä ei ole kokouspäivää"
       },
       "customTextField": {
         "emailFormat": "Sähköpostiosoite on virheellinen",

--- a/frontend/packages/otr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/translation.json
@@ -267,11 +267,17 @@
       "api": {
         "generic": "Funktionen misslyckades, försök på nytt senare",
         "interpreterInvalidNickName": null,
+        "interpreterOnrIdAndIndividualisedMismatch": null,
+        "interpreterRegionUnknown": null,
         "invalidVersion": "Funktionen misslyckades därför att du försökte att ändra förlegad data. Uppdatera sidan och försöka vid behov igen.",
         "meetingDateCreateDuplicateDate": "Det gick inte lägga till mötesdagen eftersom det valda datumet redan är ett mötesdatum",
         "meetingDateDeleteHasQualifications": null,
         "meetingDateUpdateDuplicateDate": "Mötesdagen kunde inte redigeras eftersom det valda datumet redan är en mötesdag",
-        "meetingDateUpdateHasQualifications": null
+        "meetingDateUpdateHasQualifications": null,
+        "qualificationDeleteLastQualification": null,
+        "qualificationInvalidTerm": null,
+        "qualificationLanguageUnknown": null,
+        "qualificationMissingMeetingDate": null
       },
       "customTextField": {
         "emailFormat": "E-postadressen är felaktig",

--- a/frontend/packages/otr/src/enums/api.ts
+++ b/frontend/packages/otr/src/enums/api.ts
@@ -13,9 +13,15 @@ export enum APIEndpoints {
  */
 export enum APIError {
   InterpreterInvalidNickName = 'interpreterInvalidNickName',
+  InterpreterOnrIdAndIndividualisedMismatch = 'interpreterOnrIdAndIndividualisedMismatch',
+  InterpreterRegionUnknown = 'interpreterRegionUnknown',
   InvalidVersion = 'invalidVersion',
   MeetingDateCreateDuplicateDate = 'meetingDateCreateDuplicateDate',
   MeetingDateDeleteHasQualifications = 'meetingDateDeleteHasQualifications',
   MeetingDateUpdateDuplicateDate = 'meetingDateUpdateDuplicateDate',
   MeetingDateUpdateHasQualifications = 'meetingDateUpdateHasQualifications',
+  QualificationDeleteLastQualification = 'qualificationDeleteLastQualification',
+  QualificationInvalidTerm = 'qualificationInvalidTerm',
+  QualificationLanguageUnknown = 'qualificationLanguageUnknown',
+  QualificationMissingMeetingDate = 'qualificationMissingMeetingDate',
 }


### PR DESCRIPTION
## Yhteenveto

Tuli havaittua OTR:ää pyöritellessä että rekisteröinnin poiston yhteydessä näytettiin geneerinen virheilmoitus. Tuo sekä kasa muita APIExceptioneja olivat sellaisia, joita frontend ei toistaiseksi handlannut. Lisätty noita varten APIErrorit sekä suomenkieliset käännökset. Muita noista virheistä ei pitäisi kovin helposti saamaan käyttöliittymän kautta näkymäänkään jos edes pystyy.

## Check-lista
- [x] Käännösten Excel-tiedosto päivitetty
