### PR TITLE
AKR(Backend): OPHAKRKEH-480 language pair added to contact request mails

### DIFF
--- a/backend/akr/src/main/java/fi/oph/akr/service/ContactRequestService.java
+++ b/backend/akr/src/main/java/fi/oph/akr/service/ContactRequestService.java
@@ -13,7 +13,9 @@ import fi.oph.akr.repository.EmailRepository;
 import fi.oph.akr.repository.TranslatorRepository;
 import fi.oph.akr.service.email.EmailData;
 import fi.oph.akr.service.email.EmailService;
+import fi.oph.akr.service.koodisto.LanguageService;
 import fi.oph.akr.util.TemplateRenderer;
+import fi.oph.akr.util.localisation.Language;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -38,6 +40,7 @@ public class ContactRequestService {
   private final ContactRequestTranslatorRepository contactRequestTranslatorRepository;
   private final EmailRepository emailRepository;
   private final EmailService emailService;
+  private final LanguagePairService languagePairService;
   private final TemplateRenderer templateRenderer;
   private final TranslatorRepository translatorRepository;
   private final Environment environment;
@@ -118,6 +121,10 @@ public class ContactRequestService {
 
   private void sendTranslatorEmails(final List<Translator> translators, final ContactRequestDTO contactRequestDTO) {
     final Map<String, Object> templateParams = Map.of(
+      "langPairFI",
+      getLangPair(contactRequestDTO, Language.FI),
+      "langPairSV",
+      getLangPair(contactRequestDTO, Language.SV),
       "requesterName",
       getRequesterName(contactRequestDTO),
       "requesterEmail",
@@ -147,6 +154,12 @@ public class ContactRequestService {
     final Map<String, Object> templateParams = Map.of(
       "translators",
       translators.stream().map(Translator::getFullName).sorted().toList(),
+      "langPairFI",
+      getLangPair(contactRequestDTO, Language.FI),
+      "langPairSV",
+      getLangPair(contactRequestDTO, Language.SV),
+      "langPairEN",
+      getLangPair(contactRequestDTO, Language.EN),
       "requesterName",
       getRequesterName(contactRequestDTO),
       "requesterEmail",
@@ -174,6 +187,8 @@ public class ContactRequestService {
     final Map<String, Object> templateParams = Map.of(
       "translators",
       translatorParams,
+      "langPairFI",
+      getLangPair(contactRequestDTO, Language.FI),
       "requesterName",
       getRequesterName(contactRequestDTO),
       "requesterEmail",
@@ -190,6 +205,14 @@ public class ContactRequestService {
     final String body = templateRenderer.renderContactRequestClerkEmailBody(templateParams);
 
     createEmail(recipientName, recipientAddress, subject, body, EmailType.CONTACT_REQUEST_CLERK);
+  }
+
+  private String getLangPair(final ContactRequestDTO contactRequestDTO, final Language language) {
+    return languagePairService.getLanguagePairLocalisation(
+      contactRequestDTO.fromLang(),
+      contactRequestDTO.toLang(),
+      language
+    );
   }
 
   private String getRequesterName(final ContactRequestDTO contactRequestDTO) {

--- a/backend/akr/src/main/java/fi/oph/akr/service/LanguagePairService.java
+++ b/backend/akr/src/main/java/fi/oph/akr/service/LanguagePairService.java
@@ -1,0 +1,25 @@
+package fi.oph.akr.service;
+
+import fi.oph.akr.service.koodisto.LanguageService;
+import fi.oph.akr.util.localisation.Language;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LanguagePairService {
+
+  private final LanguageService languageService;
+
+  public String getLanguagePairLocalisation(
+    final String fromLangCode,
+    final String toLangCode,
+    final Language language
+  ) {
+    return (
+      languageService.getLocalisationValue(fromLangCode, language).orElse(fromLangCode) +
+      " - " +
+      languageService.getLocalisationValue(toLangCode, language).orElse(toLangCode)
+    );
+  }
+}

--- a/backend/akr/src/main/java/fi/oph/akr/service/email/ClerkEmailService.java
+++ b/backend/akr/src/main/java/fi/oph/akr/service/email/ClerkEmailService.java
@@ -12,7 +12,7 @@ import fi.oph.akr.repository.AuthorisationTermReminderRepository;
 import fi.oph.akr.repository.EmailRepository;
 import fi.oph.akr.repository.MeetingDateRepository;
 import fi.oph.akr.repository.TranslatorRepository;
-import fi.oph.akr.service.koodisto.LanguageService;
+import fi.oph.akr.service.LanguagePairService;
 import fi.oph.akr.util.TemplateRenderer;
 import fi.oph.akr.util.localisation.Language;
 import java.time.LocalDate;
@@ -20,7 +20,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,28 +30,13 @@ public class ClerkEmailService {
 
   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy");
 
-  @Resource
   private final AuthorisationRepository authorisationRepository;
-
-  @Resource
   private final AuthorisationTermReminderRepository authorisationTermReminderRepository;
-
-  @Resource
   private final EmailRepository emailRepository;
-
-  @Resource
   private final EmailService emailService;
-
-  @Resource
-  private final LanguageService languageService;
-
-  @Resource
+  private final LanguagePairService languagePairService;
   private final MeetingDateRepository meetingDateRepository;
-
-  @Resource
   private final TemplateRenderer templateRenderer;
-
-  @Resource
   private final TranslatorRepository translatorRepository;
 
   @Transactional
@@ -147,15 +131,8 @@ public class ClerkEmailService {
     final String toLangCode,
     final LocalDate expiryDate
   ) {
-    final String langPairFI =
-      languageService.getLocalisationValue(fromLangCode, Language.FI).orElse(fromLangCode) +
-      " - " +
-      languageService.getLocalisationValue(toLangCode, Language.FI).orElse(toLangCode);
-
-    final String langPairSV =
-      languageService.getLocalisationValue(fromLangCode, Language.SV).orElse(fromLangCode) +
-      " - " +
-      languageService.getLocalisationValue(toLangCode, Language.SV).orElse(toLangCode);
+    final String langPairFI = languagePairService.getLanguagePairLocalisation(fromLangCode, toLangCode, Language.FI);
+    final String langPairSV = languagePairService.getLanguagePairLocalisation(fromLangCode, toLangCode, Language.SV);
 
     final List<LocalDate> upcomingDates = meetingDateRepository
       .findAllByOrderByDateAsc()

--- a/backend/akr/src/main/resources/email-templates/contact-request-clerk.html
+++ b/backend/akr/src/main/resources/email-templates/contact-request-clerk.html
@@ -5,7 +5,7 @@
             Hei,
         </p>
         <p>
-            [[${requesterName}]] (email: [[${requesterEmail}]], puh.: [[${requesterPhone}]]) lähetti yhteydenottopyynnön seuraaville kääntäjille, joiden sähköpostiosoite ei ollut tiedossa:
+            [[${requesterName}]] (email: [[${requesterEmail}]], puh.: [[${requesterPhone}]]) lähetti yhteydenottopyynnön kieliparia [[${langPairFI}]] koskien seuraaville kääntäjille, joiden sähköpostiosoite ei ollut tiedossa:
         </p>
         <ul th:each="translator : ${translators}">
             <li><a th:href="@{https://{akrHost}/akr/virkailija/kaantaja/{id}(akrHost=${akrHost},id=${translator.id})}">[[${translator.name}]]</a></li>

--- a/backend/akr/src/main/resources/email-templates/contact-request-requester.html
+++ b/backend/akr/src/main/resources/email-templates/contact-request-requester.html
@@ -5,7 +5,7 @@
             Hei,
         </p>
         <p>
-            Olet ottanut yhteyttä seuraaviin auktorisoituihin kääntäjiin käännöstoimeksiantoa varten:
+            Olet ottanut yhteyttä seuraaviin auktorisoituihin kääntäjiin kieliparin [[${langPairFI}]] käännöstoimeksiantoa varten:
         </p>
         <ul>
             <li th:each="name : ${translators}">[[${name}]]</li>
@@ -38,7 +38,7 @@
             Hej,
         </p>
         <p>
-            Du har kontaktat följande auktoriserade translatorer gällande ett översättningsuppdrag:
+            Du har kontaktat följande auktoriserade translatorer gällande ett översättningsuppdrag i språkparet [[${langPairSV}]]:
         </p>
         <ul>
             <li th:each="name : ${translators}">[[${name}]]</li>
@@ -71,7 +71,7 @@
             Hello,
         </p>
         <p>
-            You have contacted following authorised translators for translation assignment:
+            You have contacted following authorised translators for language pair [[${langPairEN}]] translation assignment:
         </p>
         <ul>
             <li th:each="name : ${translators}">[[${name}]]</li>

--- a/backend/akr/src/main/resources/email-templates/contact-request-translator.html
+++ b/backend/akr/src/main/resources/email-templates/contact-request-translator.html
@@ -5,7 +5,7 @@
             Hei,
         </p>
         <p>
-            Sinuun on otettu yhteyttä käännöstoimeksiantoa varten. Ohessa sinulle jätetty viesti ja tiedot sen lähettäjästä.
+            Sinuun on otettu yhteyttä kieliparin [[${langPairFI}]] käännöstoimeksiantoa varten. Ohessa sinulle jätetty viesti ja tiedot sen lähettäjästä.
         </p>
         <br/>
 
@@ -33,7 +33,7 @@
             Hej,
         </p>
         <p>
-            Du har blivit kontaktad gällande ett översättningsuppdrag. Nere meddelandet, som har lämnats till dig.
+            Du har blivit kontaktad gällande ett översättningsuppdrag i språkparet [[${langPairSV}]]. Nere meddelandet, som har lämnats till dig.
         </p>
         <br/>
 

--- a/backend/akr/src/test/java/fi/oph/akr/service/ContactRequestServiceTest.java
+++ b/backend/akr/src/test/java/fi/oph/akr/service/ContactRequestServiceTest.java
@@ -25,6 +25,7 @@ import fi.oph.akr.repository.EmailRepository;
 import fi.oph.akr.repository.TranslatorRepository;
 import fi.oph.akr.service.email.EmailData;
 import fi.oph.akr.service.email.EmailService;
+import fi.oph.akr.service.koodisto.LanguageService;
 import fi.oph.akr.util.TemplateRenderer;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -87,6 +88,10 @@ class ContactRequestServiceTest {
 
   @BeforeEach
   public void setup() {
+    final LanguageService languageService = new LanguageService();
+    languageService.init();
+    final LanguagePairService languagePairService = new LanguagePairService(languageService);
+
     when(templateRenderer.renderContactRequestTranslatorEmailBody(any())).thenReturn("<html>translator</html>");
     when(templateRenderer.renderContactRequestRequesterEmailBody(any())).thenReturn("<html>requester</html>");
     when(templateRenderer.renderContactRequestClerkEmailBody(any())).thenReturn("<html>clerk</html>");
@@ -98,6 +103,7 @@ class ContactRequestServiceTest {
         contactRequestTranslatorRepository,
         emailRepository,
         emailService,
+        languagePairService,
         templateRenderer,
         translatorRepository,
         environment

--- a/backend/akr/src/test/java/fi/oph/akr/service/email/ClerkEmailServiceTest.java
+++ b/backend/akr/src/test/java/fi/oph/akr/service/email/ClerkEmailServiceTest.java
@@ -18,6 +18,7 @@ import fi.oph.akr.repository.AuthorisationTermReminderRepository;
 import fi.oph.akr.repository.EmailRepository;
 import fi.oph.akr.repository.MeetingDateRepository;
 import fi.oph.akr.repository.TranslatorRepository;
+import fi.oph.akr.service.LanguagePairService;
 import fi.oph.akr.service.koodisto.LanguageService;
 import fi.oph.akr.util.TemplateRenderer;
 import java.time.LocalDate;
@@ -72,6 +73,7 @@ public class ClerkEmailServiceTest {
   public void setup() {
     final LanguageService languageService = new LanguageService();
     languageService.init();
+    final LanguagePairService languagePairService = new LanguagePairService(languageService);
 
     clerkEmailService =
       new ClerkEmailService(
@@ -79,7 +81,7 @@ public class ClerkEmailServiceTest {
         authorisationTermReminderRepository,
         emailRepository,
         emailService,
-        languageService,
+        languagePairService,
         meetingDateRepository,
         templateRenderer,
         translatorRepository

--- a/backend/akr/src/test/java/fi/oph/akr/util/TemplateRendererTest.java
+++ b/backend/akr/src/test/java/fi/oph/akr/util/TemplateRendererTest.java
@@ -51,6 +51,8 @@ class TemplateRendererTest {
       Map.of(
         "translators",
         List.of(Map.of("id", "1", "name", "Jack Smith")),
+        "langPairFI",
+        "suomi - ruotsi",
         "requesterName",
         "John Doe",
         "requesterEmail",
@@ -66,6 +68,7 @@ class TemplateRendererTest {
     assertTrue(renderedContent.contains("<html "));
     assertTrue(renderedContent.contains("Jack Smith"));
     assertTrue(renderedContent.contains("https://virkailija.opintopolku.fi/akr/virkailija/kaantaja/1"));
+    assertTrue(renderedContent.contains("suomi - ruotsi"));
     assertTrue(renderedContent.contains("John Doe"));
     assertTrue(renderedContent.contains("john.doe@unknown.invalid"));
     assertTrue(renderedContent.contains("+358 400 888 777"));
@@ -77,6 +80,12 @@ class TemplateRendererTest {
       Map.of(
         "translators",
         List.of("Jack Smith", "Mark Davis"),
+        "langPairFI",
+        "suomi - ruotsi",
+        "langPairSV",
+        "finska - svenska",
+        "langPairEN",
+        "Finnish - Swedish",
         "requesterName",
         "John Doe",
         "requesterEmail",
@@ -92,6 +101,9 @@ class TemplateRendererTest {
     assertTrue(renderedContent.contains("<html "));
     assertTrue(renderedContent.contains("Jack Smith"));
     assertTrue(renderedContent.contains("Mark Davis"));
+    assertTrue(renderedContent.contains("suomi - ruotsi"));
+    assertTrue(renderedContent.contains("finska - svenska"));
+    assertTrue(renderedContent.contains("Finnish - Swedish"));
     assertTrue(renderedContent.contains("John Doe"));
     assertTrue(renderedContent.contains("john.doe@unknown.invalid"));
     assertTrue(renderedContent.contains("+358 400 888 777"));
@@ -102,6 +114,10 @@ class TemplateRendererTest {
   public void testContactRequestTranslatorTemplateIsRendered() {
     final String renderedContent = templateRenderer.renderContactRequestTranslatorEmailBody(
       Map.of(
+        "langPairFI",
+        "suomi - ruotsi",
+        "langPairSV",
+        "finska - svenska",
         "requesterName",
         "John Doe",
         "requesterEmail",
@@ -115,6 +131,8 @@ class TemplateRendererTest {
 
     assertNotNull(renderedContent);
     assertTrue(renderedContent.contains("<html "));
+    assertTrue(renderedContent.contains("suomi - ruotsi"));
+    assertTrue(renderedContent.contains("finska - svenska"));
     assertTrue(renderedContent.contains("John Doe"));
     assertTrue(renderedContent.contains("john.doe@unknown.invalid"));
     assertTrue(renderedContent.contains("+358 400 888 777"));


### PR DESCRIPTION
## Yhteenveto

Kielipari lisätty yhteydenottomailipohjiin (ei pelkästään kääntäjälle lähtevään, vaan myös vahvistusviestiin yhteydenottajalle sekä virkailijoille kun sähköpostiosoite ei kääntäjän osalta tiedossa)

## Huomautukset

Pitää ehkä tarkistaa virkailijoilta tuo prepositio ruotsinkielisissä käännöksissä

## Check-lista
- [x] Yhteydenottoja testattu lokaalisti
