### PR TITLE
OPHVKTKEH-76 aiempi osallistuminen vapaana tekstikenttänä ilmolomakkeessa

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/PublicEnrollmentCreateDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/PublicEnrollmentCreateDTO.java
@@ -1,6 +1,5 @@
 package fi.oph.vkt.api.dto;
 
-import java.time.LocalDate;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -15,7 +14,7 @@ public record PublicEnrollmentCreateDTO(
   @NonNull @NotNull Boolean speechComprehensionPartialExam,
   @NonNull @NotNull Boolean writingPartialExam,
   @NonNull @NotNull Boolean readingComprehensionPartialExam,
-  LocalDate previousEnrollmentDate,
+  String previousEnrollment,
   @NonNull @NotNull Boolean digitalCertificateConsent,
   @NonNull @NotBlank String email,
   @NonNull @NotBlank String phoneNumber,

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkEnrollmentDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkEnrollmentDTO.java
@@ -1,7 +1,6 @@
 package fi.oph.vkt.api.dto.clerk;
 
 import fi.oph.vkt.model.type.EnrollmentStatus;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
@@ -23,7 +22,7 @@ public record ClerkEnrollmentDTO(
   @NonNull @NotNull Boolean writingPartialExam,
   @NonNull @NotNull Boolean readingComprehensionPartialExam,
   @NonNull @NotNull EnrollmentStatus status,
-  LocalDate previousEnrollmentDate,
+  String previousEnrollment,
   @NonNull @NotNull Boolean digitalCertificateConsent,
   @NonNull @NotBlank String email,
   @NonNull @NotBlank String phoneNumber,

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkEnrollmentUpdateDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/clerk/ClerkEnrollmentUpdateDTO.java
@@ -1,6 +1,5 @@
 package fi.oph.vkt.api.dto.clerk;
 
-import java.time.LocalDate;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -17,7 +16,7 @@ public record ClerkEnrollmentUpdateDTO(
   @NonNull @NotNull Boolean speechComprehensionPartialExam,
   @NonNull @NotNull Boolean writingPartialExam,
   @NonNull @NotNull Boolean readingComprehensionPartialExam,
-  LocalDate previousEnrollmentDate,
+  String previousEnrollment,
   @NonNull @NotNull Boolean digitalCertificateConsent,
   @NonNull @NotBlank String email,
   @NonNull @NotBlank String phoneNumber,

--- a/backend/vkt/src/main/java/fi/oph/vkt/model/Enrollment.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/model/Enrollment.java
@@ -1,7 +1,6 @@
 package fi.oph.vkt.model;
 
 import fi.oph.vkt.model.type.EnrollmentStatus;
-import java.time.LocalDate;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -52,8 +51,8 @@ public class Enrollment extends BaseEntity {
   @Enumerated(value = EnumType.STRING)
   private EnrollmentStatus status;
 
-  @Column(name = "previous_enrollment_date")
-  private LocalDate previousEnrollmentDate;
+  @Column(name = "previous_enrollment")
+  private String previousEnrollment;
 
   @Column(name = "digital_certificate_consent", nullable = false)
   private boolean digitalCertificateConsent;

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkEnrollmentService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkEnrollmentService.java
@@ -37,7 +37,7 @@ public class ClerkEnrollmentService {
     enrollment.setSpeechComprehensionPartialExam(dto.speechComprehensionPartialExam());
     enrollment.setWritingPartialExam(dto.writingPartialExam());
     enrollment.setReadingComprehensionPartialExam(dto.readingComprehensionPartialExam());
-    enrollment.setPreviousEnrollmentDate(dto.previousEnrollmentDate());
+    enrollment.setPreviousEnrollment(dto.previousEnrollment());
     enrollment.setDigitalCertificateConsent(dto.digitalCertificateConsent());
     enrollment.setEmail(dto.email());
     enrollment.setPhoneNumber(dto.phoneNumber());

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentService.java
@@ -173,7 +173,7 @@ public class PublicEnrollmentService {
     enrollment.setSpeechComprehensionPartialExam(dto.speechComprehensionPartialExam());
     enrollment.setWritingPartialExam(dto.writingPartialExam());
     enrollment.setReadingComprehensionPartialExam(dto.readingComprehensionPartialExam());
-    enrollment.setPreviousEnrollmentDate(dto.previousEnrollmentDate());
+    enrollment.setPreviousEnrollment(dto.previousEnrollment());
     enrollment.setDigitalCertificateConsent(dto.digitalCertificateConsent());
     enrollment.setEmail(dto.email());
     enrollment.setPhoneNumber(dto.phoneNumber());

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/ClerkEnrollmentUtil.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/ClerkEnrollmentUtil.java
@@ -27,7 +27,7 @@ public class ClerkEnrollmentUtil {
       .writingPartialExam(enrollment.isWritingPartialExam())
       .readingComprehensionPartialExam(enrollment.isReadingComprehensionPartialExam())
       .status(enrollment.getStatus())
-      .previousEnrollmentDate(enrollment.getPreviousEnrollmentDate())
+      .previousEnrollment(enrollment.getPreviousEnrollment())
       .digitalCertificateConsent(enrollment.isDigitalCertificateConsent())
       .email(enrollment.getEmail())
       .phoneNumber(enrollment.getPhoneNumber())

--- a/backend/vkt/src/main/java/fi/oph/vkt/view/ExamEventXlsxView.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/view/ExamEventXlsxView.java
@@ -3,7 +3,6 @@ package fi.oph.vkt.view;
 import fi.oph.vkt.api.dto.clerk.ClerkEnrollmentDTO;
 import fi.oph.vkt.api.dto.clerk.ClerkExamEventDTO;
 import fi.oph.vkt.model.type.EnrollmentStatus;
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.List;
@@ -94,7 +93,7 @@ public class ExamEventXlsxView extends AbstractXlsxView {
       row.createCell(++ci).setCellValue(enrollment.person().lastName());
       row.createCell(++ci).setCellValue(enrollment.person().firstName());
       row.createCell(++ci).setCellValue(enrollment.person().identityNumber());
-      formatNullableDate(row.createCell(++ci), enrollment.previousEnrollmentDate());
+      setNullableValue(row.createCell(++ci), enrollment.previousEnrollment());
 
       row.createCell(++ci).setCellValue(statusToText(enrollment.status()));
 
@@ -126,9 +125,9 @@ public class ExamEventXlsxView extends AbstractXlsxView {
     return byStatus.thenComparing(byEnrollmentTime);
   }
 
-  private static void formatNullableDate(final Cell cell, final LocalDate localDate) {
-    if (localDate != null) {
-      cell.setCellValue(DATE_FORMAT.format(localDate));
+  private static void setNullableValue(final Cell cell, final String string) {
+    if (string != null) {
+      cell.setCellValue(string);
     } else {
       cell.setBlank();
     }

--- a/backend/vkt/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/backend/vkt/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -432,4 +432,14 @@
                              onDelete="NO ACTION" onUpdate="NO ACTION"/>
     </changeSet>
 
+    <changeSet id="2023-01-18-modify_enrollment-table_previous-enrollment-date" author="mikhuttu">
+        <modifyDataType tableName="enrollment"
+                        columnName="previous_enrollment_date"
+                        newDataType="TEXT" />
+
+        <renameColumn tableName="enrollment"
+                      oldColumnName="previous_enrollment_date"
+                      newColumnName="previous_enrollment" />
+    </changeSet>
+
 </databaseChangeLog>

--- a/backend/vkt/src/test/java/fi/oph/vkt/Factory.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/Factory.java
@@ -50,7 +50,7 @@ public class Factory {
     enrollment.setWritingPartialExam(false);
     enrollment.setReadingComprehensionPartialExam(false);
     enrollment.setStatus(EnrollmentStatus.PAID);
-    enrollment.setPreviousEnrollmentDate(LocalDate.now().minusYears(1));
+    enrollment.setPreviousEnrollment("1.11.2022");
     enrollment.setDigitalCertificateConsent(true);
     enrollment.setEmail("foo.tester@invalid");
     enrollment.setPhoneNumber("+10001234567");

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/ClerkEnrollmentServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/ClerkEnrollmentServiceTest.java
@@ -76,7 +76,7 @@ class ClerkEnrollmentServiceTest {
     assertEquals(responseDTO.speechComprehensionPartialExam(), dto.speechComprehensionPartialExam());
     assertEquals(responseDTO.writingPartialExam(), dto.writingPartialExam());
     assertEquals(responseDTO.readingComprehensionPartialExam(), dto.readingComprehensionPartialExam());
-    assertEquals(responseDTO.previousEnrollmentDate(), dto.previousEnrollmentDate());
+    assertEquals(responseDTO.previousEnrollment(), dto.previousEnrollment());
     assertEquals(responseDTO.digitalCertificateConsent(), dto.digitalCertificateConsent());
     assertEquals(responseDTO.email(), dto.email());
     assertEquals(responseDTO.phoneNumber(), dto.phoneNumber());
@@ -100,9 +100,7 @@ class ClerkEnrollmentServiceTest {
       .speechComprehensionPartialExam(!enrollment.isSpeechComprehensionPartialExam())
       .writingPartialExam(!enrollment.isWritingPartialExam())
       .readingComprehensionPartialExam(!enrollment.isReadingComprehensionPartialExam())
-      .previousEnrollmentDate(
-        enrollment.getPreviousEnrollmentDate() != null ? enrollment.getPreviousEnrollmentDate().plusDays(1) : null
-      )
+      .previousEnrollment(enrollment.getPreviousEnrollment() != null ? enrollment.getPreviousEnrollment() + "X" : null)
       .digitalCertificateConsent(!enrollment.isDigitalCertificateConsent())
       .email(enrollment.getEmail() + "x")
       .phoneNumber(enrollment.getPhoneNumber() + "X")

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/ClerkExamEventServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/ClerkExamEventServiceTest.java
@@ -215,7 +215,7 @@ public class ClerkExamEventServiceTest {
     enrollment.setWritingPartialExam(!defaultEnrollment.isWritingPartialExam());
     enrollment.setReadingComprehensionPartialExam(!defaultEnrollment.isReadingComprehensionPartialExam());
     enrollment.setStatus(EnrollmentStatus.QUEUED);
-    enrollment.setPreviousEnrollmentDate(null);
+    enrollment.setPreviousEnrollment(null);
     enrollment.setDigitalCertificateConsent(!defaultEnrollment.isDigitalCertificateConsent());
 
     return enrollment;
@@ -240,7 +240,7 @@ public class ClerkExamEventServiceTest {
     assertEquals(expected.isWritingPartialExam(), enrollmentDTO.writingPartialExam());
     assertEquals(expected.isReadingComprehensionPartialExam(), enrollmentDTO.readingComprehensionPartialExam());
     assertEquals(expected.getStatus(), enrollmentDTO.status());
-    assertEquals(expected.getPreviousEnrollmentDate(), enrollmentDTO.previousEnrollmentDate());
+    assertEquals(expected.getPreviousEnrollment(), enrollmentDTO.previousEnrollment());
     assertEquals(expected.isDigitalCertificateConsent(), enrollmentDTO.digitalCertificateConsent());
     assertEquals(expected.getEmail(), enrollmentDTO.email());
     assertEquals(expected.getPhoneNumber(), enrollmentDTO.phoneNumber());

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentServiceTest.java
@@ -315,7 +315,7 @@ public class PublicEnrollmentServiceTest {
       .speechComprehensionPartialExam(true)
       .writingPartialExam(false)
       .readingComprehensionPartialExam(false)
-      .previousEnrollmentDate(LocalDate.now().minusYears(1))
+      .previousEnrollment("11/2022")
       .email("test@tester")
       .phoneNumber("+358000111")
       .street("Katu 1")
@@ -337,7 +337,7 @@ public class PublicEnrollmentServiceTest {
     assertEquals(dto.speechComprehensionPartialExam(), enrollment.isSpeechComprehensionPartialExam());
     assertEquals(dto.writingPartialExam(), enrollment.isWritingPartialExam());
     assertEquals(dto.readingComprehensionPartialExam(), enrollment.isReadingComprehensionPartialExam());
-    assertEquals(dto.previousEnrollmentDate(), enrollment.getPreviousEnrollmentDate());
+    assertEquals(dto.previousEnrollment(), enrollment.getPreviousEnrollment());
     assertEquals(dto.digitalCertificateConsent(), enrollment.isDigitalCertificateConsent());
     assertEquals(dto.email(), enrollment.getEmail());
     assertEquals(dto.phoneNumber(), enrollment.getPhoneNumber());

--- a/frontend/packages/vkt/public/i18n/fi-FI/common.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/common.json
@@ -35,7 +35,7 @@
           "lastName": "Sukunimi",
           "phoneNumber": "Puhelinnumero",
           "postalCode": "Postinumero",
-          "previousEnrollmentDate": "Päivämäärä",
+          "previousEnrollment": "Päivämäärä tai vapaa teksti",
           "street": "Katuosoite",
           "town": "Postitoimipaikka"
         }

--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -101,6 +101,10 @@
               "label": "Olen lukenut tämän palvelun <0></0> ja hyväksyn sen.",
               "linkLabel": "tietosuojaselosteen"
             }
+          },
+          "previousEnrollment": {
+            "description": "Oletko osallistunut aiemmin valtionhallinnon kielitutkintoon? Milloin olet viimeksi osallistunut?",
+            "label": "Päivämäärä tai vapaa teksti"
           }
         }
       },

--- a/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
@@ -2,7 +2,7 @@ import { Checkbox, FormControlLabel, FormHelperTextProps } from '@mui/material';
 import { ChangeEvent, useState } from 'react';
 import { CustomTextField, H2, H3, InfoText } from 'shared/components';
 import { Color, TextFieldTypes } from 'shared/enums';
-import { DateUtils, InputFieldUtils } from 'shared/utils';
+import { InputFieldUtils } from 'shared/utils';
 
 import {
   translateOutsideComponent,
@@ -52,8 +52,6 @@ const getTextValue = (
     field === ClerkEnrollmentTextFieldEnum.LastName
   ) {
     return enrollment.person[field] || '';
-  } else if (field === ClerkEnrollmentTextFieldEnum.PreviousEnrollmentDate) {
-    return enrollment[field] && DateUtils.formatOptionalDate(enrollment[field]);
   } else {
     return enrollment[field] || '';
   }
@@ -100,8 +98,7 @@ const ClerkEnrollmentDetailsTextField = ({
 }: ClerkEnrollmentTextFieldProps) => {
   const translateCommon = useCommonTranslation();
 
-  const required =
-    field !== ClerkEnrollmentTextFieldEnum.PreviousEnrollmentDate;
+  const required = field !== ClerkEnrollmentTextFieldEnum.PreviousEnrollment;
   const fieldError = getFieldError(enrollment, field, required);
   const showRequiredFieldError =
     showFieldError && fieldError?.length > 0 && required;
@@ -269,8 +266,8 @@ export const ClerkEnrollmentDetailsFields = ({
         <ClerkEnrollmentDetailsTextField
           className="previous-enrollment"
           {...getCommonTextFieldProps(
-            ClerkEnrollmentTextFieldEnum.PreviousEnrollmentDate,
-            true
+            ClerkEnrollmentTextFieldEnum.PreviousEnrollment,
+            editDisabled
           )}
         />
         <div className="columns align-items-start clerk-enrollment-details-fields__skills">

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/Preview.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/Preview.tsx
@@ -8,6 +8,7 @@ import { Color } from 'shared/enums';
 import { CertificateShipping } from 'components/publicEnrollment/steps/CertificateShipping';
 import { PartialExamsSelection } from 'components/publicEnrollment/steps/PartialExamsSelection';
 import { PersonDetails } from 'components/publicEnrollment/steps/PersonDetails';
+import { PreviousEnrollment } from 'components/publicEnrollment/steps/PreviousEnrollment';
 import { usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
@@ -88,6 +89,7 @@ export const Preview = ({
         email={enrollment.email}
         phoneNumber={enrollment.phoneNumber}
       />
+      <PreviousEnrollment enrollment={enrollment} editingDisabled={true} />
       <PartialExamsSelection enrollment={enrollment} editingDisabled={true} />
       <CertificateShipping enrollment={enrollment} editingDisabled={true} />
       <FormControlLabel

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/PreviousEnrollment.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/PreviousEnrollment.tsx
@@ -1,0 +1,41 @@
+import { ChangeEvent } from 'react';
+import { CustomTextField, Text } from 'shared/components';
+
+import { usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
+import { PublicEnrollment } from 'interfaces/publicEnrollment';
+import { updatePublicEnrollment } from 'redux/reducers/publicEnrollment';
+
+export const PreviousEnrollment = ({
+  enrollment,
+  editingDisabled,
+}: {
+  enrollment: PublicEnrollment;
+  editingDisabled: boolean;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'vkt.component.publicEnrollment.steps.previousEnrollment',
+  });
+
+  const dispatch = useAppDispatch();
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    dispatch(
+      updatePublicEnrollment({
+        previousEnrollment: event.target.value,
+      })
+    );
+  };
+
+  return (
+    <div className="public-enrollment__grid__previous-enrollment rows gapped-sm">
+      <Text>{t('description')}</Text>
+      <CustomTextField
+        label={t('label')}
+        value={enrollment.previousEnrollment}
+        onChange={handleChange}
+        disabled={editingDisabled}
+      />
+    </div>
+  );
+};

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/PreviousEnrollment.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/PreviousEnrollment.tsx
@@ -28,7 +28,7 @@ export const PreviousEnrollment = ({
   };
 
   return (
-    <div className="public-enrollment__grid__previous-enrollment rows gapped-sm">
+    <div className="public-enrollment__grid__previous-enrollment rows gapped">
       <Text>{t('description')}</Text>
       <CustomTextField
         label={t('label')}

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/SelectExam.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/SelectExam.tsx
@@ -4,6 +4,7 @@ import { Text } from 'shared/components';
 
 import { CertificateShipping } from 'components/publicEnrollment/steps/CertificateShipping';
 import { PartialExamsSelection } from 'components/publicEnrollment/steps/PartialExamsSelection';
+import { PreviousEnrollment } from 'components/publicEnrollment/steps/PreviousEnrollment';
 import { useCommonTranslation } from 'configs/i18n';
 import { PublicEnrollment } from 'interfaces/publicEnrollment';
 
@@ -40,6 +41,7 @@ export const SelectExam = ({
           i18nKey="examinationPaymentsDescription"
         ></Trans>
       </Text>
+      <PreviousEnrollment enrollment={enrollment} editingDisabled={isLoading} />
       <PartialExamsSelection
         enrollment={enrollment}
         editingDisabled={isLoading}

--- a/frontend/packages/vkt/src/enums/clerkEnrollment.ts
+++ b/frontend/packages/vkt/src/enums/clerkEnrollment.ts
@@ -3,7 +3,7 @@ export enum ClerkEnrollmentTextFieldEnum {
   LastName = 'lastName',
   Email = 'email',
   PhoneNumber = 'phoneNumber',
-  PreviousEnrollmentDate = 'previousEnrollmentDate',
+  PreviousEnrollment = 'previousEnrollment',
   Street = 'street',
   PostalCode = 'postalCode',
   Town = 'town',

--- a/frontend/packages/vkt/src/interfaces/clerkExamEvent.ts
+++ b/frontend/packages/vkt/src/interfaces/clerkExamEvent.ts
@@ -14,9 +14,8 @@ interface Person extends WithId, WithVersion {
 }
 
 export interface ClerkEnrollmentResponse
-  extends Omit<ClerkEnrollment, 'enrollmentTime' | 'previousEnrollmentDate'> {
+  extends Omit<ClerkEnrollment, 'enrollmentTime'> {
   enrollmentTime: string;
-  previousEnrollmentDate?: string;
 }
 
 export interface ClerkEnrollment
@@ -27,7 +26,7 @@ export interface ClerkEnrollment
   enrollmentTime: Dayjs;
   person: Person;
   status: EnrollmentStatus;
-  previousEnrollmentDate?: Dayjs;
+  previousEnrollment?: string;
   email: string;
   phoneNumber: string;
 }

--- a/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
@@ -42,5 +42,6 @@ export interface PublicEnrollment
   extends PublicEnrollmentContactDetails,
     PartialExamsAndSkills,
     CertificateShippingData {
+  previousEnrollment?: string;
   privacyStatementConfirmation: boolean;
 }

--- a/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
+++ b/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
@@ -16,6 +16,10 @@
       }
     }
 
+    &__previous-enrollment {
+      width: calc(50% - 1rem);
+    }
+
     &__partial-exam-selection {
       padding-left: 1rem;
     }

--- a/frontend/packages/vkt/src/tests/cypress/integration/enrollmentDetails/clerk_enrollment_details.spec.ts
+++ b/frontend/packages/vkt/src/tests/cypress/integration/enrollmentDetails/clerk_enrollment_details.spec.ts
@@ -33,7 +33,7 @@ describe('ClerkEnrollmentOverview:ClerkEnrollmentDetails', () => {
     const displayedTextFields = [
       ...nameFields,
       ...contactDetailsFields,
-      'previousEnrollmentDate',
+      'previousEnrollment',
     ];
 
     displayedTextFields.forEach((f) =>
@@ -54,7 +54,7 @@ describe('ClerkEnrollmentOverview:ClerkEnrollmentDetails', () => {
       '+358401000001'
     );
     onClerkEnrollmentOverviewPage.expectTextFieldValue(
-      'previousEnrollmentDate',
+      'previousEnrollment',
       ''
     );
 
@@ -84,6 +84,10 @@ describe('ClerkEnrollmentOverview:ClerkEnrollmentDetails', () => {
     );
     contactDetailsFields.forEach((f) =>
       onClerkEnrollmentOverviewPage.editTextField(f, `test-${f}`)
+    );
+    onClerkEnrollmentOverviewPage.editTextField(
+      'previousEnrollment',
+      'tammikuussa 2023'
     );
     onClerkEnrollmentOverviewPage.expectEnabledSaveButton();
 

--- a/frontend/packages/vkt/src/utils/serialization.ts
+++ b/frontend/packages/vkt/src/utils/serialization.ts
@@ -61,14 +61,9 @@ export class SerializationUtils {
   }
 
   static deserializeClerkEnrollment(enrollment: ClerkEnrollmentResponse) {
-    const previousEnrollmentDate = enrollment.previousEnrollmentDate
-      ? dayjs(enrollment.previousEnrollmentDate)
-      : undefined;
-
     return {
       ...enrollment,
       enrollmentTime: dayjs(enrollment.enrollmentTime),
-      previousEnrollmentDate,
     };
   }
 
@@ -76,9 +71,6 @@ export class SerializationUtils {
     return {
       ...enrollment,
       enrollmentTime: DateUtils.serializeDate(enrollment.enrollmentTime),
-      previousEnrollmentDate: DateUtils.serializeDate(
-        enrollment.previousEnrollmentDate
-      ),
     };
   }
 


### PR DESCRIPTION
## Yhteenveto

Muutettu tietokannan tasolla aiempi osallistumispäivämäärä valtionhallinnon kielitutkintoon vapaaksi tekstikentäksi ja mahdollistettu tuon täyttö ilmoittautuessa ja muokkaaminen virkailijana. Tämä mahdollistaa sen, että mikäli ilmoittautuja ei muista tarkasti päivämäärää, jolloin on aiemmin osallistunut tutkintoon, voi hän kuitenkin arvion tuosta ilmoittaa ja virkailijat saavat sitä kautta kaivettua tarpeelliset tiedot arkistoista viime kokeesta, jossa ollut mukana.
