### PR TITLE
VKT(Backend): OPHVKTKEH-121 local backend configuration file

### DIFF
--- a/backend/vkt/src/main/resources/application-dev.yaml
+++ b/backend/vkt/src/main/resources/application-dev.yaml
@@ -1,0 +1,3 @@
+app:
+  reservation:
+    duration: PT5M


### PR DESCRIPTION
## Yhteenveto

Mahdollisuus asettaa cloud-environment repoissa `vkt_app_reservation_duration` avaimelle haluttu varauksen umpeutumisaika per ympäristö. Untuvalla tuo voisi olla testauksen helpottamiseksi esim. 5 min (sama kuin lokaalisti) ja jos nyt palleron haluaisi vastaavan tuotantoa niin siellä 30 min.

## Huomautukset

Ennen mergausta tulee pushata sopivat arvot ympäristökohtaisiin repoihin ja mahd. erikseen julkaista konfiguraatiomuutokset: `aws/config.py <ympäristö> publish`