### PR TITLE
OTR(Frontend): OPHOTRKEH-211 updated info-text in public home page

### DIFF
--- a/frontend/packages/otr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/otr/public/i18n/en-GB/translation.json
@@ -333,7 +333,7 @@
           "title": "Search for a legal interpreter"
         },
         "noSearchResults": "No search results",
-        "note": "Legal interpreters always have two-way qualifications, for example, Finnish <-> English, English <-> Finnish",
+        "note": "Legal interpreters always have two-way qualifications, for example, Finnish <-> English, English <-> Finnish. To ensure equal visibility, the interpreters are randomly reordered within the search engine.",
         "title": "Register of Legal Interpreters"
       },
       "meetingDatesPage": {

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -333,7 +333,7 @@
           "title": "Etsi oikeustulkkia"
         },
         "noSearchResults": "Ei hakutuloksia",
-        "note": "Oikeustulkeilla on aina molemman suuntainen pätevyys esim. suomi <-> englanti englanti <-> suomi",
+        "note": "Oikeustulkeilla on aina molemman suuntainen pätevyys esim. suomi <-> englanti, englanti <-> suomi. Yhdenvertaisen näkyvyyden turvaamiseksi tulkit arvotaan hakukoneessa satunnaisjärjestykseen.",
         "title": "Oikeustulkkirekisteri"
       },
       "meetingDatesPage": {

--- a/frontend/packages/otr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/translation.json
@@ -333,7 +333,7 @@
           "title": "Sök en rättstolk"
         },
         "noSearchResults": "Inga sökresultat",
-        "note": "Rättstolkar har alltid behörighet i båda riktningarna, till exempel finska <-> engelska engelska <-> finska",
+        "note": "Rättstolkar har alltid behörighet i båda riktningarna, till exempel finska <-> engelska, engelska <-> finska. För att säkerställa likvärdig synlighet lottas tolkarna i slumpmässig ordning i sökmotorn.",
         "title": "Registret över rättstolkar"
       },
       "meetingDatesPage": {


### PR DESCRIPTION
## Yhteenveto

Päivitetty etusivun sinisen info-huomion tekstisisältöä. OTR:ssä tulkit järjestetään jokaisen sivun latauksen yhteydessä satunnaisjärjestykseen, joten tältä osin teksti eroaa AKR:n vastaavista käännöksistä. Käännökset tsekattu Saaran kanssa ja että ylipäänsä tämä satunnaisjärjestyshuomio täällä hyödyllinen.

## Check-lista
- [x] Käännösten Excel-tiedosto päivitetty
