### PR TITLE
AKR & OTR(Backend): OPHAKRKEH-490 kerran päivässä ajettavat skeduloinnit ajetaan päiväsaikaan

### DIFF
--- a/backend/akr/src/main/java/fi/oph/akr/config/Constants.java
+++ b/backend/akr/src/main/java/fi/oph/akr/config/Constants.java
@@ -6,4 +6,13 @@ public class Constants {
   public static final String EMAIL_SENDER_NAME = "AKR | Opetushallitus";
   public static final String SERVICENAME = "akr";
   public static final String APP_ROLE = "APP_AKT";
+
+  // Daily at 9:00
+  public static final String EVICT_PUBLIC_TRANSLATORS_CACHE_CRON = "0 0 9 * * *";
+  // Daily at 9:30
+  public static final String GENERATE_STATISTICS_CRON = "0 30 9 * * *";
+  // Daily at 10:00
+  public static final String CHECK_EXPIRING_AUTHORISATIONS_CRON = "0 0 10 * * *";
+  // Daily at 10:30
+  public static final String DESTROY_OBSOLETE_CONTACT_REQUESTS_CRON = "0 30 10 * * *";
 }

--- a/backend/akr/src/main/java/fi/oph/akr/scheduled/CacheEvictScheduled.java
+++ b/backend/akr/src/main/java/fi/oph/akr/scheduled/CacheEvictScheduled.java
@@ -1,7 +1,7 @@
 package fi.oph.akr.scheduled;
 
 import fi.oph.akr.config.CacheConfig;
-import fi.oph.akr.util.SchedulingUtil;
+import fi.oph.akr.config.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
@@ -13,9 +13,9 @@ public class CacheEvictScheduled {
 
   private static final Logger LOG = LoggerFactory.getLogger(CacheEvictScheduled.class);
 
-  @Scheduled(cron = "0 0 4 * * *")
+  @Scheduled(cron = Constants.EVICT_PUBLIC_TRANSLATORS_CACHE_CRON)
   @CacheEvict(cacheNames = CacheConfig.CACHE_NAME_PUBLIC_TRANSLATORS, allEntries = true)
   public void evictPublicTranslatorsCache() {
-    SchedulingUtil.runWithScheduledUser(() -> LOG.info("Evicting cache: " + CacheConfig.CACHE_NAME_PUBLIC_TRANSLATORS));
+    LOG.info("Evicting cache: " + CacheConfig.CACHE_NAME_PUBLIC_TRANSLATORS);
   }
 }

--- a/backend/akr/src/main/java/fi/oph/akr/scheduled/ExpiringAuthorisationsEmailCreator.java
+++ b/backend/akr/src/main/java/fi/oph/akr/scheduled/ExpiringAuthorisationsEmailCreator.java
@@ -1,5 +1,6 @@
 package fi.oph.akr.scheduled;
 
+import fi.oph.akr.config.Constants;
 import fi.oph.akr.model.Authorisation;
 import fi.oph.akr.model.Translator;
 import fi.oph.akr.repository.AuthorisationRepository;
@@ -13,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -33,16 +33,9 @@ public class ExpiringAuthorisationsEmailCreator {
   @Resource
   private final ClerkEmailService clerkEmailService;
 
-  @Resource
-  private final Environment environment;
-
-  @Scheduled(cron = "0 0 3 * * *")
+  @Scheduled(cron = Constants.CHECK_EXPIRING_AUTHORISATIONS_CRON)
   @SchedulerLock(name = "checkExpiringAuthorisations", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
   public void checkExpiringAuthorisations() {
-    if (!environment.getRequiredProperty("app.create-expiry-emails-enabled", Boolean.class)) {
-      LOG.info("Expiry emails creation is disabled, do nothing.");
-      return;
-    }
     SchedulingUtil.runWithScheduledUser(() -> {
       LOG.info("checkExpiringAuthorisations");
       final LocalDate expiryBetweenStart = LocalDate.now();

--- a/backend/akr/src/main/java/fi/oph/akr/scheduled/ObsoleteContactRequestsDestroyer.java
+++ b/backend/akr/src/main/java/fi/oph/akr/scheduled/ObsoleteContactRequestsDestroyer.java
@@ -1,5 +1,6 @@
 package fi.oph.akr.scheduled;
 
+import fi.oph.akr.config.Constants;
 import fi.oph.akr.service.ContactRequestService;
 import fi.oph.akr.util.SchedulingUtil;
 import java.time.LocalDateTime;
@@ -24,7 +25,7 @@ public class ObsoleteContactRequestsDestroyer {
   @Resource
   private final ContactRequestService contactRequestService;
 
-  @Scheduled(cron = "0 0 4 * * *")
+  @Scheduled(cron = Constants.DESTROY_OBSOLETE_CONTACT_REQUESTS_CRON)
   @SchedulerLock(name = "destroyObsoleteContactRequests", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
   public void destroyObsoleteContactRequests() {
     SchedulingUtil.runWithScheduledUser(() -> {

--- a/backend/akr/src/main/java/fi/oph/akr/scheduled/StatisticsGeneratorScheduled.java
+++ b/backend/akr/src/main/java/fi/oph/akr/scheduled/StatisticsGeneratorScheduled.java
@@ -1,5 +1,6 @@
 package fi.oph.akr.scheduled;
 
+import fi.oph.akr.config.Constants;
 import fi.oph.akr.service.StatisticsService;
 import fi.oph.akr.util.SchedulingUtil;
 import javax.annotation.Resource;
@@ -21,7 +22,7 @@ public class StatisticsGeneratorScheduled {
   @Resource
   private StatisticsService statisticsService;
 
-  @Scheduled(cron = "0 29 8 * * *")
+  @Scheduled(cron = Constants.GENERATE_STATISTICS_CRON)
   @SchedulerLock(name = "generateStatistics", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
   public void generateStatistics() {
     SchedulingUtil.runWithScheduledUser(() -> {

--- a/backend/akr/src/main/resources/application.yaml
+++ b/backend/akr/src/main/resources/application.yaml
@@ -57,7 +57,6 @@ cas:
   url: ${virkailija.cas.url:http://localhost:${server.port}/akr}
   login-url: ${virkailija.cas.login-url:http://localhost:${server.port}/login}
 app:
-  create-expiry-emails-enabled: ${create-expiry-emails-enabled:false}
   email:
     sending-enabled: ${email.sending-enabled:false}
     service-url: ${email.service-url:null}

--- a/backend/akr/src/main/resources/oph-configuration/akr.properties.template
+++ b/backend/akr/src/main/resources/oph-configuration/akr.properties.template
@@ -12,6 +12,5 @@ virkailija.cas.service-url=${virkailija.cas.base-url}/akr/virkailija
 virkailija.cas.url=${virkailija.cas.base-url}/cas
 virkailija.cas.login-url=${virkailija.cas.base-url}/cas/login
 
-create-expiry-emails-enabled=true
 email.sending-enabled=true
 email.service-url=${virkailija.host.alb}/ryhmasahkoposti-service/email/firewall

--- a/backend/akr/src/test/java/fi/oph/akr/scheduled/ExpiringAuthorisationsEmailCreatorTest.java
+++ b/backend/akr/src/test/java/fi/oph/akr/scheduled/ExpiringAuthorisationsEmailCreatorTest.java
@@ -1,11 +1,9 @@
 package fi.oph.akr.scheduled;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 import fi.oph.akr.Factory;
 import fi.oph.akr.model.Authorisation;
@@ -28,7 +26,6 @@ import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.core.env.Environment;
 import org.springframework.security.test.context.support.WithMockUser;
 
 @WithMockUser
@@ -51,14 +48,7 @@ public class ExpiringAuthorisationsEmailCreatorTest {
 
   @BeforeEach
   public void setup() {
-    doSetup(true);
-  }
-
-  private void doSetup(final boolean createExpiryEmailsEnabled) {
-    final Environment environment = mock(Environment.class);
-    when(environment.getRequiredProperty("app.create-expiry-emails-enabled", Boolean.class))
-      .thenReturn(createExpiryEmailsEnabled);
-    emailCreator = new ExpiringAuthorisationsEmailCreator(authorisationRepository, clerkEmailService, environment);
+    emailCreator = new ExpiringAuthorisationsEmailCreator(authorisationRepository, clerkEmailService);
   }
 
   @Test
@@ -126,20 +116,6 @@ public class ExpiringAuthorisationsEmailCreatorTest {
     entityManager.persist(meetingDate);
 
     createAuthorisation(meetingDate, LocalDate.now().plusDays(10), null);
-
-    emailCreator.checkExpiringAuthorisations();
-
-    verifyNoInteractions(clerkEmailService);
-  }
-
-  @Test
-  public void testCheckExpiringAuthorisationsDisabled() {
-    doSetup(false);
-
-    final MeetingDate meetingDate = Factory.meetingDate(LocalDate.now().minusYears(1));
-    entityManager.persist(meetingDate);
-
-    createAuthorisation(meetingDate, LocalDate.now().plusDays(10), "t1@invalid");
 
     emailCreator.checkExpiringAuthorisations();
 

--- a/backend/otr/src/main/java/fi/oph/otr/config/Constants.java
+++ b/backend/otr/src/main/java/fi/oph/otr/config/Constants.java
@@ -6,4 +6,7 @@ public class Constants {
   public static final String EMAIL_SENDER_NAME = "Oikeustulkkirekisteri | Opetushallitus";
   public static final String SERVICENAME = "otr";
   public static final String APP_ROLE = "APP_OIKEUSTULKKIREKISTERI_OIKEUSTULKKI_CRUD";
+
+  // Daily at 10:00
+  public static final String CHECK_EXPIRING_QUALIFICATIONS_CRON = "0 0 10 * * *";
 }

--- a/backend/otr/src/main/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreator.java
+++ b/backend/otr/src/main/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreator.java
@@ -1,5 +1,6 @@
 package fi.oph.otr.scheduled;
 
+import fi.oph.otr.config.Constants;
 import fi.oph.otr.model.Interpreter;
 import fi.oph.otr.model.Qualification;
 import fi.oph.otr.repository.QualificationRepository;
@@ -13,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -33,16 +33,9 @@ public class ExpiringQualificationsEmailCreator {
   @Resource
   private final ClerkEmailService clerkEmailService;
 
-  @Resource
-  private final Environment environment;
-
-  @Scheduled(cron = "0 0 3 * * *")
+  @Scheduled(cron = Constants.CHECK_EXPIRING_QUALIFICATIONS_CRON)
   @SchedulerLock(name = "checkExpiringQualifications", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
   public void checkExpiringQualifications() {
-    if (!environment.getRequiredProperty("app.create-expiry-emails-enabled", Boolean.class)) {
-      LOG.info("Expiry emails creation is disabled, do nothing.");
-      return;
-    }
     SchedulingUtil.runWithScheduledUser(() -> {
       LOG.info("checkExpiringQualifications");
       final LocalDate expiryBetweenStart = LocalDate.now();

--- a/backend/otr/src/main/resources/application.yaml
+++ b/backend/otr/src/main/resources/application.yaml
@@ -56,7 +56,6 @@ cas:
   url: ${virkailija.cas.url:http://localhost:${server.port}/otr}
   login-url: ${virkailija.cas.login-url:http://localhost:${server.port}/login}
 app:
-  create-expiry-emails-enabled: ${create-expiry-emails-enabled:false}
   email:
     sending-enabled: ${email.sending-enabled:false}
     service-url: ${email.service-url:null}

--- a/backend/otr/src/main/resources/oph-configuration/otr.properties.template
+++ b/backend/otr/src/main/resources/oph-configuration/otr.properties.template
@@ -11,7 +11,6 @@ virkailija.cas.service-url=${virkailija.cas.base-url}/otr/virkailija
 virkailija.cas.url=${virkailija.cas.base-url}/cas
 virkailija.cas.login-url=${virkailija.cas.base-url}/cas/login
 
-create-expiry-emails-enabled=true
 email.sending-enabled=true
 email.service-url=${virkailija.host.alb}/ryhmasahkoposti-service/email/firewall
 

--- a/backend/otr/src/test/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreatorTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/scheduled/ExpiringQualificationsEmailCreatorTest.java
@@ -1,11 +1,8 @@
 package fi.oph.otr.scheduled;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 import fi.oph.otr.Factory;
 import fi.oph.otr.model.Email;
@@ -27,7 +24,6 @@ import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.core.env.Environment;
 import org.springframework.security.test.context.support.WithMockUser;
 
 @WithMockUser
@@ -50,14 +46,7 @@ public class ExpiringQualificationsEmailCreatorTest {
 
   @BeforeEach
   public void setup() {
-    doSetup(true);
-  }
-
-  private void doSetup(final boolean createExpiryEmailsEnabled) {
-    final Environment environment = mock(Environment.class);
-    when(environment.getRequiredProperty("app.create-expiry-emails-enabled", Boolean.class))
-      .thenReturn(createExpiryEmailsEnabled);
-    emailCreator = new ExpiringQualificationsEmailCreator(qualificationRepository, clerkEmailService, environment);
+    emailCreator = new ExpiringQualificationsEmailCreator(qualificationRepository, clerkEmailService);
   }
 
   @Test
@@ -130,20 +119,6 @@ public class ExpiringQualificationsEmailCreatorTest {
       .collect(Collectors.toSet());
     final Set<Long> qualificationIds = Set.copyOf(longCaptor.getAllValues());
     assertEquals(expectedQualificationIds, qualificationIds);
-  }
-
-  @Test
-  public void testCheckExpiringQualificationsDisabled() {
-    doSetup(false);
-
-    final MeetingDate meetingDate = Factory.meetingDate();
-    entityManager.persist(meetingDate);
-
-    createQualification(meetingDate, LocalDate.now().plusDays(10));
-
-    emailCreator.checkExpiringQualifications();
-
-    verifyNoInteractions(clerkEmailService);
   }
 
   private Qualification createQualification(final MeetingDate meetingDate, final LocalDate endDate) {


### PR DESCRIPTION
## Yhteenveto

Kerran päivässä ajettavien skeduloitujen taskien ajastukset määritelty `Constants` luokan alla staattisina muuttujina. Muutos koski vain AKR:ää ja OTR:ää ja näistä versiot menossa untuvalle testiajoon, jotta voi huomenna tsekata, että lokeissa merkinnät taskien ajoista.

Huomiona että poistettu tuo `create-expiry-emails-enabled` konffi, joka toteutettiin sitä varten, että otettaessa AKR:ää ja OTR:ää käyttöön voitiin pitää uusi tuotantoympäristö basic authin takana ajossa ilman että se ajaa tuota tiettyä ajastettuja taskia.