### PR TITLE
OTR(Backend): OPHOTRKEH-185 umpeutumismailien disablointi datamigraatiota varten

### DIFF
--- a/backend/otr/src/main/resources/oph-configuration/otr.properties.template
+++ b/backend/otr/src/main/resources/oph-configuration/otr.properties.template
@@ -11,7 +11,7 @@ virkailija.cas.service-url=${virkailija.cas.base-url}/otr/virkailija
 virkailija.cas.url=${virkailija.cas.base-url}/cas
 virkailija.cas.login-url=${virkailija.cas.base-url}/cas/login
 
-create-expiry-emails-enabled=true
+create-expiry-emails-enabled=false
 email.sending-enabled=true
 email.service-url=${virkailija.host.alb}/ryhmasahkoposti-service/email/firewall
 


### PR DESCRIPTION
## Yhteenveto

Disabloidaan umpeutumismailien lähetys datamigraatiota varten ja enabloidaan uudestaan myöhemmin, kun ollaan tuotannossa uuden OTR:n päällä ja vanha sovellus sammutettu. Yhdistän commitit vielä ennen mergeä. Edeltävät commitit liittyvät umpeutumismailien testaukseen tuotannon sähköpostipalvelimelta lähetettäessä omiin sähköpostitileihin.
