### PR TITLE
OTR(Frontend): OPHOTRKEH-138 takaisin-nappi vie tulkin luontisivulta takaisin hetun syöttönäkymään

### DIFF
--- a/frontend/packages/otr/src/components/common/BackButton.tsx
+++ b/frontend/packages/otr/src/components/common/BackButton.tsx
@@ -5,17 +5,21 @@ import { Variant } from 'shared/enums';
 import { useCommonTranslation } from 'configs/i18n';
 import { AppRoutes } from 'enums/app';
 
-export const TopControls = () => {
+export const BackButton = ({
+  to = AppRoutes.ClerkHomePage,
+}: {
+  to?: AppRoutes;
+}) => {
   const translateCommon = useCommonTranslation();
 
   return (
     <div className="columns">
       <CustomButtonLink
-        to={AppRoutes.ClerkHomePage}
+        to={to}
         className="color-secondary-dark"
         variant={Variant.Text}
         startIcon={<ArrowBackIosOutlined />}
-        data-testid="clerk-interpreter-overview-page__back-button"
+        data-testid="back-button"
       >
         {translateCommon('back')}
       </CustomButtonLink>

--- a/frontend/packages/otr/src/components/skeletons/ClerkInterpreterOverviewPageSkeleton.tsx
+++ b/frontend/packages/otr/src/components/skeletons/ClerkInterpreterOverviewPageSkeleton.tsx
@@ -2,13 +2,13 @@ import { Skeleton } from '@mui/material';
 import { SkeletonVariant } from 'shared/enums';
 
 import { ClerkInterpreterDetails } from 'components/clerkInterpreter/overview/ClerkInterpreterDetails';
-import { TopControls } from 'components/clerkInterpreter/overview/TopControls';
+import { BackButton } from 'components/common/BackButton';
 
 export const ClerkInterpreterOverviewPageSkeleton = () => {
   return (
     <>
       <Skeleton variant={SkeletonVariant.Rectangular}>
-        <TopControls />
+        <BackButton />
       </Skeleton>
       <Skeleton
         className="full-max-width half-height margin-top-lg"

--- a/frontend/packages/otr/src/pages/ClerkInterpreterOverviewPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkInterpreterOverviewPage.tsx
@@ -7,7 +7,7 @@ import { useToast } from 'shared/hooks';
 
 import { ClerkInterpreterDetails } from 'components/clerkInterpreter/overview/ClerkInterpreterDetails';
 import { QualificationDetails } from 'components/clerkInterpreter/overview/QualificationDetails';
-import { TopControls } from 'components/clerkInterpreter/overview/TopControls';
+import { BackButton } from 'components/common/BackButton';
 import { ClerkInterpreterOverviewPageSkeleton } from 'components/skeletons/ClerkInterpreterOverviewPageSkeleton';
 import { useAppTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
@@ -84,7 +84,7 @@ export const ClerkInterpreterOverviewPage = () => {
           <ClerkInterpreterOverviewPageSkeleton />
         ) : (
           <>
-            <TopControls />
+            <BackButton />
             <div className="rows gapped">
               <ClerkInterpreterDetails />
               <QualificationDetails />

--- a/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkNewInterpreterPage.tsx
@@ -10,7 +10,7 @@ import { AddQualification } from 'components/clerkInterpreter/add/AddQualificati
 import { BottomControls } from 'components/clerkInterpreter/new/BottomControls';
 import { ClerkNewInterpreterDetails } from 'components/clerkInterpreter/new/ClerkNewInterpreterDetails';
 import { QualificationListing } from 'components/clerkInterpreter/overview/QualificationListing';
-import { TopControls } from 'components/clerkInterpreter/overview/TopControls';
+import { BackButton } from 'components/common/BackButton';
 import { useAppTranslation, useCommonTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
@@ -150,7 +150,7 @@ export const ClerkNewInterpreterPage = () => {
         className="clerk-new-interpreter-page__content-container rows"
       >
         <div className="rows gapped">
-          <TopControls />
+          <BackButton to={AppRoutes.ClerkPersonSearchPage} />
           <ClerkNewInterpreterDetails
             interpreter={interpreter}
             onDetailsChange={() => setHasLocalChanges(true)}

--- a/frontend/packages/otr/src/pages/ClerkPersonSearchPage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkPersonSearchPage.tsx
@@ -17,7 +17,7 @@ import {
 } from 'shared/enums';
 import { InputFieldUtils } from 'shared/utils';
 
-import { TopControls } from 'components/clerkInterpreter/overview/TopControls';
+import { BackButton } from 'components/common/BackButton';
 import { useAppTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
@@ -90,7 +90,7 @@ export const ClerkPersonSearchPage = () => {
         elevation={3}
         className="clerk-person-search-page__content-container rows"
       >
-        <TopControls />
+        <BackButton />
         <div className="rows gapped">
           <div className="columns margin-top-lg">
             <div className="columns margin-top-lg grow">

--- a/frontend/packages/otr/src/tests/cypress/integration/interpreterOverview/clerk_interpreter_details.spec.ts
+++ b/frontend/packages/otr/src/tests/cypress/integration/interpreterOverview/clerk_interpreter_details.spec.ts
@@ -101,7 +101,7 @@ describe('ClerkInterpreterOverview:ClerkInterpreterDetails', () => {
     onToast.expectText('Tiedot tallennettiin');
 
     // Ensure navigation protection is no longer enabled after saving.
-    onClerkInterpreterOverviewPage.navigateBackToRegister();
+    onClerkInterpreterOverviewPage.clickBackButton();
     cy.isOnPage(AppRoutes.ClerkHomePage);
   });
 
@@ -144,7 +144,7 @@ describe('ClerkInterpreterOverview:ClerkInterpreterDetails', () => {
       'input',
       'testiTesti123'
     );
-    onClerkInterpreterOverviewPage.navigateBackToRegister();
+    onClerkInterpreterOverviewPage.clickBackButton();
 
     onDialog.expectText('Haluatko varmasti poistua sivulta?');
     onDialog.clickButtonByText('Kyllä');

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkInterpreterOverviewPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkInterpreterOverviewPage.ts
@@ -7,8 +7,7 @@ class ClerkInterpreterOverviewPage {
       cy.findByTestId(
         'clerk-interpreter-overview__qualification-details__add-button'
       ),
-    backToRegisterButton: () =>
-      cy.findByTestId('clerk-interpreter-overview-page__back-button'),
+    backButton: () => cy.findByTestId('back-button'),
     editInterpreterDetailsButton: () =>
       cy.findByTestId(
         'clerk-interpreter-overview__interpreter-details__edit-button'
@@ -45,8 +44,8 @@ class ClerkInterpreterOverviewPage {
     );
   }
 
-  navigateBackToRegister() {
-    this.elements.backToRegisterButton().should('be.visible').click();
+  clickBackButton() {
+    this.elements.backButton().should('be.visible').click();
   }
 
   expectTitle(text: string) {

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkNewInterpreterPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkNewInterpreterPage.ts
@@ -4,8 +4,6 @@ class ClerkNewInterpreterPage {
   elements = {
     addQualificationButton: () =>
       cy.findByTestId('clerk-new-interpreter-page__add-qualification-button'),
-    backToRegisterButton: () =>
-      cy.findByTestId('clerk-interpreter-overview-page__back-button'),
     interpreterField: (field: string, fieldType: string) =>
       cy
         .findByTestId(`clerk-interpreter__basic-information__${field}`)


### PR DESCRIPTION
## Yhteenveto

Korjattu pieni erikoisuus käytettävyydessä, jonka johdosta tulkkia lisättäessä takaisin-napin painaminen vei aiemmin suoraan rekisterin näkymään sen sijaan, että näytettäisiin tuon ja lisäyssivun välissä oleva hetun syöttönäkymään (jossa tarkistetaan siis oppijanumerorekisteristä, löytyykö talletettavan tulkin hetulla jo olemassaolevan oppijan tietoja).

Olin laiska ja en kirjoittanut cypress-testejä luonti enkä hetun syöttönäkymälle. Voidaan tosin tehdä jos halutaan.