### PR TITLE
Hotfix: AKR and OTR buildit eivät ajaudu pakollisen wkhtmltopdf input parametrin takia

### DIFF
--- a/.github/workflows/common-backend.yml
+++ b/.github/workflows/common-backend.yml
@@ -9,7 +9,7 @@ on:
         type: string
       with-wkhtmltopdf:
         description: "Should wkhtmltopdf be installed or not"
-        required: true
+        required: false
         type: boolean
         default: false
 

--- a/.github/workflows/common-deploy.yml
+++ b/.github/workflows/common-deploy.yml
@@ -13,7 +13,7 @@ on:
         type: string
       with-wkhtmltopdf:
         description: "Should wkhtmltopdf be available in container"
-        required: true
+        required: false
         type: boolean
         default: false
     secrets:


### PR DESCRIPTION
Testattu saisiko tuon `with-wkhtmltopdf` parametrin jotenkin kätevästi määriteltyä optionaaliseksi noille common-backend ja common-deploy workfloweille, kuten oli tarkoitus, mutta en saanut ainakaan sitä kautta toistaiseksi AKR ja OTR buildeja ajautumaan. Tällä hetkellä noiden sovellusten buildit eivät tosiaan ajaudu kuten voi "Actions" alta huomata.

Tässä nyt lopulta ratkaisu minkä pitäis toimia. Commitit yhdistänen ja poistan nuo testilokalisaatiot toki ennen mergausta.