### PR TITLE
OTR: OPHOTRKEH-213 poistetuksi merkitty tulkki tai rekisteröinti toimii kuten sitä ei olisi enää kannassa

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/api/clerk/ClerkInterpreterController.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/clerk/ClerkInterpreterController.java
@@ -65,8 +65,8 @@ public class ClerkInterpreterController {
 
   @Operation(tags = TAG_INTERPRETER, summary = "Delete interpreter")
   @DeleteMapping(path = "/{interpreterId:\\d+}")
-  public ClerkInterpreterDTO deleteInterpreter(@PathVariable final long interpreterId) {
-    return clerkInterpreterService.deleteInterpreter(interpreterId);
+  public void deleteInterpreter(@PathVariable final long interpreterId) {
+    clerkInterpreterService.deleteInterpreter(interpreterId);
   }
 
   // QUALIFICATION

--- a/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/dto/clerk/ClerkInterpreterDTO.java
@@ -8,7 +8,6 @@ import lombok.NonNull;
 public record ClerkInterpreterDTO(
   @NonNull Long id,
   @NonNull Integer version,
-  @NonNull Boolean deleted,
   @NonNull Boolean isIndividualised,
   @NonNull Boolean hasIndividualisedAddress,
   @NonNull String identityNumber,

--- a/backend/otr/src/main/java/fi/oph/otr/repository/InterpreterRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/InterpreterRepository.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InterpreterRepository extends BaseRepository<Interpreter> {
-  @Query("SELECT i.onrId FROM Interpreter i")
-  List<String> listAllOnrIds();
+  @Query("SELECT i FROM Interpreter i WHERE i.deletedAt IS NULL")
+  List<Interpreter> findExistingInterpreters();
+
+  @Query("SELECT i.onrId FROM Interpreter i WHERE i.deletedAt IS NULL")
+  List<String> listExistingOnrIds();
 }

--- a/backend/otr/src/main/java/fi/oph/otr/repository/QualificationRepository.java
+++ b/backend/otr/src/main/java/fi/oph/otr/repository/QualificationRepository.java
@@ -10,13 +10,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface QualificationRepository extends BaseRepository<Qualification> {
-  @Query(
-    "SELECT q" +
-    " FROM Qualification q" +
-    " JOIN q.interpreter i" +
-    " WHERE q.deletedAt IS NULL" +
-    " AND i.deletedAt IS NULL"
-  )
+  @Query("SELECT q FROM Qualification q WHERE q.deletedAt IS NULL")
   List<Qualification> findExistingQualifications();
 
   @Query(

--- a/backend/otr/src/main/java/fi/oph/otr/scheduled/OnrCacheUpdater.java
+++ b/backend/otr/src/main/java/fi/oph/otr/scheduled/OnrCacheUpdater.java
@@ -1,5 +1,6 @@
-package fi.oph.otr.onr;
+package fi.oph.otr.scheduled;
 
+import fi.oph.otr.onr.OnrService;
 import fi.oph.otr.repository.InterpreterRepository;
 import fi.oph.otr.util.SchedulingUtil;
 import java.util.List;
@@ -36,7 +37,7 @@ public class OnrCacheUpdater {
   public void updateOnrCache() {
     SchedulingUtil.runWithScheduledUser(() -> {
       LOG.debug("updateOnrCache");
-      final List<String> onrIds = interpreterRepository.listAllOnrIds();
+      final List<String> onrIds = interpreterRepository.listExistingOnrIds();
       onrService.updateCache(onrIds);
     });
   }

--- a/backend/otr/src/main/java/fi/oph/otr/service/ClerkInterpreterService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/ClerkInterpreterService.java
@@ -88,7 +88,7 @@ public class ClerkInterpreterService {
       .stream()
       .collect(Collectors.groupingBy(q -> q.getInterpreter().getId()));
 
-    final List<Interpreter> interpreters = interpreterRepository.findAll();
+    final List<Interpreter> interpreters = interpreterRepository.findExistingInterpreters();
     final Map<String, PersonalData> personalDatas = onrService.getCachedPersonalDatas();
 
     return interpreters
@@ -132,7 +132,6 @@ public class ClerkInterpreterService {
       .builder()
       .id(interpreter.getId())
       .version(interpreter.getVersion())
-      .deleted(interpreter.isDeleted())
       .isIndividualised(personalData.getIndividualised())
       .hasIndividualisedAddress(personalData.getHasIndividualisedAddress())
       .identityNumber(personalData.getIdentityNumber())
@@ -382,14 +381,12 @@ public class ClerkInterpreterService {
   }
 
   @Transactional
-  public ClerkInterpreterDTO deleteInterpreter(final long id) {
+  public void deleteInterpreter(final long id) {
     final Interpreter interpreter = interpreterRepository.getReferenceById(id);
     interpreter.markDeleted();
     interpreter.getQualifications().forEach(BaseEntity::markDeleted);
 
-    final ClerkInterpreterDTO result = getInterpreterWithoutAudit(id);
     auditService.logById(OtrOperation.DELETE_INTERPRETER, id);
-    return result;
   }
 
   @Transactional

--- a/backend/otr/src/main/java/fi/oph/otr/service/MeetingDateService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/MeetingDateService.java
@@ -72,6 +72,7 @@ public class MeetingDateService {
   public void deleteMeetingDate(final long meetingDateId) {
     final MeetingDate meetingDate = meetingDateRepository.getReferenceById(meetingDateId);
 
+    // TODO: qualifications marked deleted block deletion of meeting date with those linked
     if (!meetingDate.getQualifications().isEmpty()) {
       throw new APIException(APIExceptionType.MEETING_DATE_DELETE_HAS_QUALIFICATIONS);
     }

--- a/backend/otr/src/test/java/fi/oph/otr/scheduled/OnrCacheUpdaterTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/scheduled/OnrCacheUpdaterTest.java
@@ -1,9 +1,10 @@
-package fi.oph.otr.onr;
+package fi.oph.otr.scheduled;
 
 import static org.mockito.Mockito.verify;
 
 import fi.oph.otr.Factory;
 import fi.oph.otr.model.Interpreter;
+import fi.oph.otr.onr.OnrService;
 import fi.oph.otr.repository.InterpreterRepository;
 import java.util.List;
 import javax.annotation.Resource;

--- a/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkInterpreter.ts
@@ -39,7 +39,6 @@ export interface ClerkInterpreter
   extends WithId,
     WithVersion,
     ClerkInterpreterBasicInformation {
-  deleted: boolean;
   isIndividualised: boolean;
   hasIndividualisedAddress: boolean;
   qualifications: ClerkInterpreterQualifications;

--- a/frontend/packages/otr/src/interfaces/clerkNewInterpreter.ts
+++ b/frontend/packages/otr/src/interfaces/clerkNewInterpreter.ts
@@ -6,7 +6,6 @@ export interface ClerkNewInterpreter
     ClerkInterpreter,
     | 'id'
     | 'version'
-    | 'deleted'
     | 'isIndividualised'
     | 'hasIndividualisedAddress'
     | 'qualifications'

--- a/frontend/packages/otr/src/utils/serialization.ts
+++ b/frontend/packages/otr/src/utils/serialization.ts
@@ -74,7 +74,6 @@ export class SerializationUtils {
     const {
       id,
       version,
-      deleted,
       isIndividualised,
       hasIndividualisedAddress,
       permissionToPublishEmail,
@@ -91,7 +90,6 @@ export class SerializationUtils {
       ...textFields,
       id,
       version,
-      deleted,
       isIndividualised,
       hasIndividualisedAddress,
       permissionToPublishEmail,


### PR DESCRIPTION
## Yhteenveto

Muutetettu ClerkInterpreter rajapintoja siten, että hakujen yhteydessä (listaus, yksittäisen tulkin haku) tulkkia, joka on merkattu poistetuksi ei enää palauteta, vaan tuon sijaan pitäis nyt tulla 404:ää. Myöskään itse tulkin poiston yhteydessä ei enää palauteta poistettua tulkkia, koska "sitä ei ole enää olemassa".


Alkuperäinen toteutus nojasi siihen ajatukseen, että UI:sta käsin voitaisiin ehkä tulevaisuudessa antaa virkailijoiden tarkastella poistetuiksi merkittyjä tulkkeja ja ehkä myös rekisteröintejä ja tehdä niillä jotain (tai vähintään tarkastella noita). Tähän hätään tuntui kuitenkin loogisemmalta, että soft-deletoidut entiteetit olisivat ikään kuin lopullisesti tuhottuja frontin näkökulmasta, niin ei tartte siellä suunnalla sitten enää miettiä, annetaanko virkailijan avata poistetun tulkin sivun tietäen sellaisen id:n tai että etusivun rekisterin koon puolesta tarttis filteröidä poistettuja pois ja mahd. muuta.

Vien tämän tuotantoon ajoon niin näkee vielä siellä että pelaa oikein.
