### PR TITLE
VKT(Frontend): OPHVKTKEH-126 ilmoittautumisflown parannuksia

### DIFF
--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
@@ -1,50 +1,22 @@
-import { useDispatch } from 'react-redux';
-import { CustomButton, H3 } from 'shared/components';
-import { Color, Variant } from 'shared/enums';
-
 import { Done } from 'components/publicEnrollment/steps/Done';
 import { FillContactDetails } from 'components/publicEnrollment/steps/FillContactDetails';
 import { Preview } from 'components/publicEnrollment/steps/Preview';
 import { SelectExam } from 'components/publicEnrollment/steps/SelectExam';
 import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
 import { PublicEnrollment } from 'interfaces/publicEnrollment';
-import { PublicExamEvent } from 'interfaces/publicExamEvent';
-import { initialisePublicEnrollment } from 'redux/reducers/publicEnrollment';
 
 export const PublicEnrollmentStepContents = ({
-  examEvent,
   activeStep,
   enrollment,
   isLoading,
   disableNext,
 }: {
-  examEvent: PublicExamEvent;
   activeStep: PublicEnrollmentFormStep;
   enrollment: PublicEnrollment;
   isLoading: boolean;
   disableNext: (disabled: boolean) => void;
 }) => {
-  const dispatch = useDispatch();
-
   switch (activeStep) {
-    case PublicEnrollmentFormStep.Identify:
-      return (
-        <div className="margin-top-xxl gapped rows">
-          <H3>Tunnistaudu ilmoittautumista varten</H3>
-          <CustomButton
-            sx={{ width: '168px' }}
-            variant={Variant.Contained}
-            color={Color.Secondary}
-            onClick={() => {
-              dispatch(initialisePublicEnrollment(examEvent));
-            }}
-            data-testid="public-enrollment__identiy"
-            disabled={isLoading}
-          >
-            TUNNISTAUDU SUOMI.FI:N KAUTTA
-          </CustomButton>
-        </div>
-      );
     case PublicEnrollmentFormStep.FillContactDetails:
       return (
         <FillContactDetails

--- a/frontend/packages/vkt/src/components/publicExamEvent/PublicExamEventGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/PublicExamEventGrid.tsx
@@ -9,6 +9,7 @@ import { PublicExamEventListing } from 'components/publicExamEvent/listing/Publi
 import { PublicExamEventGridSkeleton } from 'components/skeletons/PublicExamEventGridSkeleton';
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { resetPublicEnrollment } from 'redux/reducers/publicEnrollment';
 import { loadPublicExamEvents } from 'redux/reducers/publicExamEvent';
 import { publicExamEventsSelector } from 'redux/selectors/publicExamEvent';
 
@@ -25,6 +26,7 @@ export const PublicExamEventGrid = () => {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
+    dispatch(resetPublicEnrollment());
     dispatch(loadPublicExamEvents());
   }, [dispatch]);
 

--- a/frontend/packages/vkt/src/components/publicIdentify/PublicIdentifyGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicIdentify/PublicIdentifyGrid.tsx
@@ -34,6 +34,8 @@ export const PublicIdentifyGrid = () => {
     return null;
   }
 
+  const isExpectedToHaveOpenings = selectedExamEvent.openings > 0;
+
   const renderDesktopView = () => (
     <>
       <Grid className="public-enrollment__grid" item>
@@ -41,11 +43,11 @@ export const PublicIdentifyGrid = () => {
           <div className="public-enrollment__grid__form-container">
             <PublicEnrollmentStepper
               activeStep={PublicEnrollmentFormStep.Identify}
-              includePaymentStep={false}
+              includePaymentStep={isExpectedToHaveOpenings}
             />
             <PublicEnrollmentExamEventDetails
               examEvent={selectedExamEvent}
-              showOpenings={false}
+              showOpenings={isExpectedToHaveOpenings}
             />
             <div className="margin-top-xxl gapped rows">
               <H3>{t('title')}</H3>
@@ -56,7 +58,7 @@ export const PublicIdentifyGrid = () => {
                 onClick={() => {
                   dispatch(initialisePublicEnrollment(selectedExamEvent));
                 }}
-                data-testid="public-enrollment__identiy"
+                data-testid="public-enrollment__identify-button"
                 disabled={isLoading}
               >
                 {t('buttonText')}

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -13,6 +13,7 @@ interface PublicEnrollmentState {
   reservationDetailsStatus: APIResponseStatus;
   reservationDetails?: PublicReservationDetails;
   status: APIResponseStatus;
+  cancelStatus: APIResponseStatus;
   activeStep: PublicEnrollmentFormStep;
   enrollment: PublicEnrollment;
 }
@@ -21,6 +22,7 @@ const initialState: PublicEnrollmentState = {
   reservationDetailsStatus: APIResponseStatus.NotStarted,
   reservationDetails: undefined,
   status: APIResponseStatus.NotStarted,
+  cancelStatus: APIResponseStatus.NotStarted,
   activeStep: PublicEnrollmentFormStep.Identify,
   enrollment: {
     email: '',
@@ -76,13 +78,16 @@ const publicEnrollmentSlice = createSlice({
       } as PublicReservationDetails;
     },
     cancelPublicEnrollment(state) {
-      state.status = APIResponseStatus.InProgress;
+      state.cancelStatus = APIResponseStatus.InProgress;
     },
     cancelPublicEnrollmentAndRemoveReservation(
       state,
       _action: PayloadAction<number>
     ) {
-      state.status = APIResponseStatus.InProgress;
+      state.cancelStatus = APIResponseStatus.InProgress;
+    },
+    storePublicEnrollmentCancellation(state) {
+      state.cancelStatus = APIResponseStatus.Success;
     },
     decreaseActiveStep(state) {
       state.activeStep = --state.activeStep;
@@ -94,6 +99,7 @@ const publicEnrollmentSlice = createSlice({
       state.reservationDetailsStatus = initialState.reservationDetailsStatus;
       state.reservationDetails = initialState.reservationDetails;
       state.status = initialState.status;
+      state.cancelStatus = initialState.cancelStatus;
       state.activeStep = initialState.activeStep;
       state.enrollment = initialState.enrollment;
     },
@@ -129,6 +135,7 @@ export const {
   storePublicEnrollmentInitialisation,
   cancelPublicEnrollment,
   cancelPublicEnrollmentAndRemoveReservation,
+  storePublicEnrollmentCancellation,
   decreaseActiveStep,
   increaseActiveStep,
   resetPublicEnrollment,

--- a/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
@@ -22,7 +22,7 @@ import {
   rejectPublicEnrollmentSave,
   rejectPublicReservationRenew,
   renewPublicEnrollmentReservation,
-  resetPublicEnrollment,
+  storePublicEnrollmentCancellation,
   storePublicEnrollmentInitialisation,
   storePublicEnrollmentSave,
   updatePublicEnrollmentReservation,
@@ -75,7 +75,7 @@ function* renewPublicEnrollmentReservationSaga(action: PayloadAction<number>) {
 }
 
 function* cancelPublicEnrollmentSaga() {
-  yield put(resetPublicEnrollment());
+  yield put(storePublicEnrollmentCancellation());
 }
 
 function* cancelPublicEnrollmentAndRemoveReservationSaga(
@@ -89,7 +89,7 @@ function* cancelPublicEnrollmentAndRemoveReservationSaga(
   } catch (error) {
     // If deletion of reservation fails, it will expire in 30 mins
   } finally {
-    yield put(resetPublicEnrollment());
+    yield put(storePublicEnrollmentCancellation());
   }
 }
 

--- a/frontend/packages/vkt/src/tests/cypress/support/page-objects/publicHomePage.ts
+++ b/frontend/packages/vkt/src/tests/cypress/support/page-objects/publicHomePage.ts
@@ -16,7 +16,8 @@ class PublicHomePage {
       cy.findByTestId('public-enrollment__renew-reservation-modal-button'),
     reservationExpiredOkButton: () =>
       cy.findByTestId('public-enrollment__reservation-expired-ok-button'),
-    enrollIdentifyButton: () => cy.findByTestId('public-enrollment__identiy'),
+    enrollIdentifyButton: () =>
+      cy.findByTestId('public-enrollment__identify-button'),
   };
 
   clickExamEventRow(id: number) {


### PR DESCRIPTION
## Yhteenveto

- Peruuta-napin painaminen vie ilmoittautujan etusivulle ja poistaa varauksen tiedot. Tiedot poistetaan myös selaimen takaisin-nappia painaen. Tämän takia logiikka onkin PublicExamEventGrid alla.
- Tunnistaudu-sivulla näytetään Siirry-maksamaan steppi sekä avoinna olevien paikkojen määrä
- Ilmoittautumisen vahvistussivulta poistuminen onnistuu automaattisesti ilman navigointisuojan blokkausta
