### PR TITLE
OTR(Frontend): OPHOTRKEH-225 rekisteröinnin muokkaustoiminnot

### DIFF
--- a/frontend/packages/akr/src/components/clerkTranslator/authorisation/AuthorisationFields.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/authorisation/AuthorisationFields.tsx
@@ -173,12 +173,9 @@ export const AuthorisationFields = ({
       basis === AuthorisationBasisEnum.AUT &&
       (!examinationDate || !dayjs(examinationDate).isValid());
 
-    const isRequiredPropsEmpty = Object.values({
-      fromLang,
-      toLang,
-      basis,
-      termBeginDate,
-    }).some((p) => !p);
+    const isRequiredPropsEmpty = [fromLang, toLang, basis, termBeginDate].some(
+      (p) => !p
+    );
 
     return (
       isLoading || isExaminationDateNotDefinedOrInvalid || isRequiredPropsEmpty

--- a/frontend/packages/otr/public/i18n/en-GB/common.json
+++ b/frontend/packages/otr/public/i18n/en-GB/common.json
@@ -1,8 +1,6 @@
 {
   "otr": {
     "common": {
-      "add": "Add",
-      "addQualification": null,
       "allRegions": "Whole Finland",
       "appNameAbbreviation": "OTR",
       "appTitle": "Register of legal interpreters | Finnish National Agency for Education",

--- a/frontend/packages/otr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/otr/public/i18n/en-GB/translation.json
@@ -82,13 +82,6 @@
         },
         "qualifications": {
           "actions": {
-            "changePermissionToPublish": {
-              "ariaLabel": "Change the permission to publish",
-              "dialog": {
-                "description": null,
-                "header": "Are you sure you want to change the permission to publish?"
-              }
-            },
             "removal": {
               "ariaLabel": null,
               "dialog": {
@@ -99,19 +92,24 @@
             }
           },
           "fields": {
+            "actions": "Actions",
             "diaryNumber": "Case identifier",
             "endDate": "End date",
             "examinationType": "Education",
             "languagePair": "Language pair",
-            "permissionToPublish": "Permission to publish",
+            "permissionToPublish": "Publish",
             "startDate": "Start date"
           },
           "header": null,
+          "modalTitle": {
+            "addQualification": null,
+            "editQualification": null
+          },
           "noQualifications": "No qualifications meeting the selected criteria were found",
           "toasts": {
             "addingSucceeded": null,
             "removingSucceeded": null,
-            "updatingPublishPermissionSucceeded": null
+            "updatingSucceeded": null
           },
           "toggleFilters": {
             "effective": "Valid",
@@ -197,7 +195,7 @@
         },
         "fieldLabel": {
           "beginDate": null,
-          "diaryNumber": "Case identifier",
+          "diaryNumber": "Registration case ID",
           "endDate": null,
           "examination": null,
           "from": "Language pair (source language)",
@@ -212,7 +210,7 @@
           "to": "Target language"
         },
         "switch": {
-          "permissionToPublish": "Permission to publish"
+          "permissionToPublish": "May be published online"
         }
       },
       "publicInterpreterFilters": {
@@ -303,6 +301,9 @@
       },
       "clerkNewInterpreterPage": {
         "addedQualificationsTitle": null,
+        "modalTitle": {
+          "addQualification": null
+        },
         "removeQualificationDialog": {
           "title": null
         },

--- a/frontend/packages/otr/public/i18n/fi-FI/common.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/common.json
@@ -1,8 +1,6 @@
 {
   "otr": {
     "common": {
-      "add": "Lisää",
-      "addQualification": "Lisää rekisteröinti",
       "allRegions": "Koko Suomi",
       "appNameAbbreviation": "OTR",
       "appTitle": "Oikeustulkkirekisteri | Opetushallitus",

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -82,13 +82,6 @@
         },
         "qualifications": {
           "actions": {
-            "changePermissionToPublish": {
-              "ariaLabel": "Vaihda julkaisulupaa",
-              "dialog": {
-                "description": "Tämä muuttaa rekisteröinnin näkymistä julkisessa rekisterissä.",
-                "header": "Haluatko varmasti vaihtaa julkaisulupaa?"
-              }
-            },
             "removal": {
               "ariaLabel": "Poista rekisteröinti",
               "dialog": {
@@ -99,6 +92,7 @@
             }
           },
           "fields": {
+            "actions": "Toiminnot",
             "diaryNumber": "Asiatunnus",
             "endDate": "Päättymispäivä",
             "examinationType": "Koulutus",
@@ -107,11 +101,15 @@
             "startDate": "Alkamispäivä"
           },
           "header": "Rekisteröinnit",
+          "modalTitle": {
+            "addQualification": "Lisää rekisteröinti",
+            "editQualification": "Muokkaa rekisteröintiä"
+          },
           "noQualifications": "Valituille kriteereille ei löytynyt rekisteröintejä",
           "toasts": {
             "addingSucceeded": "Rekisteröinti lisätty onnistuneesti",
             "removingSucceeded": "Valittu rekisteröinti poistettu",
-            "updatingPublishPermissionSucceeded": "Rekisteröinnin julkaisulupaa muutettu"
+            "updatingSucceeded": "Rekisteröinnin muokkaus onnistui"
           },
           "toggleFilters": {
             "effective": "Voimassa olevat",
@@ -197,7 +195,7 @@
         },
         "fieldLabel": {
           "beginDate": "Rekisteröinnin alkamispäivä",
-          "diaryNumber": "Asiatunnus",
+          "diaryNumber": "Rekisteröinnin asiatunnus",
           "endDate": "Rekisteröinnin päättymispäivä",
           "examination": "Koulutus",
           "from": "Kielipari (mistä)",
@@ -212,7 +210,7 @@
           "to": "Mihin"
         },
         "switch": {
-          "permissionToPublish": "Julkaisulupa"
+          "permissionToPublish": "Saa julkaista internetissä"
         }
       },
       "publicInterpreterFilters": {
@@ -303,6 +301,9 @@
       },
       "clerkNewInterpreterPage": {
         "addedQualificationsTitle": "Lisätyt rekisteröinnit",
+        "modalTitle": {
+          "addQualification": "Lisää rekisteröinti"
+        },
         "removeQualificationDialog": {
           "title": "Haluatko varmasti poistaa rekisteröinnin?"
         },

--- a/frontend/packages/otr/public/i18n/sv-SE/common.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/common.json
@@ -1,8 +1,6 @@
 {
   "otr": {
     "common": {
-      "add": "Lägg till",
-      "addQualification": null,
       "allRegions": "Hela Finland",
       "appNameAbbreviation": "OTR",
       "appTitle": "Registret över rättstolkar | Utbildningsstyrelsen",

--- a/frontend/packages/otr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/translation.json
@@ -82,13 +82,6 @@
         },
         "qualifications": {
           "actions": {
-            "changePermissionToPublish": {
-              "ariaLabel": "Ändra publiceringstillstånd",
-              "dialog": {
-                "description": null,
-                "header": "Är du säker på att du vill byta publiceringstillstånd?"
-              }
-            },
             "removal": {
               "ariaLabel": null,
               "dialog": {
@@ -99,6 +92,7 @@
             }
           },
           "fields": {
+            "actions": "Funktioner",
             "diaryNumber": "Diarienummer",
             "endDate": "Slutdatum",
             "examinationType": "Utbildning",
@@ -107,11 +101,15 @@
             "startDate": "Startdatum"
           },
           "header": null,
+          "modalTitle": {
+            "addQualification": null,
+            "editQualification": null
+          },
           "noQualifications": null,
           "toasts": {
             "addingSucceeded": null,
             "removingSucceeded": null,
-            "updatingPublishPermissionSucceeded": null
+            "updatingSucceeded": null
           },
           "toggleFilters": {
             "effective": "I kraft",
@@ -212,7 +210,7 @@
           "to": "Vart"
         },
         "switch": {
-          "permissionToPublish": "Publiceringstillstånd"
+          "permissionToPublish": "Får publiceras på internet"
         }
       },
       "publicInterpreterFilters": {
@@ -303,6 +301,9 @@
       },
       "clerkNewInterpreterPage": {
         "addedQualificationsTitle": null,
+        "modalTitle": {
+          "addQualification": null
+        },
         "removeQualificationDialog": {
           "title": null
         },

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationDetails.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationDetails.tsx
@@ -10,21 +10,25 @@ import {
 import { APIResponseStatus, Color, Severity, Variant } from 'shared/enums';
 import { useDialog, useToast } from 'shared/hooks';
 
-import { AddQualification } from 'components/clerkInterpreter/add/AddQualification';
 import { QualificationListing } from 'components/clerkInterpreter/overview/QualificationListing';
+import { QualificationFields } from 'components/clerkInterpreter/qualification/QualificationFields';
 import { useAppTranslation, useCommonTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { QualificationStatus } from 'enums/clerkInterpreter';
-import { Qualification } from 'interfaces/qualification';
+import { NewQualification, Qualification } from 'interfaces/qualification';
 import { loadMeetingDates } from 'redux/reducers/meetingDate';
 import {
   addQualification,
   removeQualification,
-  resetQualificationState,
+  resetQualificationAdd,
+  resetQualificationRemove,
+  resetQualificationUpdate,
+  updateQualification,
 } from 'redux/reducers/qualification';
 import { clerkInterpreterOverviewSelector } from 'redux/selectors/clerkInterpreterOverview';
 import { selectMeetingDatesByMeetingStatus } from 'redux/selectors/meetingDate';
 import { qualificationSelector } from 'redux/selectors/qualification';
+import { QualificationUtils } from 'utils/qualifications';
 
 export const QualificationDetails = () => {
   // I18n
@@ -34,12 +38,20 @@ export const QualificationDetails = () => {
   const translateCommon = useCommonTranslation();
 
   // State
-  const [open, setOpen] = useState(false);
-  const handleOpenModal = () => setOpen(true);
-  const handleCloseModal = () => setOpen(false);
   const [selectedToggleFilter, setSelectedToggleFilter] = useState(
     QualificationStatus.Effective
   );
+  const [qualification, setQualification] = useState<NewQualification>(
+    QualificationUtils.newQualification
+  );
+  const [open, setOpen] = useState(false);
+  const handleOpenModal = () => setOpen(true);
+  const handleCloseModal = () => {
+    setOpen(false);
+    setQualification(QualificationUtils.newQualification);
+  };
+  const [isQualificationOpenForEdit, setIsQualificationOpenForEdit] =
+    useState(false);
 
   // Redux
   const dispatch = useAppDispatch();
@@ -62,6 +74,13 @@ export const QualificationDetails = () => {
         description: t('toasts.addingSucceeded'),
       });
     }
+
+    if (
+      addStatus === APIResponseStatus.Success ||
+      addStatus === APIResponseStatus.Error
+    ) {
+      dispatch(resetQualificationAdd());
+    }
   }, [dispatch, addStatus, showToast, t]);
 
   useEffect(() => {
@@ -71,25 +90,34 @@ export const QualificationDetails = () => {
         description: t('toasts.removingSucceeded'),
       });
     }
+
+    if (
+      removeStatus === APIResponseStatus.Success ||
+      removeStatus === APIResponseStatus.Error
+    ) {
+      dispatch(resetQualificationRemove());
+    }
   }, [dispatch, removeStatus, showToast, t]);
 
   useEffect(() => {
     if (updateStatus === APIResponseStatus.Success) {
+      handleCloseModal();
       showToast({
         severity: Severity.Success,
-        description: t('toasts.updatingPublishPermissionSucceeded'),
+        description: t('toasts.updatingSucceeded'),
       });
+    }
+
+    if (
+      updateStatus === APIResponseStatus.Success ||
+      updateStatus === APIResponseStatus.Error
+    ) {
+      dispatch(resetQualificationUpdate());
     }
   }, [dispatch, updateStatus, showToast, t]);
 
   useEffect(() => {
     dispatch(loadMeetingDates());
-  }, [dispatch]);
-
-  useEffect(() => {
-    return () => {
-      dispatch(resetQualificationState());
-    };
   }, [dispatch]);
 
   if (!interpreter) {
@@ -126,11 +154,12 @@ export const QualificationDetails = () => {
     setSelectedToggleFilter(status);
   };
 
-  const handleAddQualification = (qualification: Qualification) => {
-    dispatch(addQualification(qualification));
+  const handleAddQualification = () => {
+    setIsQualificationOpenForEdit(false);
+    handleOpenModal();
   };
 
-  const handleRemoveQualification = (qualification: Qualification) => {
+  const onQualificationRemove = (qualification: Qualification) => {
     showDialog({
       title: t('actions.removal.dialog.header'),
       severity: Severity.Warning,
@@ -151,21 +180,47 @@ export const QualificationDetails = () => {
     });
   };
 
+  const onQualificationEdit = (qualification: Qualification) => {
+    setQualification(qualification);
+    setIsQualificationOpenForEdit(true);
+    handleOpenModal();
+  };
+
+  const handleSaveQualification = () => {
+    const q = qualification as Qualification;
+
+    const action = isQualificationOpenForEdit
+      ? updateQualification(q)
+      : addQualification({
+          qualification: q,
+          interpreterId: interpreter.id,
+        });
+
+    dispatch(action);
+  };
+
   return (
     <>
       <CustomModal
-        data-testid="qualification-details__add-qualification-modal"
         open={open}
         onCloseModal={handleCloseModal}
         ariaLabelledBy="modal-title"
-        modalTitle={translateCommon('addQualification')}
+        modalTitle={
+          isQualificationOpenForEdit
+            ? t('modalTitle.editQualification')
+            : t('modalTitle.addQualification')
+        }
       >
-        <AddQualification
-          interpreterId={interpreter.id}
+        <QualificationFields
+          qualification={qualification}
+          setQualification={setQualification}
           meetingDates={passedMeetingDates}
+          onSave={handleSaveQualification}
           onCancel={handleCloseModal}
-          onQualificationAdd={handleAddQualification}
-          isLoading={addStatus === APIResponseStatus.InProgress}
+          isLoading={
+            addStatus === APIResponseStatus.InProgress ||
+            updateStatus === APIResponseStatus.InProgress
+          }
         />
       </CustomModal>
       <div className="rows gapped-xs">
@@ -183,16 +238,17 @@ export const QualificationDetails = () => {
             variant={Variant.Contained}
             color={Color.Secondary}
             startIcon={<AddIcon />}
-            onClick={handleOpenModal}
+            onClick={handleAddQualification}
           >
-            {translateCommon('addQualification')}
+            {t('modalTitle.addQualification')}
           </CustomButton>
         </div>
         {activeQualifications.length ? (
           <QualificationListing
             qualifications={activeQualifications}
-            permissionToPublishReadOnly={false}
-            handleRemoveQualification={handleRemoveQualification}
+            showEditButton={true}
+            onQualificationEdit={onQualificationEdit}
+            onQualificationRemove={onQualificationRemove}
           />
         ) : (
           <Text className="centered bold margin-top-lg">

--- a/frontend/packages/otr/src/enums/app.ts
+++ b/frontend/packages/otr/src/enums/app.ts
@@ -28,7 +28,6 @@ export enum HeaderTabNav {
 }
 
 export enum UIMode {
-  EditQualificationDetails = 'editQualificationDetails',
   EditInterpreterDetails = 'editInterpreterDetails',
   View = 'view',
 }

--- a/frontend/packages/otr/src/interfaces/qualification.ts
+++ b/frontend/packages/otr/src/interfaces/qualification.ts
@@ -13,12 +13,18 @@ export interface Qualification
   endDate: Dayjs;
   examinationType: ExaminationType;
   permissionToPublish: boolean;
-  diaryNumber?: string;
-  interpreterId?: number;
+  diaryNumber: string;
 }
 
 export interface QualificationResponse
-  extends Omit<Qualification, 'beginDate' | 'endDate'> {
+  extends Omit<Qualification, 'beginDate' | 'endDate' | 'diaryNumber'> {
   beginDate: string;
   endDate: string;
+  diaryNumber?: string;
+}
+
+export interface NewQualification
+  extends Omit<Qualification, 'beginDate' | 'endDate'> {
+  beginDate?: Dayjs;
+  endDate?: Dayjs;
 }

--- a/frontend/packages/otr/src/redux/reducers/qualification.ts
+++ b/frontend/packages/otr/src/redux/reducers/qualification.ts
@@ -5,8 +5,8 @@ import { Qualification } from 'interfaces/qualification';
 
 interface QualificationState {
   addStatus: APIResponseStatus;
-  updateStatus: APIResponseStatus;
   removeStatus: APIResponseStatus;
+  updateStatus: APIResponseStatus;
 }
 
 const initialState: QualificationState = {
@@ -19,12 +19,13 @@ const qualificationSlice = createSlice({
   name: 'qualification',
   initialState,
   reducers: {
-    resetQualificationState(state) {
-      state.removeStatus = initialState.removeStatus;
-      state.addStatus = initialState.addStatus;
-      state.updateStatus = initialState.updateStatus;
-    },
-    addQualification(state, _action: PayloadAction<Qualification>) {
+    addQualification(
+      state,
+      _action: PayloadAction<{
+        qualification: Qualification;
+        interpreterId: number;
+      }>
+    ) {
       state.addStatus = APIResponseStatus.InProgress;
     },
     rejectAddQualification(state) {
@@ -32,6 +33,9 @@ const qualificationSlice = createSlice({
     },
     addQualificationSucceeded(state) {
       state.addStatus = APIResponseStatus.Success;
+    },
+    resetQualificationAdd(state) {
+      state.addStatus = initialState.addStatus;
     },
     removeQualification(state, _action: PayloadAction<number>) {
       state.removeStatus = APIResponseStatus.InProgress;
@@ -42,6 +46,9 @@ const qualificationSlice = createSlice({
     removeQualificationSucceeded(state) {
       state.removeStatus = APIResponseStatus.Success;
     },
+    resetQualificationRemove(state) {
+      state.removeStatus = initialState.removeStatus;
+    },
     updateQualification(state, _action: PayloadAction<Qualification>) {
       state.updateStatus = APIResponseStatus.InProgress;
     },
@@ -51,19 +58,24 @@ const qualificationSlice = createSlice({
     updateQualificationSucceeded(state) {
       state.updateStatus = APIResponseStatus.Success;
     },
+    resetQualificationUpdate(state) {
+      state.updateStatus = initialState.updateStatus;
+    },
   },
 });
 
 export const qualificationReducer = qualificationSlice.reducer;
 export const {
-  resetQualificationState,
   addQualification,
   rejectAddQualification,
   addQualificationSucceeded,
+  resetQualificationAdd,
   removeQualification,
   rejectRemoveQualification,
   removeQualificationSucceeded,
+  resetQualificationRemove,
   updateQualification,
   updateQualificationSucceeded,
   rejectUpdateQualification,
+  resetQualificationUpdate,
 } = qualificationSlice.actions;

--- a/frontend/packages/otr/src/redux/sagas/qualification.ts
+++ b/frontend/packages/otr/src/redux/sagas/qualification.ts
@@ -23,17 +23,17 @@ import {
 import { NotifierUtils } from 'utils/notifier';
 import { SerializationUtils } from 'utils/serialization';
 
-function* addQualificationSaga(action: PayloadAction<Qualification>) {
-  const { interpreterId } = action.payload;
-
+function* addQualificationSaga(
+  action: PayloadAction<{
+    qualification: Qualification;
+    interpreterId: number;
+  }>
+) {
   try {
-    if (!interpreterId) {
-      throw new Error();
-    }
     const apiResponse: AxiosResponse<ClerkInterpreterResponse> = yield call(
       axiosInstance.post,
-      `${APIEndpoints.ClerkInterpreter}/${interpreterId}/qualification`,
-      SerializationUtils.serializeQualification(action.payload)
+      `${APIEndpoints.ClerkInterpreter}/${action.payload.interpreterId}/qualification`,
+      SerializationUtils.serializeQualification(action.payload.qualification)
     );
     const interpreter = SerializationUtils.deserializeClerkInterpreter(
       apiResponse.data

--- a/frontend/packages/otr/src/styles/components/clerkInterpreter/_qualification-fields.scss
+++ b/frontend/packages/otr/src/styles/components/clerkInterpreter/_qualification-fields.scss
@@ -1,4 +1,4 @@
-.add-qualification {
+.qualification {
   &__fields {
     align-items: flex-end;
     display: grid;

--- a/frontend/packages/otr/src/styles/styles.scss
+++ b/frontend/packages/otr/src/styles/styles.scss
@@ -5,13 +5,13 @@
 @import 'base/base';
 
 // Components
-@import 'components/clerkInterpreter/add-qualification';
+@import 'components/clerkInterpreter/clerk-interpreter-autocomplete-filters';
+@import 'components/clerkInterpreter/clerk-interpreter-listing';
+@import 'components/clerkInterpreter/qualification-fields';
 @import 'components/layouts/header';
 @import 'components/layouts/footer';
 @import 'components/publicInterpreter/public-interpreter-listing';
 @import 'components/publicInterpreter/public-interpreter-filters';
-@import 'components/clerkInterpreter/clerk-interpreter-autocomplete-filters';
-@import 'components/clerkInterpreter/clerk-interpreter-listing';
 
 // Pages
 @import 'pages/accessibility-statement-page';

--- a/frontend/packages/otr/src/tests/cypress/fixtures/utils/qualificationFields.ts
+++ b/frontend/packages/otr/src/tests/cypress/fixtures/utils/qualificationFields.ts
@@ -1,4 +1,4 @@
-export const addQualificationFields = [
+export const qualificationFields = [
   {
     fieldName: 'to',
     fieldType: 'input',

--- a/frontend/packages/otr/src/tests/cypress/integration/clerk_new_interpreter_page.spec.ts
+++ b/frontend/packages/otr/src/tests/cypress/integration/clerk_new_interpreter_page.spec.ts
@@ -82,7 +82,7 @@ describe('ClerkNewInterpreterPage', () => {
         'test@tester'
       );
       onClerkNewInterpreterPage.clickAddQualificationButton();
-      onClerkNewInterpreterPage.fillOutAddQualificationFields();
+      onClerkNewInterpreterPage.fillOutQualificationFields();
       onClerkNewInterpreterPage.clickSaveQualificationButton();
 
       onClerkNewInterpreterPage.expectEnabledSaveInterpreterButton();
@@ -107,7 +107,7 @@ describe('ClerkNewInterpreterPage', () => {
         'test@tester'
       );
       onClerkNewInterpreterPage.clickAddQualificationButton();
-      onClerkNewInterpreterPage.fillOutAddQualificationFields();
+      onClerkNewInterpreterPage.fillOutQualificationFields();
       onClerkNewInterpreterPage.clickSaveQualificationButton();
 
       onClerkNewInterpreterPage.clickSaveInterpreterButton();

--- a/frontend/packages/otr/src/tests/cypress/integration/interpreterOverview/clerk_interpreter_details.spec.ts
+++ b/frontend/packages/otr/src/tests/cypress/integration/interpreterOverview/clerk_interpreter_details.spec.ts
@@ -107,10 +107,11 @@ describe('ClerkInterpreterOverview:ClerkInterpreterDetails', () => {
 
   it('should add qualification successfully', () => {
     onClerkInterpreterOverviewPage.clickAddQualificationButton();
-    onClerkInterpreterOverviewPage.fillOutAddQualificationFields();
-    onClerkInterpreterOverviewPage.toggleAddQualificationPermissionToPublishSwitch();
+    onClerkInterpreterOverviewPage.expectQualificationSaveButtonDisabled();
+    onClerkInterpreterOverviewPage.fillOutQualificationFields();
+    onClerkInterpreterOverviewPage.toggleQualificationPermissionToPublishSwitch();
 
-    onClerkInterpreterOverviewPage.saveQualification();
+    onClerkInterpreterOverviewPage.clickSaveQualification();
 
     onQualificationDetails.assertRowExists(99);
     onToast.expectText('Rekisteröinti lisätty onnistuneesti');
@@ -122,19 +123,6 @@ describe('ClerkInterpreterOverview:ClerkInterpreterDetails', () => {
       'endDate',
       'input'
     );
-  });
-
-  it('should not allow adding qualification if required fields are not filled', () => {
-    onClerkInterpreterOverviewPage.clickAddQualificationButton();
-    onClerkInterpreterOverviewPage.fillOutAddQualificationFields();
-    onClerkInterpreterOverviewPage.expectQualificationSaveButtonEnabled();
-
-    onClerkInterpreterOverviewPage.fillOutAddQualificationField(
-      'diaryNumber',
-      'input',
-      ''
-    );
-    onClerkInterpreterOverviewPage.expectQualificationSaveButtonDisabled();
   });
 
   it('should display a confirmation dialog if the back button is clicked and there are unsaved changes', () => {

--- a/frontend/packages/otr/src/tests/cypress/integration/interpreterOverview/qualification_details.spec.ts
+++ b/frontend/packages/otr/src/tests/cypress/integration/interpreterOverview/qualification_details.spec.ts
@@ -31,33 +31,6 @@ describe('ClerkInterpreterOverview:QualificationDetails', () => {
     );
   });
 
-  it('should open a confirmation dialog when publish permission switch is clicked, and do no changes if user backs out', () => {
-    onQualificationDetails.switchPublishPermission(EFFECTIVE_QUALIFICATION_ID);
-    onDialog.expectText('Haluatko varmasti vaihtaa julkaisulupaa?');
-    onDialog.clickButtonByText('Takaisin');
-
-    onQualificationDetails.expectPublishPermission(
-      EFFECTIVE_QUALIFICATION_ID,
-      true
-    );
-  });
-
-  it('should open a confirmation dialog when publish permission switch is clicked, and change the publish permission if user confirms', () => {
-    onQualificationDetails.expectPublishPermission(
-      EFFECTIVE_QUALIFICATION_ID,
-      true
-    );
-
-    onQualificationDetails.switchPublishPermission(EFFECTIVE_QUALIFICATION_ID);
-    onDialog.clickButtonByText('Kyllä');
-
-    onQualificationDetails.expectPublishPermission(
-      EFFECTIVE_QUALIFICATION_ID,
-      false
-    );
-    onToast.expectText('Rekisteröinnin julkaisulupaa muutettu');
-  });
-
   it('should open a confirmation dialog when a delete icon is clicked, and do no changes if user backs out', () => {
     onQualificationDetails.clickDeleteButton(EFFECTIVE_QUALIFICATION_ID);
     onDialog.expectText('Haluatko varmasti poistaa rekisteröinnin?');

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkInterpreterOverviewPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkInterpreterOverviewPage.ts
@@ -1,5 +1,5 @@
 import { AppRoutes, UIMode } from 'enums/app';
-import { addQualificationFields } from 'tests/cypress/fixtures/utils/clerkInterpreterOverview';
+import { qualificationFields } from 'tests/cypress/fixtures/utils/qualificationFields';
 
 class ClerkInterpreterOverviewPage {
   elements = {
@@ -25,16 +25,13 @@ class ClerkInterpreterOverviewPage {
         .findByTestId(`clerk-interpreter__basic-information__${field}`)
         .should('be.visible')
         .find(`div>${fieldType}`),
-    addQualificationField: (field: string, fieldType: string) =>
-      cy
-        .findByTestId(`add-qualification-field-${field}`)
-        .find(`div>${fieldType}`),
+    qualificationField: (field: string, fieldType: string) =>
+      cy.findByTestId(`qualification-field-${field}`).find(`div>${fieldType}`),
     permissionToPublishSwitch: () =>
-      cy.findByTestId('add-qualification-field-permissionToPublish'),
+      cy.findByTestId('qualification-field-permissionToPublish'),
     qualificationRow: (id: number) =>
       cy.findByTestId(`qualifications-table__id-${id}-row`),
-    saveQualificationButton: () =>
-      cy.findByTestId('add-qualification-modal__save'),
+    saveQualificationButton: () => cy.findByTestId('qualification-modal__save'),
     title: () => cy.findByTestId('clerk-interpreter__basic-information__title'),
   };
 
@@ -94,20 +91,20 @@ class ClerkInterpreterOverviewPage {
       .should('have.value', value);
   }
 
-  fillOutAddQualificationField(
+  fillOutQualificationField(
     fieldName: string,
     fieldType: string,
     newValue: string
   ) {
     this.elements
-      .addQualificationField(fieldName, fieldType)
+      .qualificationField(fieldName, fieldType)
       .clear()
       .type(`${newValue}{enter}`);
   }
 
-  fillOutAddQualificationFields(fields = addQualificationFields) {
+  fillOutQualificationFields(fields = qualificationFields) {
     fields.forEach(({ fieldName, fieldType, value }) => {
-      onClerkInterpreterOverviewPage.fillOutAddQualificationField(
+      onClerkInterpreterOverviewPage.fillOutQualificationField(
         fieldName,
         fieldType,
         value
@@ -115,17 +112,17 @@ class ClerkInterpreterOverviewPage {
     });
   }
 
-  toggleAddQualificationPermissionToPublishSwitch() {
+  toggleQualificationPermissionToPublishSwitch() {
     this.elements.permissionToPublishSwitch().click();
   }
 
   expectDisabledAddQualificationField(fieldName: string, fieldType: string) {
     this.elements
-      .addQualificationField(fieldName, fieldType)
+      .qualificationField(fieldName, fieldType)
       .should('be.disabled');
   }
 
-  saveQualification() {
+  clickSaveQualification() {
     this.elements.saveQualificationButton().should('be.visible').click();
   }
 
@@ -161,9 +158,6 @@ class ClerkInterpreterOverviewPage {
       case UIMode.EditInterpreterDetails:
         this.elements.cancelInterpreterDetailsButton().should('be.visible');
         break;
-      case UIMode.EditQualificationDetails:
-        // not implemented yet
-        assert(false);
     }
   }
 

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkNewInterpreterPage.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/clerkNewInterpreterPage.ts
@@ -1,4 +1,4 @@
-import { addQualificationFields } from 'tests/cypress/fixtures/utils/clerkInterpreterOverview';
+import { qualificationFields } from 'tests/cypress/fixtures/utils/qualificationFields';
 
 class ClerkNewInterpreterPage {
   elements = {
@@ -9,14 +9,11 @@ class ClerkNewInterpreterPage {
         .findByTestId(`clerk-interpreter__basic-information__${field}`)
         .should('be.visible')
         .find(`div>${fieldType}`),
-    addQualificationField: (field: string, fieldType: string) =>
-      cy
-        .findByTestId(`add-qualification-field-${field}`)
-        .find(`div>${fieldType}`),
+    qualificationField: (field: string, fieldType: string) =>
+      cy.findByTestId(`qualification-field-${field}`).find(`div>${fieldType}`),
     qualificationRow: (i: number) =>
-      cy.findByTestId(`qualifications-table__id-${i}-unsaved`),
-    saveQualificationButton: () =>
-      cy.findByTestId('add-qualification-modal__save'),
+      cy.findByTestId(`qualifications-table__id-${i}-row`),
+    saveQualificationButton: () => cy.findByTestId('qualification-modal__save'),
     saveInterpreterButton: () =>
       cy.findByTestId('clerk-new-interpreter-page__save-button'),
     title: () => cy.findByTestId('clerk-interpreter__basic-information__title'),
@@ -76,20 +73,20 @@ class ClerkNewInterpreterPage {
     this.elements.addQualificationButton().should('be.visible').click();
   }
 
-  fillOutAddQualificationField(
+  fillOutQualificationField(
     fieldName: string,
     fieldType: string,
     newValue: string
   ) {
     this.elements
-      .addQualificationField(fieldName, fieldType)
+      .qualificationField(fieldName, fieldType)
       .clear()
       .type(`${newValue}{enter}`);
   }
 
-  fillOutAddQualificationFields(fields = addQualificationFields) {
+  fillOutQualificationFields(fields = qualificationFields) {
     fields.forEach(({ fieldName, fieldType, value }) => {
-      this.fillOutAddQualificationField(fieldName, fieldType, value);
+      this.fillOutQualificationField(fieldName, fieldType, value);
     });
   }
 

--- a/frontend/packages/otr/src/tests/cypress/support/page-objects/qualificationDetails.ts
+++ b/frontend/packages/otr/src/tests/cypress/support/page-objects/qualificationDetails.ts
@@ -9,9 +9,7 @@ class QualificationDetails {
     expiredToggleButton: () => cy.findByTestId(toggleButton('expired')),
     row: (id: number) => cy.findByTestId(rowTestId(id)),
     deleteButton: (id: number) =>
-      cy.findByTestId(`${rowTestId(id)}__delete-button`),
-    publishPermissionSwitch: (id: number) =>
-      cy.findByTestId(rowTestId(id)).find('input[type=checkbox]'),
+      cy.findByTestId(`${rowTestId(id)}__delete-btn`),
   };
 
   clickExpiredToggleBtn() {
@@ -28,15 +26,6 @@ class QualificationDetails {
 
   expectRowToHaveText(id: number, text: string) {
     this.elements.row(id).should('contain.text', text);
-  }
-
-  switchPublishPermission(id: number) {
-    this.elements.publishPermissionSwitch(id).click();
-  }
-
-  expectPublishPermission(id: number, publishPermission: boolean) {
-    const value = publishPermission ? 'on' : 'off';
-    this.elements.publishPermissionSwitch(id).should('be.have', value);
   }
 
   clickDeleteButton(id: number) {

--- a/frontend/packages/otr/src/tests/msw/handlers.ts
+++ b/frontend/packages/otr/src/tests/msw/handlers.ts
@@ -9,10 +9,7 @@ import { newMeetingDate } from 'tests/msw/fixtures/newMeetingDate';
 import { newQualification } from 'tests/msw/fixtures/newQualification';
 import { person1, person2 } from 'tests/msw/fixtures/person';
 import { publicInterpreters10 } from 'tests/msw/fixtures/publicInterpreters10';
-import {
-  publishPermissionChangeResponse,
-  qualificationRemoveResponse,
-} from 'tests/msw/utils/clerkInterpreterOverview';
+import { qualificationRemoveResponse } from 'tests/msw/utils/clerkInterpreterOverview';
 
 export const handlers = [
   rest.get(APIEndpoints.PublicInterpreter, (req, res, ctx) => {
@@ -64,20 +61,6 @@ export const handlers = [
       );
     }
   ),
-  rest.put(APIEndpoints.Qualification, async (req, res, ctx) => {
-    const { id, permissionToPublish } = await req.json();
-
-    return res(
-      ctx.status(200),
-      ctx.json(
-        publishPermissionChangeResponse(
-          clerkInterpreter,
-          id,
-          !permissionToPublish
-        )
-      )
-    );
-  }),
   rest.delete(`${APIEndpoints.Qualification}/:id`, async (req, res, ctx) => {
     const { id } = req.params;
 

--- a/frontend/packages/otr/src/tests/msw/utils/clerkInterpreterOverview.ts
+++ b/frontend/packages/otr/src/tests/msw/utils/clerkInterpreterOverview.ts
@@ -1,25 +1,5 @@
 import { ClerkInterpreterResponse } from 'interfaces/clerkInterpreter';
 
-export const publishPermissionChangeResponse = (
-  interpreterResponse: ClerkInterpreterResponse,
-  effectiveQualificationId: number,
-  newPublishPermissionValue: boolean
-) => {
-  const effective = interpreterResponse.qualifications.effective.map((q) =>
-    q.id === effectiveQualificationId
-      ? { ...q, permissionToPublish: newPublishPermissionValue }
-      : q
-  );
-
-  return {
-    ...interpreterResponse,
-    qualifications: {
-      ...interpreterResponse.qualifications,
-      effective,
-    },
-  };
-};
-
 export const qualificationRemoveResponse = (
   interpreterResponse: ClerkInterpreterResponse,
   effectiveQualificationId: number

--- a/frontend/packages/otr/src/utils/qualifications.ts
+++ b/frontend/packages/otr/src/utils/qualifications.ts
@@ -1,11 +1,22 @@
+import { ExaminationType } from 'enums/interpreter';
 import { ClerkInterpreterQualifications } from 'interfaces/clerkInterpreter';
 import { LanguagePair } from 'interfaces/languagePair';
-import { Qualification } from 'interfaces/qualification';
+import { NewQualification, Qualification } from 'interfaces/qualification';
 import koodistoLangsFI from 'public/i18n/koodisto/langs/koodisto_langs_fi-FI.json';
 
 export class QualificationUtils {
   static defaultFromLang = 'FI';
   static selectableFromLangs = ['FI'];
+
+  static newQualification: NewQualification = {
+    fromLang: QualificationUtils.defaultFromLang,
+    toLang: '',
+    examinationType: undefined as unknown as ExaminationType,
+    beginDate: undefined,
+    endDate: undefined,
+    permissionToPublish: true,
+    diaryNumber: '',
+  };
 
   static isEffective(
     { id }: Qualification,

--- a/frontend/packages/otr/src/utils/serialization.ts
+++ b/frontend/packages/otr/src/utils/serialization.ts
@@ -100,13 +100,14 @@ export class SerializationUtils {
   }
 
   static serializeQualification(qualification: Qualification) {
-    const { beginDate, endDate, diaryNumber, ...rest } = qualification;
+    const { beginDate, endDate, tempId: _, ...rest } = qualification;
+    const diaryNumber = qualification.diaryNumber.trim();
 
     return {
+      ...rest,
       beginDate: DateUtils.serializeDate(beginDate),
       endDate: DateUtils.serializeDate(endDate),
-      diaryNumber: diaryNumber ? diaryNumber.trim() : undefined,
-      ...rest,
+      diaryNumber: diaryNumber ? diaryNumber : undefined,
     };
   }
 
@@ -115,8 +116,9 @@ export class SerializationUtils {
   ): Qualification {
     const beginDate = dayjs(qualification.beginDate);
     const endDate = dayjs(qualification.endDate);
+    const diaryNumber = qualification.diaryNumber || '';
 
-    return { ...qualification, beginDate, endDate };
+    return { ...qualification, beginDate, endDate, diaryNumber };
   }
 
   static deserializeMeetingDates(response: Array<MeetingDateResponse>) {


### PR DESCRIPTION
## Yhteenveto

Lisätty samalla tavoin Muokkaa-painike rekisteröintiriveille kuin auktorisointiriveille tehtiin PR:ssä https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/430.

Rekisteröintien julkaisuluvan muokkaus toteutettiin täällä aikanaan rekisteröintien muokkausrajapinnan kautta. Näin ollen rajapintamuutoksia / koskemista backendin puolelle ei tarvinnut tehdä lainkaan.

## Check-lista

- [ ] Käännösten Excel-tiedosto päivitetty
- [x] UI-muutoksia testattu eri selaimilla
