### PR TITLE
OTR(Frontend): OPHOTRKEH-149 virkailijan etusivun taulukon parannukset

### DIFF
--- a/frontend/packages/otr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/otr/public/i18n/en-GB/translation.json
@@ -43,8 +43,7 @@
           "name": "Name",
           "languagePairs": "Language pairs",
           "permissionToPublish": "Permission to publish",
-          "title": "Search results",
-          "valid": "Valid"
+          "title": "Search results"
         }
       },
       "clerkInterpreterOverview": {

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -43,8 +43,7 @@
           "name": "Nimi",
           "languagePairs": "Kieliparit",
           "permissionToPublish": "Julkaisulupa",
-          "title": "Hakutulokset",
-          "valid": "Voimassa"
+          "title": "Hakutulokset"
         }
       },
       "clerkInterpreterOverview": {

--- a/frontend/packages/otr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/translation.json
@@ -43,8 +43,7 @@
           "name": "Namn",
           "languagePairs": "Språkpar",
           "permissionToPublish": "Publiceringstillstånd",
-          "title": "Sökresultat",
-          "valid": "I kraft"
+          "title": "Sökresultat"
         }
       },
       "clerkInterpreterOverview": {

--- a/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingHeader.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingHeader.tsx
@@ -27,9 +27,6 @@ export const ClerkInterpreterListingHeader = () => {
           <H3>{t('endDate')}</H3>
         </TableCell>
         <TableCell>
-          <H3>{t('valid')}</H3>
-        </TableCell>
-        <TableCell>
           <H3>{t('permissionToPublish')}</H3>
         </TableCell>
       </TableRow>

--- a/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingRow.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingRow.tsx
@@ -1,4 +1,5 @@
 import { TableCell, TableRow } from '@mui/material';
+import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { Text } from 'shared/components';
 import { DateUtils } from 'shared/utils';
@@ -10,8 +11,18 @@ import {
 import { useAppDispatch } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
 import { ClerkInterpreter } from 'interfaces/clerkInterpreter';
+import { Qualification } from 'interfaces/qualification';
 import { setClerkInterpreterOverview } from 'redux/reducers/clerkInterpreterOverview';
 import { QualificationUtils } from 'utils/qualifications';
+
+enum QualificationColumn {
+  LanguagePair = 'languagePair',
+  ExaminationType = 'examinationType',
+  BeginDate = 'beginDate',
+  EndDate = 'endDate',
+  Valid = 'valid',
+  PermissionToPublish = 'permissionToPublish',
+}
 
 export const ClerkInterpreterListingRow = ({
   interpreter,
@@ -43,6 +54,47 @@ export const ClerkInterpreterListingRow = ({
   const handleRowClick = () =>
     dispatch(setClerkInterpreterOverview(interpreter));
 
+  const getQualificationCellContent = useCallback(
+    (activeColumn: QualificationColumn, qualification: Qualification) => {
+      const {
+        fromLang,
+        toLang,
+        beginDate,
+        endDate,
+        examinationType,
+        permissionToPublish,
+      } = qualification;
+      switch (activeColumn) {
+        case QualificationColumn.LanguagePair:
+          return QualificationUtils.getLanguagePairLocalisation(
+            { from: fromLang, to: toLang },
+            translateLanguage
+          );
+        case QualificationColumn.ExaminationType:
+          return examinationType;
+        case QualificationColumn.BeginDate:
+          return DateUtils.formatOptionalDate(beginDate);
+        case QualificationColumn.EndDate:
+          return DateUtils.formatOptionalDate(endDate);
+        case QualificationColumn.Valid:
+          return QualificationUtils.isEffective(qualification, qualifications)
+            ? translateCommon('yes')
+            : translateCommon('no');
+        case QualificationColumn.PermissionToPublish:
+          return permissionToPublish
+            ? translateCommon('yes')
+            : translateCommon('no');
+      }
+    },
+    [qualifications, translateCommon, translateLanguage]
+  );
+
+  const getQualificationCellClassName = (qualification: Qualification) => {
+    return !QualificationUtils.isEffective(qualification, qualifications)
+      ? 'clerk-interpreter-listing__ineffective'
+      : '';
+  };
+
   return (
     <TableRow
       className="clerk-interpreter-listing__row"
@@ -53,49 +105,20 @@ export const ClerkInterpreterListingRow = ({
           <Text>{`${lastName} ${nickName}`}</Text>
         </Link>
       </TableCell>
-      <TableCell>
-        {visibleQualifications.map(({ fromLang, toLang }, k) => (
-          <Text key={k}>
-            {QualificationUtils.getLanguagePairLocalisation(
-              { from: fromLang, to: toLang },
-              translateLanguage
-            )}
-          </Text>
-        ))}
-      </TableCell>
-      <TableCell>
-        {visibleQualifications.map(({ examinationType }, k) => (
-          <Text key={k}>{examinationType}</Text>
-        ))}
-      </TableCell>
-      <TableCell>
-        {visibleQualifications.map(({ beginDate }, k) => (
-          <Text key={k}>{DateUtils.formatOptionalDate(beginDate)}</Text>
-        ))}
-      </TableCell>
-      <TableCell>
-        {visibleQualifications.map(({ endDate }, k) => (
-          <Text key={k}>{DateUtils.formatOptionalDate(endDate)}</Text>
-        ))}
-      </TableCell>
-      <TableCell>
-        {visibleQualifications.map((qualification, k) => (
-          <Text key={k}>
-            {QualificationUtils.isEffective(qualification, qualifications)
-              ? translateCommon('yes')
-              : translateCommon('no')}
-          </Text>
-        ))}
-      </TableCell>
-      <TableCell>
-        {visibleQualifications.map(({ permissionToPublish }, k) => (
-          <Text key={k}>
-            {permissionToPublish
-              ? translateCommon('yes')
-              : translateCommon('no')}
-          </Text>
-        ))}
-      </TableCell>
+      {Object.values(QualificationColumn).map((activeColumn) => (
+        <TableCell key={activeColumn}>
+          <div className="rows">
+            {visibleQualifications.map((qualification, idx) => (
+              <Text
+                className={getQualificationCellClassName(qualification)}
+                key={idx}
+              >
+                {getQualificationCellContent(activeColumn, qualification)}
+              </Text>
+            ))}
+          </div>
+        </TableCell>
+      ))}
     </TableRow>
   );
 };

--- a/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingRow.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingRow.tsx
@@ -20,7 +20,6 @@ enum QualificationColumn {
   ExaminationType = 'examinationType',
   BeginDate = 'beginDate',
   EndDate = 'endDate',
-  Valid = 'valid',
   PermissionToPublish = 'permissionToPublish',
 }
 
@@ -76,17 +75,13 @@ export const ClerkInterpreterListingRow = ({
           return DateUtils.formatOptionalDate(beginDate);
         case QualificationColumn.EndDate:
           return DateUtils.formatOptionalDate(endDate);
-        case QualificationColumn.Valid:
-          return QualificationUtils.isEffective(qualification, qualifications)
-            ? translateCommon('yes')
-            : translateCommon('no');
         case QualificationColumn.PermissionToPublish:
           return permissionToPublish
             ? translateCommon('yes')
             : translateCommon('no');
       }
     },
-    [qualifications, translateCommon, translateLanguage]
+    [translateCommon, translateLanguage]
   );
 
   const getQualificationCellClassName = (qualification: Qualification) => {

--- a/frontend/packages/otr/src/styles/components/clerkInterpreter/_clerk-interpreter-listing.scss
+++ b/frontend/packages/otr/src/styles/components/clerkInterpreter/_clerk-interpreter-listing.scss
@@ -1,4 +1,10 @@
 .clerk-interpreter-listing {
+  &__ineffective {
+    &#{&} {
+      color: $color-grey-600;
+    }
+  }
+
   &__row {
     td:first-child {
       position: relative;


### PR DESCRIPTION
## Yhteenveto

Toteutus enemmän ja vähemmän copy pastea pienellä mukautuksella AKR:stä: https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/392

Tässä lisätty harmaa taustaväri umpeutuneille rekisteröintiriveille sekä poistettu Voimassa-sarake.

## Check-lista
- [x] Käännösten Excel-tiedosto päivitetty
- [x] UI-muutoksia testattu eri selaimilla
