### PR TITLE
OTR(Backend): OPHOTRKEH-182 qualification expiry emails creation enabled

### DIFF
--- a/backend/otr/src/main/resources/oph-configuration/otr.properties.template
+++ b/backend/otr/src/main/resources/oph-configuration/otr.properties.template
@@ -11,7 +11,7 @@ virkailija.cas.service-url=${virkailija.cas.base-url}/otr/virkailija
 virkailija.cas.url=${virkailija.cas.base-url}/cas
 virkailija.cas.login-url=${virkailija.cas.base-url}/cas/login
 
-create-expiry-emails-enabled=false
+create-expiry-emails-enabled=true
 email.sending-enabled=true
 email.service-url=${virkailija.host.alb}/ryhmasahkoposti-service/email/firewall
 


### PR DESCRIPTION
### Yhteenveto

Umpeutuvien rekisteröintien (umpeutuminen 3kk sisään nykyhetkestä) osalta lähetetään öisin muistutussähköposteja. Tällä hetkellä lähetys ollut eri ympäristöissä estetty:

```
2023-02-14T03:00:00.060+02:00 INFO  {} [scheduling-1] INFO  fi.oph.otr.scheduled.ExpiringQualificationsEmailCreator: Expiry emails creation is disabled, do nothing.
```