### PR TITLE
OPHYKIKEH-148: YKI registation base structure

### DIFF
--- a/frontend/packages/yki/public/i18n/en-GB/common.json
+++ b/frontend/packages/yki/public/i18n/en-GB/common.json
@@ -17,6 +17,11 @@
           "sv": "På svenska"
         }
       },
+      "languageLevel": {
+        "KESKI": "intermediate level",
+        "PERUS": "basic level",
+        "YLIN": "advanced level"
+      },
       "languages": {
         "deu": "German",
         "eng": "English",
@@ -29,15 +34,10 @@
         "swe": "Swedish"
       },
       "level": "Level",
-      "levels": {
-        "PERUS": "basic level",
-        "KESKI": "intermediate level",
-        "YLIN": "advanced level"
-      },
       "ophLogo": "Logo of Finnish National Agency for Education",
       "price": "Price",
-      "registration": "Registration",
-      "reassessment": "Reassessment"
+      "reassessment": "Reassessment",
+      "registration": "Registration"
     }
   }
 }

--- a/frontend/packages/yki/public/i18n/fi-FI/common.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/common.json
@@ -2,10 +2,12 @@
   "yki": {
     "common": {
       "appTitle": "Yleiset kielitutkinnot | Opetushallitus",
+      "back": "Takaisin",
       "buttons": {
         "empty": "Tyhjennä kaikki",
         "showResults": "Näytä tulokset ({{count}})"
       },
+      "cancel": "Peruuta",
       "component": {
         "table": {
           "pagination": {
@@ -23,6 +25,13 @@
       },
       "error": "Tapahtui odottamaton virhe.",
       "errors": {
+        "customTextField": {
+          "emailFormat": "Sähköpostiosoite on virheellinen",
+          "maxLength": "Teksti on liian pitkä",
+          "numberFormat": "Arvo on virheellinen",
+          "required": "Tieto on pakollinen",
+          "telFormat": "Puhelinnumero on virheellinen"
+        },
         "loadingFailed": "Tietojen lataaminen epäonnistui."
       },
       "examSession": "Tutkintotilaisuus",
@@ -38,6 +47,11 @@
       },
       "institution": "Oppilaitos",
       "language": "Kieli",
+      "languageLevel": {
+        "KESKI": "keskitaso",
+        "PERUS": "perustaso",
+        "YLIN": "ylin taso"
+      },
       "languages": {
         "deu": "saksa",
         "eng": "englanti",
@@ -50,18 +64,19 @@
         "swe": "ruotsi"
       },
       "level": "Taso",
-      "levels": {
-        "PERUS": "perustaso",
-        "KESKI": "keskitaso",
-        "YLIN": "ylin taso"
-      },
       "municipality": "Paikkakunta",
+      "navigationProtection": {
+        "description": "Menetät tekemäsi muutokset.",
+        "header": "Haluatko varmasti poistua sivulta?"
+      },
+      "next": "Seuraava",
       "ophLogo": "Opetushallituksen logo",
       "placesAvailable": "Paikkoja vapaana",
       "price": "Hinta",
+      "reassessment": "Tarkistusarviointi",
       "registration": "Ilmoittautuminen",
       "registrationPeriod": "Ilmoittautumisaika",
-      "reassessment": "Tarkistusarviointi",
+      "yes": "Kyllä",
       "ykiHomepage": {
         "ariaLabel": "Yleisten kielitutkintojen kotisivu (oph.fi), avaa uudessa välilehdessä",
         "link": "https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/yleiset-kielitutkinnot-yki"

--- a/frontend/packages/yki/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/public.json
@@ -30,26 +30,96 @@
           }
         }
       },
-      "publicExamEventGrid": {
-        "title": "Yleisiin kielitutkintoihin ilmoittautuminen"
+      "registration": {
+        "controlButtons": {
+          "cancelDialog": {
+            "description": "Haluatko peruuttaa ilmoittautumisen? Menetät täyttämäsi tiedot.",
+            "title": "Peruuta ilmoittautuminen"
+          },
+          "pay": "Siirry maksamaan",
+          "sendForm": "Lähetä lomake"
+        },
+        "examSessionDetails": {
+          "address": "Osoite",
+          "examDate": "Tutkintopäivä",
+          "openings": "Paikkoja vapaana",
+          "registrationCloses": "Ilmoittautuminen sulkeutuu"
+        },
+        "paymentSum": {
+          "title": "Tutkintomaksu"
+        },
+        "stepper": {
+          "active": "Aktiivinen",
+          "completed": "Suoritettu",
+          "phase": "Vaihe",
+          "step": {
+            "Done": "Valmis",
+            "Identify": "Tunnistaudu",
+            "Register": "Ilmoittaudu"
+          }
+        },
+        "steps": {
+          "done": {
+            "description": {
+              "part1": "Sinulle lähetetään vahvistus osoitteeseen",
+              "part2": "Tämä sivu ohjaa sinut automaattisesti takaisin etusivulle. Jos mitään ei tapahdu voit klikata alla olevasta napista."
+            },
+            "successToast": "Ilmoittautuminen onnistui!",
+            "title": "Maksu on suoritettu."
+          },
+          "identify": {
+            "buttonText": "TUNNISTAUDU SUOMI.FI:N KAUTTA",
+            "title": "Tunnistaudu ilmoittautumista varten"
+          },
+          "personDetails": {
+            "address": "Katuosoite",
+            "firstNames": "Etunimet",
+            "lastName": "Sukunimi",
+            "postNumber": "Postinumero",
+            "postOffice": "Postitoimipaikka",
+            "title": "Henkilötiedot"
+          },
+          "register": {
+            "email": "Sähköpostiosoite",
+            "emailConfirmation": "Vahvista sähköpostiosoite",
+            "mismatchingEmailsError": "Sähköpostiosoitekenttien sisällöt eivät vastaa toisiaan",
+            "phoneNumber": "Puhelinnumero",
+            "privacyStatement": {
+              "ariaLabel": "Tietosuojaseloste",
+              "label": "Olen lukenut tämän palvelun <0></0> ja hyväksyn sen.",
+              "linkLabel": "tietosuojaselosteen"
+            },
+            "termsAndConditions": {
+              "description": "1.1.2023 alkaen tarvitset todistuksen sairaudesta tai muusta painavasta syystä, jos haluat perua ilmoittautumisesi YKI-testiin.",
+              "label": "Hyväksyn ehdot",
+              "title": "Ilmoittautuminen YKI-testiin on sitova. Et voi muuttaa ilmoittautumista vahvistamisen jälkeen. Tarkista, että olet ilmoittautumassa oikean kielen ja tason testiin."
+            },
+            "title": "Yhteystiedot"
+          }
+        }
       }
     },
     "pages": {
+      "examDetailsPage": {
+        "toasts": {
+          "notFound": "Kielitutkintoa ei löytynyt"
+        }
+      },
       "registrationPage": {
         "labels": {
+          "excludeFullSessions": "Näytä vain tutkintotilaisuudet, joissa on tilaa",
+          "excludeNonOpenSessions": "Näytä vain nyt avoinna olevat tutkintotilaisuudet",
+          "filterExamSessions": "Suodata tutkintotilaisuuksia",
           "selectLanguage": "Valitse kieli",
           "selectLevel": "Valitse taso",
-          "selectMunicipality": "Valitse paikkakunta",
-          "filterExamSessions": "Suodata tutkintotilaisuuksia",
-          "excludeFullSessions": "Näytä vain tutkintotilaisuudet, joissa on tilaa",
-          "excludeNonOpenSessions": "Näytä vain nyt avoinna olevat tutkintotilaisuudet"
+          "selectMunicipality": "Valitse paikkakunta"
         },
-        "title": "Yleiset kielitutkinnot (YKI) - Ilmoittautuminen",
         "register": "Ilmoittaudu",
         "searchResults": "Tulokset ({{count}})",
-        "searchResultsAriaLabel_zero": "Tulokset (ei tuloksia)",
         "searchResultsAriaLabel_one": "Tulokset (1 tulos)",
-        "searchResultsAriaLabel_other": "Tulokset ({{count}} tulosta)"
+        "searchResultsAriaLabel_other": "Tulokset ({{count}} tulosta)",
+        "searchResultsAriaLabel_zero": "Tulokset (ei tuloksia)",
+        "title": "Yleiset kielitutkinnot (YKI) - Ilmoittautuminen"
       }
     }
   }

--- a/frontend/packages/yki/public/i18n/sv-SE/common.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/common.json
@@ -17,6 +17,11 @@
           "sv": "På svenska"
         }
       },
+      "languageLevel": {
+        "KESKI": "mellannivå",
+        "PERUS": "grundnivå",
+        "YLIN": "högsta nivå"
+      },
       "languages": {
         "deu": "tyska",
         "eng": "engelska",
@@ -29,15 +34,10 @@
         "swe": "svenska"
       },
       "level": "Nivå",
-      "levels": {
-        "PERUS": "grundnivå",
-        "KESKI": "mellannivå",
-        "YLIN": "högsta nivå"
-      },
       "ophLogo": "Utbildningsstyrelsens logo",
       "price": "Pris",
-      "registration": "Anmälning",
-      "reassessment": "Kontrollbedömning"
+      "reassessment": "Kontrollbedömning",
+      "registration": "Anmälning"
     }
   }
 }

--- a/frontend/packages/yki/src/components/layouts/publicHeader/PublicNavTabs.tsx
+++ b/frontend/packages/yki/src/components/layouts/publicHeader/PublicNavTabs.tsx
@@ -1,6 +1,6 @@
 import { Tab, Tabs } from '@mui/material';
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { matchPath, useLocation, useNavigate } from 'react-router-dom';
 import { Color } from 'shared/enums';
 
 import { useCommonTranslation } from 'configs/i18n';
@@ -18,7 +18,11 @@ export const PublicNavTabs = (): JSX.Element => {
   };
 
   useEffect(() => {
-    if (pathname === AppRoutes.Registration) {
+    if (
+      pathname === AppRoutes.Registration ||
+      matchPath(AppRoutes.ExamSession, pathname) ||
+      matchPath(AppRoutes.ExamSessionRegistration, pathname)
+    ) {
       setValue(HeaderTabNav.Registration);
     } else if (pathname === AppRoutes.Reassessment) {
       setValue(HeaderTabNav.Reassessment);

--- a/frontend/packages/yki/src/components/registration/PrivacyStatementCheckboxLabel.tsx
+++ b/frontend/packages/yki/src/components/registration/PrivacyStatementCheckboxLabel.tsx
@@ -1,0 +1,24 @@
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { Trans } from 'react-i18next';
+import { ExtLink } from 'shared/components';
+
+import { usePublicTranslation } from 'configs/i18n';
+import { AppRoutes } from 'enums/app';
+
+export const PrivacyStatementCheckboxLabel = () => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.steps.register.privacyStatement',
+  });
+
+  return (
+    <Trans t={t} i18nKey="label">
+      <ExtLink
+        className="public-registration__grid__preview__privacy-statement-checkbox-label__link"
+        text={t('linkLabel')}
+        href={AppRoutes.PrivacyPolicyPage}
+        endIcon={<OpenInNewIcon />}
+        aria-label={t('ariaLabel')}
+      />
+    </Trans>
+  );
+};

--- a/frontend/packages/yki/src/components/registration/PublicIdentificationGrid.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicIdentificationGrid.tsx
@@ -1,0 +1,76 @@
+import { Grid, Paper } from '@mui/material';
+import { useNavigate } from 'react-router';
+import { CustomButton, H3 } from 'shared/components';
+import { Color, Variant } from 'shared/enums';
+
+import { PublicRegistrationExamSessionDetails } from 'components/registration/PublicRegistrationExamSessionDetails';
+import { PublicRegistrationStepper } from 'components/registration/PublicRegistrationStepper';
+import { usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { AppRoutes } from 'enums/app';
+import { increaseActiveStep } from 'redux/reducers/examSession';
+import { examSessionSelector } from 'redux/selectors/examSession';
+
+export const PublicIdentificationGrid = () => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.steps.identify',
+  });
+
+  const navigate = useNavigate();
+
+  const { activeStep, examSession } = useAppSelector(examSessionSelector);
+  const dispatch = useAppDispatch();
+
+  if (!examSession) {
+    return null;
+  }
+
+  const renderDesktopView = () => (
+    <>
+      <Grid className="public-registration" item>
+        <Paper elevation={3}>
+          <div className="public-registration__grid__form-container">
+            <PublicRegistrationStepper activeStep={activeStep} />
+            <PublicRegistrationExamSessionDetails
+              examSession={examSession}
+              showOpenings={true}
+            />
+            <div className="margin-top-xxl gapped rows">
+              <H3>{t('title')}</H3>
+              <CustomButton
+                sx={{ width: '168px' }}
+                variant={Variant.Contained}
+                color={Color.Secondary}
+                onClick={() => {
+                  // TODO: init authentication for suomi.fi
+                  dispatch(increaseActiveStep());
+                  navigate(
+                    AppRoutes.ExamSessionRegistration.replace(
+                      /:examSessionId$/,
+                      `${examSession.id}`
+                    )
+                  );
+                }}
+                data-testid="public-registration__identify-button"
+                disabled={false}
+              >
+                {t('buttonText')}
+              </CustomButton>
+            </div>
+          </div>
+        </Paper>
+      </Grid>
+    </>
+  );
+
+  return (
+    <Grid
+      container
+      rowSpacing={4}
+      direction="column"
+      className="public-registration"
+    >
+      {renderDesktopView()}
+    </Grid>
+  );
+};

--- a/frontend/packages/yki/src/components/registration/PublicRegistrationControlButtons.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicRegistrationControlButtons.tsx
@@ -1,0 +1,120 @@
+import {
+  ArrowBackOutlined as ArrowBackIcon,
+  ArrowForwardOutlined as ArrowForwardIcon,
+} from '@mui/icons-material';
+import { useNavigate } from 'react-router';
+import { CustomButton } from 'shared/components';
+import { Color, Severity, Variant } from 'shared/enums';
+import { useDialog } from 'shared/hooks';
+
+import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
+import { AppRoutes } from 'enums/app';
+import { PublicRegistrationFormStep } from 'enums/publicRegistration';
+import {
+  decreaseActiveStep,
+  increaseActiveStep,
+  resetPublicRegistration,
+} from 'redux/reducers/examSession';
+
+export const PublicRegistrationControlButtons = ({
+  activeStep,
+  isLoading,
+  disableNext,
+}: {
+  activeStep: PublicRegistrationFormStep;
+  isLoading: boolean;
+  disableNext: boolean;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.controlButtons',
+  });
+  const translateCommon = useCommonTranslation();
+
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const { showDialog } = useDialog();
+
+  const handleCancelBtnClick = () => {
+    showDialog({
+      title: t('cancelDialog.title'),
+      severity: Severity.Info,
+      description: t('cancelDialog.description'),
+      actions: [
+        {
+          title: translateCommon('back'),
+          variant: Variant.Outlined,
+        },
+        {
+          title: translateCommon('yes'),
+          variant: Variant.Contained,
+          action: () => {
+            dispatch(resetPublicRegistration());
+            navigate(AppRoutes.Registration);
+          },
+        },
+      ],
+    });
+  };
+
+  const handleBackBtnClick = () => {
+    dispatch(decreaseActiveStep());
+  };
+
+  const handleSubmitBtnClick = () => {
+    dispatch(increaseActiveStep());
+  };
+
+  const CancelButton = () => (
+    <>
+      <CustomButton
+        variant={Variant.Text}
+        color={Color.Secondary}
+        onClick={handleCancelBtnClick}
+        data-testid="public-registration__controlButtons__cancel"
+        disabled={isLoading}
+      >
+        {translateCommon('cancel')}
+      </CustomButton>
+    </>
+  );
+
+  const BackButton = () => (
+    <CustomButton
+      variant={Variant.Outlined}
+      color={Color.Secondary}
+      onClick={handleBackBtnClick}
+      data-testid="public-registration__controlButtons__back"
+      startIcon={<ArrowBackIcon />}
+      disabled={activeStep == PublicRegistrationFormStep.Register || isLoading}
+    >
+      {translateCommon('back')}
+    </CustomButton>
+  );
+
+  const SubmitButton = () => (
+    <CustomButton
+      variant={Variant.Contained}
+      color={Color.Secondary}
+      onClick={handleSubmitBtnClick}
+      data-testid="public-registration__controlButtons__submit"
+      endIcon={<ArrowForwardIcon />}
+      disabled={disableNext || isLoading}
+    >
+      {t('pay')}
+    </CustomButton>
+  );
+
+  const renderBack = activeStep !== PublicRegistrationFormStep.Identify;
+
+  const renderSubmit = activeStep === PublicRegistrationFormStep.Register;
+
+  return (
+    <div className="columns flex-end gapped margin-top-lg">
+      {CancelButton()}
+      {renderBack && BackButton()}
+      {renderSubmit && SubmitButton()}
+    </div>
+  );
+};

--- a/frontend/packages/yki/src/components/registration/PublicRegistrationExamSessionDetails.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicRegistrationExamSessionDetails.tsx
@@ -1,0 +1,61 @@
+import { H2, HeaderSeparator, Text } from 'shared/components';
+import { DateUtils } from 'shared/utils';
+
+import {
+  getCurrentLang,
+  useCommonTranslation,
+  usePublicTranslation,
+} from 'configs/i18n';
+import { ExamSession } from 'interfaces/examSessions';
+import { ExamUtils } from 'utils/exam';
+import { ExamSessionUtils } from 'utils/examSession';
+
+export const PublicRegistrationExamSessionDetails = ({
+  examSession,
+  showOpenings,
+}: {
+  examSession: ExamSession;
+  showOpenings: boolean;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.examSessionDetails',
+  });
+  const translateCommon = useCommonTranslation();
+  const header = ExamSessionUtils.languageAndLevelText(
+    examSession.language_code,
+    examSession.level_code,
+    translateCommon
+  );
+
+  const location = ExamUtils.getLocationInfo(examSession, getCurrentLang());
+
+  return (
+    <div className="margin-top-xxl rows">
+      <div className="rows gapped-xs">
+        <H2>{header}</H2>
+        <HeaderSeparator />
+      </div>
+      <div className="rows-gapped-xxs">
+        <Text>{`${t('address')}: ${location.name}, ${
+          location.street_address
+        }, ${location.post_office}`}</Text>
+        <Text>{`${t('examDate')}: ${DateUtils.formatOptionalDate(
+          examSession.session_date
+        )}`}</Text>
+        <Text>{`${t('registrationCloses')}: ${DateUtils.formatOptionalDate(
+          examSession.registration_end_date
+        )}`}</Text>
+        {showOpenings && (
+          <Text>{`${t('openings')}: ${
+            examSession.participants
+              ? Math.max(
+                  examSession.max_participants - examSession.participants,
+                  0
+                )
+              : examSession.max_participants
+          }`}</Text>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/packages/yki/src/components/registration/PublicRegistrationGrid.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicRegistrationGrid.tsx
@@ -1,0 +1,82 @@
+import { Grid, Paper } from '@mui/material';
+import { useState } from 'react';
+import { LoadingProgressIndicator } from 'shared/components';
+import { APIResponseStatus } from 'shared/enums';
+
+import { PublicRegistrationControlButtons } from 'components/registration/PublicRegistrationControlButtons';
+import { PublicRegistrationExamSessionDetails } from 'components/registration/PublicRegistrationExamSessionDetails';
+import { PublicRegistrationPaymentSum } from 'components/registration/PublicRegistrationPaymentSum';
+import { PublicRegistrationStepContents } from 'components/registration/PublicRegistrationStepContents';
+import { PublicRegistrationStepper } from 'components/registration/PublicRegistrationStepper';
+import { useAppSelector } from 'configs/redux';
+import { PublicRegistrationFormStep } from 'enums/publicRegistration';
+import { useNavigationProtection } from 'hooks/useNavigationProtection';
+import { examSessionSelector } from 'redux/selectors/examSession';
+
+export const PublicRegistrationGrid = () => {
+  const [disableNext, setDisableNext] = useState(true);
+
+  const disableNextCb = (disabled: boolean) => setDisableNext(disabled);
+
+  const { status, activeStep, examSession, registration, isEmailRegistration } =
+    useAppSelector(examSessionSelector);
+
+  // TODO: Add bypass or some another way to skip nav prot when user
+  // intentionally chooses to cancel the registration and navigate back
+  useNavigationProtection(false);
+
+  const isLoading = status === APIResponseStatus.InProgress;
+  const isRegistrationStepActive =
+    activeStep === PublicRegistrationFormStep.Register;
+  const isDoneStepActive = activeStep === PublicRegistrationFormStep.Done;
+
+  if (!examSession) {
+    return null;
+  }
+
+  const renderDesktopView = () => (
+    <>
+      <Grid className="public-registration" item>
+        <Paper elevation={3}>
+          <LoadingProgressIndicator isLoading={isLoading} displayBlock={true}>
+            <div className="public-registration__grid__form-container">
+              <PublicRegistrationStepper activeStep={activeStep} />
+              <PublicRegistrationExamSessionDetails
+                examSession={examSession}
+                showOpenings={!isDoneStepActive}
+              />
+              <PublicRegistrationStepContents
+                activeStep={activeStep}
+                registration={registration}
+                isLoading={isLoading}
+                disableNext={disableNextCb}
+                isEmailRegistration={isEmailRegistration}
+              />
+              {isRegistrationStepActive && (
+                <PublicRegistrationPaymentSum examSession={examSession} />
+              )}
+              {!isDoneStepActive && (
+                <PublicRegistrationControlButtons
+                  activeStep={activeStep}
+                  isLoading={isLoading}
+                  disableNext={disableNext}
+                />
+              )}
+            </div>
+          </LoadingProgressIndicator>
+        </Paper>
+      </Grid>
+    </>
+  );
+
+  return (
+    <Grid
+      container
+      rowSpacing={4}
+      direction="column"
+      className="public-registration"
+    >
+      {renderDesktopView()}
+    </Grid>
+  );
+};

--- a/frontend/packages/yki/src/components/registration/PublicRegistrationPaymentSum.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicRegistrationPaymentSum.tsx
@@ -1,0 +1,26 @@
+import { H1 } from 'shared/components';
+
+import { usePublicTranslation } from 'configs/i18n';
+import { ExamSession } from 'interfaces/examSessions';
+
+export const PublicRegistrationPaymentSum = ({
+  examSession,
+}: {
+  examSession: ExamSession;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.paymentSum',
+  });
+
+  if (!examSession?.exam_fee) {
+    return null;
+  }
+
+  const content = `${t('title')}: ${examSession.exam_fee}.00 €`;
+
+  return (
+    <div className="columns flex-end">
+      <H1 className="margin-top-lg">{content}</H1>
+    </div>
+  );
+};

--- a/frontend/packages/yki/src/components/registration/PublicRegistrationStepContents.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicRegistrationStepContents.tsx
@@ -1,0 +1,49 @@
+import { Done } from 'components/registration/steps/Done';
+import { EmailRegistrationFillContactDetails } from 'components/registration/steps/EmailRegistrationFillContactDetails';
+import { FillContactDetails } from 'components/registration/steps/FillContactDetails';
+import { PublicRegistrationFormStep } from 'enums/publicRegistration';
+import {
+  PublicEmailRegistration,
+  PublicSuomiFiRegistration,
+} from 'interfaces/publicRegistration';
+
+export const PublicRegistrationStepContents = ({
+  activeStep,
+  registration,
+  isLoading,
+  isEmailRegistration,
+  disableNext,
+}: {
+  activeStep: PublicRegistrationFormStep;
+  registration: PublicEmailRegistration | PublicSuomiFiRegistration;
+  isLoading: boolean;
+  isEmailRegistration?: boolean;
+  disableNext: (disabled: boolean) => void;
+}) => {
+  switch (activeStep) {
+    case PublicRegistrationFormStep.Identify:
+      return <></>;
+    case PublicRegistrationFormStep.Register:
+      if (isEmailRegistration) {
+        return (
+          <EmailRegistrationFillContactDetails
+            registration={registration as PublicEmailRegistration}
+            isLoading={isLoading}
+            disableNext={disableNext}
+          />
+        );
+      }
+
+      return (
+        <FillContactDetails
+          registration={registration as PublicSuomiFiRegistration}
+          isLoading={isLoading}
+          disableNext={disableNext}
+        />
+      );
+    case PublicRegistrationFormStep.Done:
+      return <Done registration={registration} />;
+    default:
+      return <> </>;
+  }
+};

--- a/frontend/packages/yki/src/components/registration/PublicRegistrationStepper.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicRegistrationStepper.tsx
@@ -1,0 +1,63 @@
+import { Step, StepLabel, Stepper } from '@mui/material';
+
+import { usePublicTranslation } from 'configs/i18n';
+import { PublicRegistrationFormStep } from 'enums/publicRegistration';
+
+export const PublicRegistrationStepper = ({
+  activeStep,
+}: {
+  activeStep: PublicRegistrationFormStep;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.stepper',
+  });
+
+  const doneStepNumber = PublicRegistrationFormStep.Done;
+
+  const stepNumbers = Object.values(PublicRegistrationFormStep)
+    .filter((i) => !isNaN(Number(i)))
+    .map(Number)
+    .filter((i) => i <= doneStepNumber);
+
+  const getStatusText = (stepNumber: number) => {
+    if (stepNumber < activeStep) {
+      return t('completed');
+    } else if (stepNumber === activeStep) {
+      return t('active');
+    }
+  };
+
+  const getDescription = (stepNumber: number) => {
+    return t(`step.${PublicRegistrationFormStep[stepNumber]}`);
+  };
+
+  const getStepAriaLabel = (stepNumber: number) => {
+    const part = `${stepNumber}/${stepNumbers.length}`;
+    const statusText = getStatusText(stepNumber);
+    const partStatus = statusText ? `${part}, ${statusText}` : part;
+
+    return `${t('phase')} ${partStatus}: ${getDescription(stepNumber)}`;
+  };
+
+  return (
+    <Stepper
+      className="public-registration__grid__stepper"
+      activeStep={activeStep - 1}
+    >
+      {stepNumbers.map((i) => (
+        <Step key={i}>
+          <StepLabel
+            aria-label={getStepAriaLabel(i)}
+            className={
+              activeStep < i
+                ? 'public-registration__grid__stepper__step-disabled'
+                : undefined
+            }
+          >
+            {getDescription(i)}
+          </StepLabel>
+        </Step>
+      ))}
+    </Stepper>
+  );
+};

--- a/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingFilters.tsx
+++ b/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingFilters.tsx
@@ -77,7 +77,7 @@ export const PublicExamSessionFilters = ({
 
   const levelToComboBoxOption = (v: ExamLevel) => ({
     value: v.toString(),
-    label: translateCommon('levels.' + v.toString()),
+    label: translateCommon('languageLevel.' + v.toString()),
   });
   const levelValues = Object.values(ExamLevel).map(levelToComboBoxOption);
   const municipalityToComboBoxOption = (m: string) => ({

--- a/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingRow.tsx
+++ b/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingRow.tsx
@@ -1,8 +1,14 @@
 import { TableCell, TableRow } from '@mui/material';
+import { useNavigate } from 'react-router';
+import { CustomButton } from 'shared/components';
+import { Color, Variant } from 'shared/enums';
 import { DateUtils } from 'shared/utils';
 
 import { getCurrentLang, usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
+import { AppRoutes } from 'enums/app';
 import { ExamSession } from 'interfaces/examSessions';
+import { storeExamSession } from 'redux/reducers/examSession';
 import { ExamUtils } from 'utils/exam';
 
 export const PublicExamSessionListingRow = ({
@@ -10,10 +16,14 @@ export const PublicExamSessionListingRow = ({
 }: {
   examSession: ExamSession;
 }) => {
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const locationInfo = ExamUtils.getLocationInfo(examSession, getCurrentLang());
+
   const { t } = usePublicTranslation({
     keyPrefix: 'yki.pages.registrationPage',
   });
-  const locationInfo = ExamUtils.getLocationInfo(examSession, getCurrentLang());
 
   return (
     <TableRow
@@ -40,7 +50,24 @@ export const PublicExamSessionListingRow = ({
       <TableCell>
         {examSession.max_participants - (examSession.participants ?? 0)}
       </TableCell>
-      <TableCell>{t('register')}</TableCell>
+      <TableCell>
+        <CustomButton
+          data-testid="clerk-translator-registry__reset-filters-btn"
+          color={Color.Secondary}
+          variant={Variant.Outlined}
+          onClick={() => {
+            dispatch(storeExamSession(examSession));
+            navigate(
+              AppRoutes.ExamSession.replace(
+                /:examSessionId$/,
+                `${examSession.id}`
+              )
+            );
+          }}
+        >
+          {t('register')}
+        </CustomButton>
+      </TableCell>
     </TableRow>
   );
 };

--- a/frontend/packages/yki/src/components/registration/steps/Done.tsx
+++ b/frontend/packages/yki/src/components/registration/steps/Done.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useEffect } from 'react';
+import { CustomButton, H2, Text } from 'shared/components';
+import { Duration, Severity } from 'shared/enums';
+import { useToast } from 'shared/hooks';
+
+import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
+import {
+  PublicEmailRegistration,
+  PublicSuomiFiRegistration,
+} from 'interfaces/publicRegistration';
+import { resetPublicRegistration } from 'redux/reducers/examSession';
+
+export const Done = ({
+  registration,
+}: {
+  registration: PublicEmailRegistration | PublicSuomiFiRegistration;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.steps.done',
+  });
+  const translateCommon = useCommonTranslation();
+
+  const dispatch = useAppDispatch();
+  const { showToast } = useToast();
+
+  const resetAndRedirect = useCallback(() => {
+    dispatch(resetPublicRegistration());
+  }, [dispatch]);
+
+  useEffect(() => {
+    showToast({
+      severity: Severity.Success,
+      description: t('successToast'),
+    });
+
+    const timer = setTimeout(() => {
+      resetAndRedirect();
+    }, Duration.MediumExtra);
+
+    return () => clearTimeout(timer);
+  }, [t, showToast, resetAndRedirect]);
+
+  return (
+    <div className="margin-top-xxl rows gapped">
+      <H2>{t('title')}</H2>
+      <Text>
+        <strong>{`${t('description.part1')}: ${registration.email}`}</strong>
+      </Text>
+      <Text>{t('description.part2')}</Text>
+      <CustomButton
+        className="align-self-start margin-top-lg"
+        color="secondary"
+        variant="contained"
+        onClick={resetAndRedirect}
+      >
+        {translateCommon('frontPage')}
+      </CustomButton>
+    </div>
+  );
+};

--- a/frontend/packages/yki/src/components/registration/steps/EmailRegistrationFillContactDetails.tsx
+++ b/frontend/packages/yki/src/components/registration/steps/EmailRegistrationFillContactDetails.tsx
@@ -1,0 +1,180 @@
+import { Checkbox, FormControlLabel } from '@mui/material';
+import { ChangeEvent, useEffect, useState } from 'react';
+import { CustomTextField, Text } from 'shared/components';
+import { Color, TextFieldTypes } from 'shared/enums';
+import { InputFieldUtils, StringUtils } from 'shared/utils';
+
+import { PrivacyStatementCheckboxLabel } from 'components/registration/PrivacyStatementCheckboxLabel';
+import { PersonDetails } from 'components/registration/steps/PersonDetails';
+import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
+import {
+  PublicEmailRegistration,
+  RegistrationCheckboxDetails,
+} from 'interfaces/publicRegistration';
+import { updatePublicRegistration } from 'redux/reducers/examSession';
+
+export const EmailRegistrationFillContactDetails = ({
+  registration,
+  isLoading,
+  disableNext,
+}: {
+  registration: PublicEmailRegistration;
+  isLoading: boolean;
+  disableNext: (disabled: boolean) => void;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.steps.register',
+  });
+  const translateCommon = useCommonTranslation();
+
+  const [fieldErrors, setFieldErrors] = useState({
+    firstNames: '',
+    lastName: '',
+    phoneNumber: '',
+    email: '',
+    address: '',
+    postNumber: '',
+    postOffice: '',
+    privacyStatementConfirmation: '',
+    certificateLanguage: '',
+    termsAndConditionsAgreed: '',
+    nationality: '',
+    dateOfBirth: '',
+    sex: '',
+    hasSSN: '',
+    ssn: '',
+  });
+
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const hasFieldErrors = !!(
+      fieldErrors.firstNames ||
+      fieldErrors.lastName ||
+      fieldErrors.address ||
+      fieldErrors.postNumber ||
+      fieldErrors.postOffice ||
+      fieldErrors.email ||
+      fieldErrors.phoneNumber ||
+      fieldErrors.nationality ||
+      fieldErrors.dateOfBirth ||
+      fieldErrors.sex
+    );
+
+    const ssnError =
+      registration.hasSSN === undefined ||
+      (registration.hasSSN && StringUtils.isBlankString(registration.ssn));
+
+    const hasBlankFieldValues = [
+      registration.email,
+      registration.phoneNumber,
+    ].some(StringUtils.isBlankString);
+
+    disableNext(hasFieldErrors || hasBlankFieldValues || ssnError);
+  }, [fieldErrors, disableNext, registration]);
+
+  const handleCheckboxClick = (
+    fieldName: keyof RegistrationCheckboxDetails
+  ) => {
+    dispatch(
+      updatePublicRegistration({
+        [fieldName]: !registration[fieldName],
+      })
+    );
+  };
+
+  const handleChange =
+    (fieldName: keyof PublicEmailRegistration) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (fieldErrors[fieldName]) {
+        handleErrors(fieldName)(event);
+      }
+
+      dispatch(
+        updatePublicRegistration({
+          [fieldName]: event.target.value,
+        })
+      );
+    };
+
+  const handleErrors =
+    (fieldName: keyof PublicEmailRegistration) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { type, value, required } = event.target;
+
+      const error = InputFieldUtils.inspectCustomTextFieldErrors(
+        type as TextFieldTypes,
+        value,
+        required
+      );
+
+      const fieldErrorMessage = error ? translateCommon(error) : '';
+
+      setFieldErrors({
+        ...fieldErrors,
+        [fieldName]: fieldErrorMessage,
+      });
+    };
+
+  const showCustomTextFieldError = (
+    fieldName: keyof PublicEmailRegistration
+  ) => {
+    return fieldErrors[fieldName].length > 0;
+  };
+
+  const getCustomTextFieldAttributes = (
+    fieldName: keyof PublicEmailRegistration
+  ) => ({
+    id: `public-registration__contact-details__${fieldName}-field`,
+    label: t(fieldName),
+    onBlur: handleErrors(fieldName),
+    onChange: handleChange(fieldName),
+    error: showCustomTextFieldError(fieldName),
+    helperText: fieldErrors[fieldName],
+    required: true,
+    disabled: isLoading,
+  });
+
+  return (
+    <div className="margin-top-xxl rows gapped">
+      <PersonDetails
+        getCustomTextFieldAttributes={getCustomTextFieldAttributes}
+      />
+      <CustomTextField
+        {...getCustomTextFieldAttributes('phoneNumber')}
+        className="phone-number"
+        value={registration.phoneNumber}
+        type={TextFieldTypes.PhoneNumber}
+      />
+      <Text>
+        <b>{t('preview.termsAndConditions.title')}</b>
+      </Text>
+      <Text>{t('preview.termsAndConditions.description')}</Text>
+      <FormControlLabel
+        control={
+          <Checkbox
+            onClick={() => handleCheckboxClick('termsAndConditionsAgreed')}
+            color={Color.Secondary}
+            checked={registration.termsAndConditionsAgreed}
+            disabled={isLoading}
+          />
+        }
+        label={t('preview.termsAndConditions.label')}
+        className="public-registration__grid__preview__privacy-statement-checkbox-label"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            onClick={() => handleCheckboxClick('privacyStatementConfirmation')}
+            color={Color.Secondary}
+            checked={registration.privacyStatementConfirmation}
+            disabled={isLoading}
+          />
+        }
+        label={<PrivacyStatementCheckboxLabel />}
+        className="public-registration__grid__preview__privacy-statement-checkbox-label"
+      />
+    </div>
+  );
+};

--- a/frontend/packages/yki/src/components/registration/steps/FillContactDetails.tsx
+++ b/frontend/packages/yki/src/components/registration/steps/FillContactDetails.tsx
@@ -1,0 +1,196 @@
+import { Checkbox, FormControlLabel } from '@mui/material';
+import { ChangeEvent, useEffect, useState } from 'react';
+import { Namespace, TFunction } from 'react-i18next';
+import { CustomTextField, H3, Text } from 'shared/components';
+import { AppLanguage, Color, TextFieldTypes } from 'shared/enums';
+import { InputFieldUtils, StringUtils } from 'shared/utils';
+
+import { PrivacyStatementCheckboxLabel } from 'components/registration/PrivacyStatementCheckboxLabel';
+import { PersonDetails } from 'components/registration/steps/PersonDetails';
+import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
+import {
+  PublicSuomiFiRegistration,
+  RegistrationCheckboxDetails,
+} from 'interfaces/publicRegistration';
+import { updatePublicRegistration } from 'redux/reducers/examSession';
+
+export const FillContactDetails = ({
+  registration,
+  isLoading,
+  disableNext,
+}: {
+  registration: PublicSuomiFiRegistration;
+  isLoading: boolean;
+  disableNext: (disabled: boolean) => void;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.steps.register',
+  });
+  const { t: tPerson } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.steps.personDetails',
+  });
+  const translateCommon = useCommonTranslation();
+
+  const [fieldErrors, setFieldErrors] = useState({
+    firstNames: '',
+    lastName: '',
+    email: '',
+    emailConfirmation: '',
+    phoneNumber: '',
+    address: '',
+    postNumber: '',
+    postOffice: '',
+    privacyStatementConfirmation: '',
+    certificateLanguage: '',
+    termsAndConditionsAgreed: '',
+  });
+
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const hasFieldErrors = !!(fieldErrors.email || fieldErrors.phoneNumber);
+
+    const hasBlankFieldValues = [
+      registration.email,
+      registration.phoneNumber,
+    ].some(StringUtils.isBlankString);
+    const mismatchingEmails =
+      registration.email !== registration.emailConfirmation;
+
+    disableNext(hasFieldErrors || hasBlankFieldValues || mismatchingEmails);
+  }, [fieldErrors, disableNext, registration]);
+
+  const handleCheckboxClick = (
+    fieldName: keyof RegistrationCheckboxDetails
+  ) => {
+    dispatch(
+      updatePublicRegistration({
+        [fieldName]: !registration[fieldName],
+      })
+    );
+  };
+
+  const handleChange =
+    (fieldName: keyof PublicSuomiFiRegistration) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (fieldErrors[fieldName]) {
+        handleErrors(fieldName)(event);
+      }
+
+      dispatch(
+        updatePublicRegistration({
+          [fieldName]: event.target.value,
+        })
+      );
+    };
+
+  const handleErrors =
+    (fieldName: keyof PublicSuomiFiRegistration) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { type, value, required } = event.target;
+
+      const error = InputFieldUtils.inspectCustomTextFieldErrors(
+        type as TextFieldTypes,
+        value,
+        required
+      );
+
+      const fieldErrorMessage = error ? translateCommon(error) : '';
+
+      const emailConfirmationErrorMessage =
+        registration.emailConfirmation &&
+        registration.email !== registration.emailConfirmation
+          ? t('mismatchingEmailsError')
+          : '';
+
+      setFieldErrors({
+        ...fieldErrors,
+        [fieldName]: fieldErrorMessage,
+        ['emailConfirmation']: emailConfirmationErrorMessage,
+      });
+    };
+
+  const showCustomTextFieldError = (
+    fieldName: keyof PublicSuomiFiRegistration
+  ) => {
+    return fieldErrors[fieldName].length > 0;
+  };
+
+  const getCustomTextFieldAttributes =
+    (translate: TFunction<Namespace<AppLanguage>, string>) =>
+    (fieldName: keyof PublicSuomiFiRegistration) => {
+      return {
+        id: `public-registration__contact-details__${fieldName}-field`,
+        label: translate(fieldName),
+        onBlur: handleErrors(fieldName),
+        onChange: handleChange(fieldName),
+        error: showCustomTextFieldError(fieldName),
+        helperText: fieldErrors[fieldName],
+        required: true,
+        disabled: isLoading || ['firstNames', 'lastName'].includes(fieldName),
+      };
+    };
+
+  return (
+    <div className="margin-top-xxl rows gapped">
+      <PersonDetails
+        getCustomTextFieldAttributes={getCustomTextFieldAttributes(tPerson)}
+      />
+      <div className="margin-top-sm rows gapped">
+        <H3>{t('title')}</H3>
+        <div className="grid-columns gapped">
+          <CustomTextField
+            {...getCustomTextFieldAttributes(t)('email')}
+            type={TextFieldTypes.Email}
+            value={registration.email}
+          />
+          <CustomTextField
+            {...getCustomTextFieldAttributes(t)('emailConfirmation')}
+            type={TextFieldTypes.Email}
+            value={registration.emailConfirmation}
+            onPaste={(e) => {
+              e.preventDefault();
+
+              return false;
+            }}
+          />
+        </div>
+      </div>
+      <CustomTextField
+        {...getCustomTextFieldAttributes(t)('phoneNumber')}
+        className="phone-number"
+        value={registration.phoneNumber}
+        type={TextFieldTypes.PhoneNumber}
+      />
+      <Text>
+        <b>{t('termsAndConditions.title')}</b>
+      </Text>
+      <Text>{t('termsAndConditions.description')}</Text>
+      <FormControlLabel
+        control={
+          <Checkbox
+            onClick={() => handleCheckboxClick('termsAndConditionsAgreed')}
+            color={Color.Secondary}
+            checked={registration.termsAndConditionsAgreed}
+            disabled={isLoading}
+          />
+        }
+        label={t('termsAndConditions.label')}
+        className="public-registration__grid__preview__privacy-statement-checkbox-label"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            onClick={() => handleCheckboxClick('privacyStatementConfirmation')}
+            color={Color.Secondary}
+            checked={registration.privacyStatementConfirmation}
+            disabled={isLoading}
+          />
+        }
+        label={<PrivacyStatementCheckboxLabel />}
+        className="public-registration__grid__preview__privacy-statement-checkbox-label"
+      />
+    </div>
+  );
+};

--- a/frontend/packages/yki/src/components/registration/steps/PersonDetails.tsx
+++ b/frontend/packages/yki/src/components/registration/steps/PersonDetails.tsx
@@ -1,0 +1,50 @@
+import { CustomTextField, CustomTextFieldProps, H3 } from 'shared/components';
+
+import { usePublicTranslation } from 'configs/i18n';
+import { useAppSelector } from 'configs/redux';
+import { PersonFillOutDetails } from 'interfaces/publicRegistration';
+import { examSessionSelector } from 'redux/selectors/examSession';
+
+export const PersonDetails = ({
+  getCustomTextFieldAttributes,
+}: {
+  getCustomTextFieldAttributes: (
+    fieldName: keyof PersonFillOutDetails
+  ) => CustomTextFieldProps;
+}) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.steps.personDetails',
+  });
+
+  const { registration } = useAppSelector(examSessionSelector);
+
+  return (
+    <div className="rows gapped">
+      <H3>{t('title')}</H3>
+      <div className="grid-columns gapped">
+        <CustomTextField
+          {...getCustomTextFieldAttributes('firstNames')}
+          value={registration.firstNames}
+        />
+        <CustomTextField
+          {...getCustomTextFieldAttributes('lastName')}
+          value={registration.lastName}
+        />
+      </div>
+      <div className="grid-columns gapped">
+        <CustomTextField
+          {...getCustomTextFieldAttributes('address')}
+          value={registration.address}
+        />
+        <CustomTextField
+          {...getCustomTextFieldAttributes('postNumber')}
+          value={registration.postNumber}
+        />
+        <CustomTextField
+          {...getCustomTextFieldAttributes('postOffice')}
+          value={registration.postOffice}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/packages/yki/src/components/skeletons/PublicExamDetailsPageSkeleton.tsx
+++ b/frontend/packages/yki/src/components/skeletons/PublicExamDetailsPageSkeleton.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from '@mui/material';
+import { SkeletonVariant } from 'shared/enums';
+
+export const PublicExamDetailsPageSkeleton = () => {
+  return (
+    <>
+      <Skeleton variant={SkeletonVariant.Rectangular}></Skeleton>
+      <Skeleton
+        className="full-max-width half-height margin-top-lg"
+        variant={SkeletonVariant.Rectangular}
+      ></Skeleton>
+      <Skeleton
+        className="full-max-width margin-top-lg"
+        variant={SkeletonVariant.Rectangular}
+      ></Skeleton>
+    </>
+  );
+};

--- a/frontend/packages/yki/src/components/skeletons/PublicIdentificationPageSkeleton.tsx
+++ b/frontend/packages/yki/src/components/skeletons/PublicIdentificationPageSkeleton.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from '@mui/material';
+import { SkeletonVariant } from 'shared/enums';
+
+export const PublicIdentificationPageSkeleton = () => {
+  return (
+    <>
+      <Skeleton variant={SkeletonVariant.Rectangular}></Skeleton>
+      <Skeleton
+        className="full-max-width half-height margin-top-lg"
+        variant={SkeletonVariant.Rectangular}
+      ></Skeleton>
+      <Skeleton
+        className="full-max-width margin-top-lg"
+        variant={SkeletonVariant.Rectangular}
+      ></Skeleton>
+    </>
+  );
+};

--- a/frontend/packages/yki/src/enums/api.ts
+++ b/frontend/packages/yki/src/enums/api.ts
@@ -1,3 +1,4 @@
 export enum APIEndpoints {
   ExamSessions = '/yki/api/exam-session',
+  ExamSession = '/yki/api/exam-session/:examSessionId',
 }

--- a/frontend/packages/yki/src/enums/app.ts
+++ b/frontend/packages/yki/src/enums/app.ts
@@ -4,8 +4,11 @@ export enum AppConstants {
 
 export enum AppRoutes {
   Registration = '/yki/ilmoittautuminen',
+  ExamSessionRegistration = '/yki/ilmoittautuminen/tutkintotilaisuus/:examSessionId',
   Reassessment = '/yki/tarkistusarviointi',
+  ExamSession = '/yki/tutkintotilaisuus/:examSessionId',
   NotFoundPage = '*',
+  PrivacyPolicyPage = '/yki/tietosuojaseloste',
 }
 
 export enum HeaderTabNav {
@@ -29,4 +32,10 @@ export enum ExamLevel {
   YLIN = 'YLIN',
   KESKI = 'KESKI',
   PERUS = 'PERUS',
+}
+
+export enum CertificateLanguage {
+  FI = 'fi',
+  SV = 'sv',
+  EN = 'en',
 }

--- a/frontend/packages/yki/src/enums/publicRegistration.ts
+++ b/frontend/packages/yki/src/enums/publicRegistration.ts
@@ -1,0 +1,5 @@
+export enum PublicRegistrationFormStep {
+  Identify = 1,
+  Register,
+  Done,
+}

--- a/frontend/packages/yki/src/hooks/useNavigationProtection.ts
+++ b/frontend/packages/yki/src/hooks/useNavigationProtection.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+import { Severity, Variant } from 'shared/enums';
+import {
+  useNavigationProtection as useCommonNavigationProtection,
+  useDialog,
+} from 'shared/hooks';
+
+import { useCommonTranslation } from 'configs/i18n';
+
+export const useNavigationProtection = (when: boolean) => {
+  const translateCommon = useCommonTranslation();
+  const { showDialog } = useDialog();
+
+  const showConfirmationDialog = useCallback(
+    (confirmNavigation: () => void, cancelNavigation: () => void) => {
+      showDialog({
+        title: translateCommon('navigationProtection.header'),
+        severity: Severity.Info,
+        description: translateCommon('navigationProtection.description'),
+        actions: [
+          {
+            title: translateCommon('back'),
+            variant: Variant.Outlined,
+            action: cancelNavigation,
+          },
+          {
+            title: translateCommon('yes'),
+            variant: Variant.Contained,
+            action: confirmNavigation,
+          },
+        ],
+        onClose: cancelNavigation,
+      });
+    },
+    [showDialog, translateCommon]
+  );
+
+  useCommonNavigationProtection(when, showConfirmationDialog);
+};

--- a/frontend/packages/yki/src/interfaces/examSessions.ts
+++ b/frontend/packages/yki/src/interfaces/examSessions.ts
@@ -21,7 +21,7 @@ export interface ExamSessions {
   exam_sessions: Array<ExamSession>;
 }
 
-interface ExamSessionResponse
+export interface ExamSessionResponse
   extends Omit<
     ExamSession,
     | 'session_date'

--- a/frontend/packages/yki/src/interfaces/publicRegistration.ts
+++ b/frontend/packages/yki/src/interfaces/publicRegistration.ts
@@ -1,0 +1,34 @@
+import { Dayjs } from 'dayjs';
+
+import { CertificateLanguage } from 'enums/app';
+
+export interface PersonFillOutDetails {
+  firstNames: string;
+  lastName: string;
+  address: string;
+  postNumber: string;
+  postOffice: string;
+  certificateLanguage: CertificateLanguage;
+}
+
+export interface RegistrationCheckboxDetails {
+  privacyStatementConfirmation: boolean;
+  termsAndConditionsAgreed: boolean;
+}
+
+export interface PublicSuomiFiRegistration
+  extends PersonFillOutDetails,
+    RegistrationCheckboxDetails {
+  email: string;
+  emailConfirmation: string;
+  phoneNumber: string;
+}
+
+export interface PublicEmailRegistration
+  extends Omit<PublicSuomiFiRegistration, 'emailConfirmation'> {
+  nationality: string;
+  dateOfBirth: Dayjs;
+  sex: string;
+  hasSSN: boolean;
+  ssn?: string;
+}

--- a/frontend/packages/yki/src/pages/ExamDetailsPage.tsx
+++ b/frontend/packages/yki/src/pages/ExamDetailsPage.tsx
@@ -1,0 +1,80 @@
+import { Box, Paper } from '@mui/material';
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { APIResponseStatus, Severity } from 'shared/enums';
+import { useToast } from 'shared/hooks';
+
+import { PublicRegistrationGrid } from 'components/registration/PublicRegistrationGrid';
+import { PublicExamDetailsPageSkeleton } from 'components/skeletons/PublicExamDetailsPageSkeleton';
+import { usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { AppRoutes } from 'enums/app';
+import { loadExamSession } from 'redux/reducers/examSession';
+import { examSessionSelector } from 'redux/selectors/examSession';
+
+export const ExamDetailsPage = () => {
+  // i18n
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.pages.examDetailsPage',
+  });
+
+  const { showToast } = useToast();
+
+  // Redux
+  const dispatch = useAppDispatch();
+  const { status, examSession } = useAppSelector(examSessionSelector);
+  // React Router
+  const navigate = useNavigate();
+  const params = useParams();
+
+  const isLoading = status === APIResponseStatus.InProgress;
+
+  useEffect(() => {
+    if (
+      status === APIResponseStatus.NotStarted &&
+      !examSession?.id &&
+      params.examSessionId
+    ) {
+      // Fetch exam details
+      dispatch(loadExamSession(+params.examSessionId));
+    } else if (
+      status === APIResponseStatus.Error ||
+      isNaN(Number(params.examSessionId))
+    ) {
+      // Show an error
+      showToast({
+        severity: Severity.Error,
+        description: t('toasts.notFound'),
+      });
+
+      navigate(AppRoutes.Registration, { replace: true });
+    }
+  }, [
+    status,
+    dispatch,
+    navigate,
+    params.examSessionId,
+    showToast,
+    examSession?.id,
+    t,
+  ]);
+
+  return (
+    <Box className="public-exam-details-page">
+      <Paper
+        elevation={3}
+        className="public-exam-details-page__content-container rows"
+      >
+        {isLoading ? (
+          <PublicExamDetailsPageSkeleton />
+        ) : (
+          <>
+            <div className="rows gapped">
+              <PublicRegistrationGrid />
+            </div>
+          </>
+        )}
+      </Paper>
+    </Box>
+  );
+};

--- a/frontend/packages/yki/src/pages/IdentifyPage.tsx
+++ b/frontend/packages/yki/src/pages/IdentifyPage.tsx
@@ -1,0 +1,87 @@
+import { Box, Paper } from '@mui/material';
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { APIResponseStatus, Severity } from 'shared/enums';
+import { useToast } from 'shared/hooks';
+
+import { PublicIdentificationGrid } from 'components/registration/PublicIdentificationGrid';
+import { PublicIdentificationPageSkeleton } from 'components/skeletons/PublicIdentificationPageSkeleton';
+import { usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { AppRoutes } from 'enums/app';
+import { loadExamSession } from 'redux/reducers/examSession';
+import { examSessionSelector } from 'redux/selectors/examSession';
+
+export const IdentifyPage = () => {
+  // i18n
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.pages.examDetailsPage',
+  });
+
+  const { showToast } = useToast();
+
+  // Redux
+  const dispatch = useAppDispatch();
+  const { status, examSession } = useAppSelector(examSessionSelector);
+  // React Router
+  const navigate = useNavigate();
+  const params = useParams();
+
+  const isLoading = status === APIResponseStatus.InProgress;
+
+  useEffect(() => {
+    if (
+      status === APIResponseStatus.NotStarted &&
+      !examSession?.id &&
+      params.examSessionId
+    ) {
+      // Fetch exam details
+      dispatch(loadExamSession(+params.examSessionId));
+    } else if (
+      status === APIResponseStatus.Error ||
+      isNaN(Number(params.examSessionId))
+    ) {
+      // Show an error
+      showToast({
+        severity: Severity.Error,
+        description: t('toasts.notFound'),
+      });
+
+      navigate(AppRoutes.Registration, { replace: true });
+    }
+  }, [
+    status,
+    dispatch,
+    navigate,
+    params.examSessionId,
+    showToast,
+    examSession?.id,
+    t,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      // TODO: Reset fields on unmount
+      // dispatch(resetClerkTranslatorOverview());
+    };
+  }, [dispatch]);
+
+  return (
+    <Box className="public-exam-details-page">
+      <Paper
+        elevation={3}
+        className="public-exam-details-page__content-container rows"
+      >
+        {isLoading ? (
+          <PublicIdentificationPageSkeleton />
+        ) : (
+          <>
+            <div className="rows gapped">
+              <PublicIdentificationGrid />
+            </div>
+          </>
+        )}
+      </Paper>
+    </Box>
+  );
+};

--- a/frontend/packages/yki/src/redux/reducers/examSession.ts
+++ b/frontend/packages/yki/src/redux/reducers/examSession.ts
@@ -1,0 +1,81 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { APIResponseStatus } from 'shared/enums';
+
+import { CertificateLanguage } from 'enums/app';
+import { PublicRegistrationFormStep } from 'enums/publicRegistration';
+import { ExamSession } from 'interfaces/examSessions';
+import {
+  PublicEmailRegistration,
+  PublicSuomiFiRegistration,
+} from 'interfaces/publicRegistration';
+
+interface ExamSessionState {
+  status: APIResponseStatus;
+  activeStep: PublicRegistrationFormStep;
+  examSession?: ExamSession;
+  registration: PublicSuomiFiRegistration | PublicEmailRegistration;
+  isEmailRegistration?: boolean;
+}
+
+const initialState: ExamSessionState = {
+  status: APIResponseStatus.NotStarted,
+  activeStep: PublicRegistrationFormStep.Identify,
+  registration: {
+    firstNames: 'Test',
+    lastName: 'Tester',
+    address: '',
+    postNumber: '',
+    postOffice: '',
+    email: '',
+    emailConfirmation: '',
+    phoneNumber: '',
+    privacyStatementConfirmation: false,
+    certificateLanguage: CertificateLanguage.FI,
+    termsAndConditionsAgreed: false,
+  },
+};
+
+const examSessionSlice = createSlice({
+  name: 'examSession',
+  initialState,
+  reducers: {
+    loadExamSession(state, _action: PayloadAction<number>) {
+      state.status = APIResponseStatus.InProgress;
+    },
+    rejectExamSession(state) {
+      state.status = APIResponseStatus.Error;
+    },
+    storeExamSession(state, action: PayloadAction<ExamSession>) {
+      state.status = APIResponseStatus.Success;
+      state.examSession = action.payload;
+    },
+    decreaseActiveStep(state) {
+      state.activeStep = --state.activeStep;
+    },
+    increaseActiveStep(state) {
+      state.activeStep = ++state.activeStep;
+    },
+    updatePublicRegistration(
+      state,
+      action: PayloadAction<
+        Partial<PublicSuomiFiRegistration | PublicEmailRegistration>
+      >
+    ) {
+      state.registration = { ...state.registration, ...action.payload };
+    },
+    resetPublicRegistration() {
+      return initialState;
+    },
+  },
+});
+
+export const examSessionReducer = examSessionSlice.reducer;
+export const {
+  loadExamSession,
+  rejectExamSession,
+  storeExamSession,
+  increaseActiveStep,
+  decreaseActiveStep,
+  updatePublicRegistration,
+  resetPublicRegistration,
+} = examSessionSlice.actions;

--- a/frontend/packages/yki/src/redux/selectors/examSession.ts
+++ b/frontend/packages/yki/src/redux/selectors/examSession.ts
@@ -1,0 +1,3 @@
+import { RootState } from 'configs/redux';
+
+export const examSessionSelector = (state: RootState) => state.examSession;

--- a/frontend/packages/yki/src/redux/store/index.ts
+++ b/frontend/packages/yki/src/redux/store/index.ts
@@ -2,13 +2,18 @@ import createSagaMiddleware from '@redux-saga/core';
 import { configureStore } from '@reduxjs/toolkit';
 
 import { APIErrorReducer } from 'redux/reducers/APIError';
+import { examSessionReducer } from 'redux/reducers/examSession';
 import { examSessionsReducer } from 'redux/reducers/examSessions';
 import rootSaga from 'redux/sagas/index';
 
 const saga = createSagaMiddleware();
 
 const store = configureStore({
-  reducer: { APIError: APIErrorReducer, examSessions: examSessionsReducer },
+  reducer: {
+    APIError: APIErrorReducer,
+    examSessions: examSessionsReducer,
+    examSession: examSessionReducer,
+  },
   middleware: [saga],
 });
 

--- a/frontend/packages/yki/src/routers/AppRouter.tsx
+++ b/frontend/packages/yki/src/routers/AppRouter.tsx
@@ -7,6 +7,8 @@ import { Header } from 'components/layouts/Header';
 import { useCommonTranslation } from 'configs/i18n';
 import { AppRoutes } from 'enums/app';
 import { useAPIErrorToast } from 'hooks/useAPIErrorToast';
+import { ExamDetailsPage } from 'pages/ExamDetailsPage';
+import { IdentifyPage } from 'pages/IdentifyPage';
 import { RegistrationPage } from 'pages/RegistrationPage';
 
 export const AppRouter: FC = () => {
@@ -28,6 +30,11 @@ export const AppRouter: FC = () => {
               <Route
                 path={AppRoutes.Registration}
                 element={<RegistrationPage />}
+              />
+              <Route path={AppRoutes.ExamSession} element={<IdentifyPage />} />
+              <Route
+                path={AppRoutes.ExamSessionRegistration}
+                element={<ExamDetailsPage />}
               />
             </Routes>
           </div>

--- a/frontend/packages/yki/src/styles/components/registration/_public-registration.scss
+++ b/frontend/packages/yki/src/styles/components/registration/_public-registration.scss
@@ -1,0 +1,44 @@
+.public-registration {
+  & &__grid {
+    &__form-container {
+      padding: 3rem;
+    }
+
+    &__stepper {
+      margin-left: 13rem;
+      margin-right: 13rem;
+
+      &__step-disabled {
+        span,
+        svg {
+          color: $color-grey-700;
+        }
+      }
+    }
+
+    &__preview {
+      &__privacy-statement-checkbox-label {
+        margin-right: 0;
+        padding-left: 1rem;
+
+        &__link {
+          font-size: 1.6rem;
+          padding: 0 3px 0 0;
+          text-transform: lowercase;
+
+          & span {
+            margin-left: 2px;
+          }
+        }
+      }
+    }
+
+    .phone-number {
+      max-width: calc(50% - 1rem);
+
+      @include phone {
+        max-width: 100%;
+      }
+    }
+  }
+}

--- a/frontend/packages/yki/src/styles/pages/_public-exam-details-page.scss
+++ b/frontend/packages/yki/src/styles/pages/_public-exam-details-page.scss
@@ -1,0 +1,14 @@
+.public-exam-details-page {
+  flex: 1;
+
+  & &__grid-container {
+    display: block;
+
+    &__item-header {
+      @include phone {
+        margin-top: 2rem;
+        padding: 2rem 2rem 0;
+      }
+    }
+  }
+}

--- a/frontend/packages/yki/src/styles/styles.scss
+++ b/frontend/packages/yki/src/styles/styles.scss
@@ -9,6 +9,8 @@
 @import 'components/layouts/header';
 @import 'components/layouts/footer';
 @import 'components/registration/exam-session-filters';
+@import 'components/registration/public-registration';
 
 // Pages
 @import 'pages/registration-page';
+@import 'pages/public-exam-details-page';

--- a/frontend/packages/yki/src/utils/exam.ts
+++ b/frontend/packages/yki/src/utils/exam.ts
@@ -10,7 +10,7 @@ export class ExamUtils {
     const t = translateOutsideComponent();
 
     return `${t('yki.common.languages.' + es.language_code)}, ${t(
-      'yki.common.levels.' + es.level_code
+      'yki.common.languageLevel.' + es.level_code
     )}`;
   }
 

--- a/frontend/packages/yki/src/utils/examSession.ts
+++ b/frontend/packages/yki/src/utils/examSession.ts
@@ -1,0 +1,16 @@
+import { ExamLanguage, ExamLevel } from 'enums/app';
+
+export class ExamSessionUtils {
+  static languageAndLevelText(
+    language: ExamLanguage,
+    level: ExamLevel,
+    translateCommon: (t: string) => string
+  ) {
+    const langTranslation = translateCommon(`languages.${language}`);
+    const levelTranslation = translateCommon(
+      `languageLevel.${ExamLevel[level]}`
+    );
+
+    return `${langTranslation}, ${levelTranslation}`;
+  }
+}

--- a/frontend/packages/yki/src/utils/serialization.ts
+++ b/frontend/packages/yki/src/utils/serialization.ts
@@ -1,29 +1,42 @@
 import dayjs from 'dayjs';
 import { DateUtils } from 'shared/utils';
 
-import { ExamSessions, ExamSessionsResponse } from 'interfaces/examSessions';
+import {
+  ExamSession,
+  ExamSessionResponse,
+  ExamSessions,
+  ExamSessionsResponse,
+} from 'interfaces/examSessions';
 
 export class SerializationUtils {
+  static deserializeExamSessionResponse(
+    examSessionResponse: ExamSessionResponse
+  ): ExamSession {
+    return {
+      ...examSessionResponse,
+      session_date: dayjs(examSessionResponse.session_date),
+      post_admission_start_date: DateUtils.optionalStringToDate(
+        examSessionResponse.post_admission_start_date
+      ),
+      post_admission_end_date: DateUtils.optionalStringToDate(
+        examSessionResponse.post_admission_end_date
+      ),
+      registration_start_date: DateUtils.optionalStringToDate(
+        examSessionResponse.registration_start_date
+      ),
+      registration_end_date: DateUtils.optionalStringToDate(
+        examSessionResponse.registration_end_date
+      ),
+      exam_fee: parseInt(examSessionResponse.exam_fee as string),
+    };
+  }
+
   static deserializeExamSessionsResponse(
     examSessionsResponse: ExamSessionsResponse
   ): ExamSessions {
-    const exam_sessions = examSessionsResponse.exam_sessions.map((es) => ({
-      ...es,
-      session_date: dayjs(es.session_date),
-      post_admission_start_date: DateUtils.optionalStringToDate(
-        es.post_admission_start_date
-      ),
-      post_admission_end_date: DateUtils.optionalStringToDate(
-        es.post_admission_end_date
-      ),
-      registration_start_date: DateUtils.optionalStringToDate(
-        es.registration_start_date
-      ),
-      registration_end_date: DateUtils.optionalStringToDate(
-        es.registration_end_date
-      ),
-      exam_fee: parseInt(es.exam_fee as string),
-    }));
+    const exam_sessions = examSessionsResponse.exam_sessions.map(
+      SerializationUtils.deserializeExamSessionResponse
+    );
 
     return { exam_sessions };
   }


### PR DESCRIPTION
## Yhteenveto

YKI:n julkisen etusivun (/yki/ilmoittaudu) tukintolistauksen "Ilmoittaudu" -napista avautuu nyt samankaltainen stepper flow kuten VKT:ssa. Stepper menee tällä hetkellä Preview:n asti. Stepperistä puuttuvat maksun käsittely sekä "tunnistaudu sähköpostilla" vaihtoehto (ja varsiainen tunnistuslogiikan handlaus sekä suomi.fi + sposti). Todistuksen kielivalinta radiobutton puuttuu

## Lisätiedot

1. Ilmoittautumisen ensimmäisessä vaiheessa suomi.fi placeholder button ohjaa tällä hetkellä suoraan henkilötietojen täyttöön, jotta steppejä voi tarkastella. 
2. Cypress testit vielä kirjoittamatta. 
3. Mobiilinäkymiä ei ole testattu / otettu tarkemmin huomioon tässä PR:ssä
