### PR TITLE
OTR(Backend): OPHOTRKEH-199 qualification expiry mail finalised

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/service/email/ClerkEmailService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/email/ClerkEmailService.java
@@ -64,7 +64,7 @@ public class ClerkEmailService {
     if (personalData != null) {
       final String recipientName = personalData.getNickName() + " " + personalData.getLastName();
       final String recipientAddress = personalData.getEmail();
-      final String emailSubject = "Merkintäsi oikeustulkkirekisteriin on päättymässä | Din ... ... går mot sitt slut";
+      final String emailSubject = "Merkintäsi oikeustulkkirekisteriin on päättymässä";
 
       if (recipientAddress == null) {
         LOG.info("Email for interpreter with onr id {} doesn't exist", interpreter.getOnrId());
@@ -105,18 +105,11 @@ public class ClerkEmailService {
       " - " +
       languageService.getLocalisationValue(toLangCode, Language.FI).orElse(toLangCode);
 
-    final String langPairSV =
-      languageService.getLocalisationValue(fromLangCode, Language.SV).orElse(fromLangCode) +
-      " - " +
-      languageService.getLocalisationValue(toLangCode, Language.SV).orElse(toLangCode);
-
     final Map<String, Object> templateParams = Map.of(
       "interpreterName",
       interpreterName,
       "langPairFI",
       langPairFI,
-      "langPairSV",
-      langPairSV,
       "expiryDate",
       expiryDate.format(DATE_FORMATTER)
     );

--- a/backend/otr/src/main/resources/email-templates/qualification-expiry.html
+++ b/backend/otr/src/main/resources/email-templates/qualification-expiry.html
@@ -16,9 +16,15 @@
             Jos et uusi merkintääsi, tietosi poistuvat julkisesta oikeustulkkirekisteristä merkintäsi päättymisen jälkeen.
         </p>
         <p>
-            Hakemuslomake on tulostettavissa yllä mainitulta verkkosivulta. Täytetty ja allekirjoitettu lomake lähetetään postitse tai skannattuna osoitteeseen:<br/>
-            Kirjaamo Opetushallitus, PL 380, 00531 Helsinki tai <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a>
+            Hakemuslomake on tulostettavissa yllä mainitulta verkkosivulta. Täytetty ja allekirjoitettu lomake lähetetään postitse tai skannattuna osoitteeseen:
         </p>
+        <p>
+            Kirjaamo<br/>
+            Opetushallitus<br/>
+            PL 380<br/>
+            00531 Helsinki
+        </p>
+        <p>tai <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a></p>
         <p>
             Hakemuksen tulee olla perillä kaksi viikkoa ennen lautakunnan käsittelykokousta.
         </p>
@@ -30,42 +36,10 @@
         <p>
             Älä vastaa tähän viestiin - viesti on lähetetty automaattisesti.
         </p>
-        <p style="border-bottom: 1px solid black; padding-bottom: 15px;">
+        <p>
             Ystävällisin terveisin<br/>
             Oikeustulkkirekisteri<br/>
             Opetushallitus
-        </p>
-
-        <p>
-            Bästa [[${interpreterName}]],
-        </p>
-        <br/>
-
-        <p>
-            Ruotsiksi: Merkintäsi oikeustulkkirekisteriin kieliparissa [[${langPairSV}]] on päättymässä [[${expiryDate}]].
-        </p>
-        <p>
-            Ruotsiksi: Sinun tulee hakea merkinnän uusimista, mikäli haluat jatkaa rekisteröitynä oikeustulkkina. Oikeustulkkirekisteriin merkitsemisestä päättää Oikeustulkkirekisterilautakunta kokouksissaan, joiden aikataulun näet rekisterin verkkosivulta: <a href="https://www.oph.fi/fi/palvelut/oikeustulkkirekisteri">https://www.oph.fi/fi/palvelut/oikeustulkkirekisteri</a>.
-        </p>
-        <p>
-            En ifylld och underskriven ansökningsblankett samt bilagan (utdrag ur befolkningsdatasystemet) skickas per post eller skannad till adressen:<br/>
-            Registratur, Utbildningsstyrelsen, PB 380, 00531 Helsingfors eller <a href="mailto:kirjaamo@oph.fi">kirjaamo@oph.fi</a>
-        </p>
-        <p>
-            Ansökan ska vara framme två veckor innan Examensnämndens nästa möte.
-        </p>
-        <p>
-            Ruotsiksi: Lisätietoja ja kysymyksiä: <a href="mailto:oikeustulkkirekisteri@oph.fi">oikeustulkkirekisteri@oph.fi</a>
-        </p>
-        <br/>
-
-        <p>
-            Svara inte till detta meddelande, det har skickats automatiskt.
-        </p>
-        <p>
-            Med vänlig hälsning<br/>
-            Registret över rättstolkar<br/>
-            Utbildningsstyrelsen
         </p>
     </body>
 </html>

--- a/backend/otr/src/test/java/fi/oph/otr/service/email/ClerkEmailServiceTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/service/email/ClerkEmailServiceTest.java
@@ -111,8 +111,6 @@ public class ClerkEmailServiceTest {
       "Iiro Rajala",
       "langPairFI",
       "suomi - englanti",
-      "langPairSV",
-      "finska - engelska",
       "expiryDate",
       "01.12.2049"
     );
@@ -128,10 +126,7 @@ public class ClerkEmailServiceTest {
 
     assertEquals("Iiro Rajala", emailData.recipientName());
     assertEquals("iiro.rajala@example.invalid", emailData.recipientAddress());
-    assertEquals(
-      "Merkintäsi oikeustulkkirekisteriin on päättymässä | Din ... ... går mot sitt slut",
-      emailData.subject()
-    );
+    assertEquals("Merkintäsi oikeustulkkirekisteriin on päättymässä", emailData.subject());
     assertEquals("Merkintäsi päättyy 01.12.2049", emailData.body());
 
     verify(qualificationReminderRepository).save(any());

--- a/backend/otr/src/test/java/fi/oph/otr/util/TemplateRendererTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/util/TemplateRendererTest.java
@@ -19,23 +19,13 @@ class TemplateRendererTest {
   @Test
   public void testQualificationExpiryTemplateIsRendered() {
     final String renderedContent = templateRenderer.renderQualificationExpiryEmailBody(
-      Map.of(
-        "interpreterName",
-        "Erkki Esimerkki",
-        "langPairFI",
-        "suomi - japani",
-        "langPairSV",
-        "finska - japanska",
-        "expiryDate",
-        "06.02.2022"
-      )
+      Map.of("interpreterName", "Erkki Esimerkki", "langPairFI", "suomi - japani", "expiryDate", "06.02.2022")
     );
 
     assertNotNull(renderedContent);
     assertTrue(renderedContent.contains("<html "));
     assertTrue(renderedContent.contains("Erkki Esimerkki"));
     assertTrue(renderedContent.contains("suomi - japani"));
-    assertTrue(renderedContent.contains("finska - japanska"));
     assertTrue(renderedContent.contains("06.02.2022"));
   }
 }


### PR DESCRIPTION
## Yhteenveto

Poistettu ruotsinkielinen osuus rekisteröinnin umpeutumismailipohjasta ml. sen tarvitsema `langPairSV` parametri. Muutettu myös postitusosoite allekkain eri riveille Saaran muokkauksen pohjalta.

Tätä vois testata vielä pallerolla joko tässä branchissä tai mergauksen jälkeen. Untuvalla testauksessa se ongelma, että noita sähköposteja luodaan vain öisin, jolloin untuva alhaalla ja niitä ei sitä myöten muodostu. Ajastusta vois toki myös muuttaa, jos sinne haluaa viedä version tämän kokeilemista varten.
