### PR TITLE
Updated README and app related docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This mono-repo contains the language and translator services of the Finnish Nati
 
 - Maven 3.1+
 - JDK 17
-- PostgreSQL 12.9
+- PostgreSQL 14.7
 - node v16.16.0
 - yarn 3.2.2 (to enable it, run the following command: `corepack enable`)
 
@@ -26,12 +26,35 @@ In addition, the shared frontend content can be found [here](./docs/shared_front
 
 &nbsp;
 
+## Development setup initialisation with Docker
+
+1. Download Docker Desktop
+2. Build containers for a specific app
+```sh
+docker-compose -f docker-compose-<app>.yml build
+```
+3. Run mvn install for the backend: `cd backend/<app>; ./mwnw install`
+4. Run the app with docker-compose
+```sh
+docker-compose -f docker-compose-<app>.yml up
+```
+
+In order to connect the database from terminal, download a PostgreSQL client (14.x). For example with OSX with Homebrew:
+```sh
+brew install postgresql@14
+```
+
+Or use PostgresSQL client inside docker:
+```sh
+docker exec -ti <app>-postgres psql -U postgres -d <app>-postgres
+```
+
 ## Development
 
 Create and start database, backend, and frontend containers for a specific application:
 
 ```sh
-docker-compose -f <service-docker-compose-file-name.yml> up
+docker-compose -f docker-compose-<app>.yml up
 ```
 
 Or
@@ -46,14 +69,14 @@ To disable default Spring Security configurations, create the following environm
 
 ```sh
 export AKR_UNSECURE=true
-docker-compose -f <service-docker-compose-file-name.yml> up
+docker-compose -f docker-compose-<app>.yml up
 ```
 
 In case of errors, clean cache and recreate volumes:
 
 ```sh
-docker-compose -f <service-docker-compose-file-name.yml> down
-docker-compose -f <service-docker-compose-file-name.yml> up --build --force-recreate --renew-anon-volumes
+docker-compose -f docker-compose-<app>.yml down
+docker-compose -f docker-compose-<app>.yml up --build --force-recreate --renew-anon-volumes
 ```
 
 After starting the services, the frontend runs on > <http://localhost:4000>
@@ -84,10 +107,10 @@ The project uses the shared workspace configs. In order to keep code clean and e
 - [stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
 - [sort-json](https://marketplace.visualstudio.com/items?itemName=richie5um2.vscode-sort-json)
 
-To reformat all frontend files, run:
+To reformat all frontend files for a certain application, run:
 
 ```sh
-npm run <project-name>:lint
+yarn <app>:format:write
 ```
 
 &nbsp;
@@ -147,12 +170,24 @@ AKR(Frontend): Added new translations
 
 ### Branching naming conventions
 
-Jira ticket numbers are used as branch names without any extra suffixes.
+Jira ticket numbers are used as branch names with possible suffix indicating what the branch is for.
 
-Used prefixes are `feature`, `hotfix`, and `release`. Below are some examples.
+Used prefixes are `feature`, and `hotfix`. Below are some examples.
 
 ```sh
 feature/<ticket-number>         ---->   feature/OPHAKRKEH-250
 hotfix/<service-name>           ---->   hotfix/akr
-release/<service-name/<date>    ---->   release/akr/2022-04-12
+```
+
+### Releases
+
+Production releases for different applications are marked with tags. For example for AKR, tags are named as `AKR-ga-1234` where `ga-1234` stands for the Github Action workflow number. The name of the tag also matches the name of the release in Jira.
+
+In order to create a new release for example for AKR, check the commit ID of the build to be released, hard reset your local repository to that commit, create tag
+```sh
+git tag AKR-ga-1234
+```
+and push the tag to remote repository
+```sh
+git push origin AKR-ga-1234
 ```

--- a/docs/akr.md
+++ b/docs/akr.md
@@ -65,36 +65,30 @@ Set `AKR_UNSECURE=true` environment variable as shown [here](../README.md#develo
 
 `ExpiringAuthorisationsEmailCreator` does scheduling of finding expiring authorisations, and creating reminder emails about them. It is run every 12 hours (`FIXED_DELAY`). The reminder emails that are created are eventually sent via `EmailScheduledSending`.
 
-&nbsp;
-
 ## Frontend
 
 ### Build and Run
 
 ```sh
-npm install
-npm run start  # Starts Webpack DevServer
+yarn install
+yarn akr:start  # Starts Webpack DevServer
 ```
 
 and the app runs on > <http://localhost:4000/akr/etusivu>
-
-```sh
-npm run build # Builds the app for production to the dist folder.
-```
 
 ### Running tests
 
 End-to-end tests:
 
 ```sh
-npm run test:cypress
+yarn akr:test:cypress
 ```
 
 Unit and Integration tests
 
 ```sh
-npm run test:jest
-npm run test:jest -- -u  # Regenerate snapshots
+yarn akr:test:jest
+yarn akr:test:jest -- -u  # Regenerate snapshots
 ```
 
 ## Documentation

--- a/docs/otr.md
+++ b/docs/otr.md
@@ -76,36 +76,30 @@ If there is a case where the learners need to be deleted and re-initialised for 
 been updated via some means after their creation outside from the APIs we use, there's a
 chance deletion of learners fails due to some foreign key constraint.
 
-&nbsp;
-
 ## Frontend
 
 ### Build and Run
 
 ```sh
-npm install
-npm run start  # Starts Webpack DevServer
+yarn install
+yarn otr:start  # Starts Webpack DevServer
 ```
 
 and the app runs on > <http://localhost:4001/otr/etusivu>
-
-```sh
-npm run build # Builds the app for production to the dist folder.
-```
 
 ### Running tests
 
 End-to-end tests:
 
 ```sh
-npm run test:cypress
+yarn otr:test:cypress
 ```
 
 Unit and Integration tests
 
 ```sh
-npm run test:jest
-npm run test:jest -- -u  # Regenerate snapshots
+yarn otr:test:jest
+yarn otr:test:jest -- -u  # Regenerate snapshots
 ```
 
 ## Documentation

--- a/docs/vkt.md
+++ b/docs/vkt.md
@@ -57,36 +57,30 @@ Or
 
 Set `VKT_UNSECURE=true` environment variable as shown [here](../README.md#development).
 
-&nbsp;
-
 ## Frontend
 
 ### Build and Run
 
 ```sh
-npm install
-npm run start  # Starts Webpack DevServer
+yarn install
+yarn vkt:start  # Starts Webpack DevServer
 ```
 
 and the app runs on > <http://localhost:4002/vkt/etusivu>
-
-```sh
-npm run build # Builds the app for production to the dist folder.
-```
 
 ### Running tests
 
 End-to-end tests:
 
 ```sh
-npm run test:cypress
+yarn vkt:test:cypress
 ```
 
 Unit and Integration tests
 
 ```sh
-npm run test:jest
-npm run test:jest -- -u  # Regenerate snapshots
+yarn vkt:test:jest
+yarn vkt:test:jest -- -u  # Regenerate snapshots
 ```
 
 ## Documentation


### PR DESCRIPTION
## Yhteenveto

Päivitetty README:tä siltä pohjalta, että tuli uuden työkoneen setuppauksessa havaittua, että `docker-compose -f docker-compose-vkt.yml up` ei onnistunut ennen kuin kävi manuaalisesti ajamassa maven wrapperillä installin `backend/vkt` hakemiston alla.

Teron kanssa meillä oli ainakin ollut käytössä PostgrelSQL 14.5 aiemmin, päivitin tähän nyt käytetyksi versioksi 14.7, sillä tuo tulee ainakin defaultina Homebrewllä OSX:llä, kun asentaa postgresql@14:n.
