### PR TITLE
VKT(Frontend): OPHVKTKEH-67 navigation protection for enrollment

### DIFF
--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -10,6 +10,7 @@ import { PublicEnrollmentStepContents } from 'components/publicEnrollment/Public
 import { PublicEnrollmentStepper } from 'components/publicEnrollment/PublicEnrollmentStepper';
 import { useAppSelector } from 'configs/redux';
 import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
+import { useNavigationProtection } from 'hooks/useNavigationProtection';
 import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
 
 export const PublicEnrollmentGrid = () => {
@@ -20,6 +21,8 @@ export const PublicEnrollmentGrid = () => {
   const { status, activeStep, enrollment, reservationDetails } = useAppSelector(
     publicEnrollmentSelector
   );
+
+  useNavigationProtection(activeStep > PublicEnrollmentFormStep.Identify);
 
   if (!reservationDetails) {
     return null;


### PR DESCRIPTION
### Yhteenveto

Kun selaimen takaisinnappia painaa ilmoittautuessa tunnistusvaiheen jälkeen, vaaditaan vahvistus poistumiseen.

Alustavasti oli ajatuksena, että tämän yhteydessä voisi myös poistaa tehdyn varauksen (mikäli ei jonopaikka). Tuon toteuttaminen meni vähän hankalaksi, mutta lopulta kun asiaa lisää pohdin, niin en sitten tiedä onko kovin tarpeellistakaan. 

Ainoa kiusanteko, joka tässä pitäisi olla nyt yksityishenkilönä mahdollista on sellainen, että varaa puolen tunnin välein paikkoja avoimiin tutkintotilaisuuksiin tunnistautumisen jälkeen. Kahta varausta ei samalla hetulla voi yksittäiseen tutkintotilaisuuteen parhaillaan olla, sillä jos varaa paikan tutkintoon ja yrittää varata paikan uudestaan, asetetaan vain aiemmin luodulle varuakselle uusi umpeutumisaika. Tosin yhtä lailla yksittäistä varausta tutkintoon voi pitää itsellä kauemminkin kuin tuo puoli tuntia pitäen vain selainikkunaa auki ja uusien varauksen (jos uusiminen sallitaan kuten Figma-leiskoihin piirretty).