### PR TITLE
AKR:OTR:Shared OPHAKRKEH-497: korjattu saavutettavuusselosteiden otsikkotason eteneminen

### DIFF
--- a/frontend/packages/akr/package.json
+++ b/frontend/packages/akr/package.json
@@ -22,6 +22,6 @@
     "akr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.1"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.2"
   }
 }

--- a/frontend/packages/akr/src/pages/AccessibilityStatementPage.tsx
+++ b/frontend/packages/akr/src/pages/AccessibilityStatementPage.tsx
@@ -55,23 +55,21 @@ export const AccessibilityStatementPage = () => {
       rowSpacing={4}
       direction="column"
     >
+      <Grid item className="accessibility-statement-page__back-button">
+        <BackButton />
+      </Grid>
       <Grid item className="accessibility-statement-page__heading">
         <H1>{translateAccessibility('heading.title')}</H1>
         <HeaderSeparator />
         <Text>{translateAccessibility('heading.description')}</Text>
       </Grid>
       <Grid item>
-        <Paper
-          className="accessibility-statement-page__content rows gapped-xxl"
-          elevation={3}
-        >
-          <BackButton />
+        <Paper className="accessibility-statement-page__content" elevation={3}>
           <AccessibilityStatementContent
             caveats={caveats}
             feedbackEmail={feedbackEmail}
             translateAccessibility={translateAccessibility}
           />
-          <BackButton />
         </Paper>
       </Grid>
     </Grid>

--- a/frontend/packages/akr/src/styles/pages/_accessibility-statement-page.scss
+++ b/frontend/packages/akr/src/styles/pages/_accessibility-statement-page.scss
@@ -1,9 +1,15 @@
 .accessibility-statement-page {
   flex: 1;
 
-  & &__heading {
+  & &__back-button {
     @include phone {
       margin-top: 2rem;
+      padding: 2rem 2rem 0;
+    }
+  }
+
+  & &__heading {
+    @include phone {
       padding: 2rem 2rem 0;
     }
   }

--- a/frontend/packages/otr/package.json
+++ b/frontend/packages/otr/package.json
@@ -25,6 +25,6 @@
     "otr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.1"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.2"
   }
 }

--- a/frontend/packages/otr/src/pages/AccessibilityStatementPage.tsx
+++ b/frontend/packages/otr/src/pages/AccessibilityStatementPage.tsx
@@ -55,23 +55,21 @@ export const AccessibilityStatementPage = () => {
       rowSpacing={4}
       direction="column"
     >
+      <Grid item className="accessibility-statement-page__back-button">
+        <BackButton />
+      </Grid>
       <Grid item className="accessibility-statement-page__heading">
         <H1>{translateAccessibility('heading.title')}</H1>
         <HeaderSeparator />
         <Text>{translateAccessibility('heading.description')}</Text>
       </Grid>
       <Grid item>
-        <Paper
-          className="accessibility-statement-page__content rows gapped-xxl"
-          elevation={3}
-        >
-          <BackButton />
+        <Paper className="accessibility-statement-page__content" elevation={3}>
           <AccessibilityStatementContent
             caveats={caveats}
             feedbackEmail={feedbackEmail}
             translateAccessibility={translateAccessibility}
           />
-          <BackButton />
         </Paper>
       </Grid>
     </Grid>

--- a/frontend/packages/otr/src/styles/pages/_accessibility-statement-page.scss
+++ b/frontend/packages/otr/src/styles/pages/_accessibility-statement-page.scss
@@ -1,9 +1,15 @@
 .accessibility-statement-page {
   flex: 1;
 
-  & &__heading {
+  & &__back-button {
     @include phone {
       margin-top: 2rem;
+      padding: 2rem 2rem 0;
+    }
+  }
+
+  & &__heading {
+    @include phone {
       padding: 2rem 2rem 0;
     }
   }

--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.9.2] - 2023-03-30
+
+### Changed
+
+- Improved accessibility of AccessibilityContent
+
 ## [1.9.1] - 2023-03-29
 
 ### Added

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/components/AccessibilityStatement/AccessibilityStatementContent.tsx
+++ b/frontend/packages/shared/src/components/AccessibilityStatement/AccessibilityStatementContent.tsx
@@ -43,24 +43,28 @@ export const AccessibilityStatementContent: FC<
         </div>
         <div className="rows gapped-xxs">
           <H2>{translateAccessibility('content.nonAccessible.title')}</H2>
-          <H3>{translateAccessibility('content.nonAccessible.description')}</H3>
+          <Text>
+            {translateAccessibility('content.nonAccessible.description')}
+          </Text>
         </div>
         <div className="accessibility-statement-content__caveats rows gapped-xxl">
           {caveats.map(({}, i) => (
             <div className="rows gapped-xs" key={i}>
-              <H2>{`${translateAccessibility(
+              <H3>{`${translateAccessibility(
                 `content.caveats.items.${i}.title`
-              )}`}</H2>
-              <H3>{translateAccessibility('content.caveats.description')}</H3>
+              )}`}</H3>
+              <Text>
+                {translateAccessibility('content.caveats.description')}
+              </Text>
               <Text>
                 {translateAccessibility(
                   `content.caveats.items.${i}.description`
                 )}
               </Text>
               <div>
-                <H3>
+                <Text>
                   {translateAccessibility('content.caveats.extraDescription')}
-                </H3>
+                </Text>
                 <ul>
                   <Text>
                     <li>
@@ -84,9 +88,9 @@ export const AccessibilityStatementContent: FC<
           </Text>
         </div>
         <div className="rows gapped-xxs">
-          <H2>
+          <H3>
             {translateAccessibility('content.administrativeAgency.title')}
-          </H2>
+          </H3>
           <div className="inline-text-box">
             <Text>
               {translateAccessibility(
@@ -110,11 +114,11 @@ export const AccessibilityStatementContent: FC<
           </div>
         </div>
         <div className="rows gapped-xxs">
-          <H2>
+          <H3>
             {translateAccessibility(
               'content.contactAdministrativeAgency.title'
             )}
-          </H2>
+          </H3>
           <Text>
             {translateAccessibility('content.contactAdministrativeAgency.name')}
           </Text>
@@ -152,8 +156,10 @@ export const AccessibilityStatementContent: FC<
           </Text>
         </div>
         <div className="rows gapped-xxs">
-          <H2>{translateAccessibility('content.furtherImprove.title')}</H2>
-          <H3>{translateAccessibility('content.furtherImprove.subtitle')}</H3>
+          <H3>{translateAccessibility('content.furtherImprove.title')}</H3>
+          <Text>
+            {translateAccessibility('content.furtherImprove.subtitle')}
+          </Text>
           <Text>
             {translateAccessibility('content.furtherImprove.description')}
           </Text>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2686,7 +2686,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.akr@workspace:packages/akr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.1"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.2"
   languageName: unknown
   linkType: soft
 
@@ -2694,7 +2694,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.otr@workspace:packages/otr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.1"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.2"
   languageName: unknown
   linkType: soft
 
@@ -2786,7 +2786,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.1":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.2":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -11813,6 +11813,13 @@ __metadata:
   version: 1.9.0
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.9.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.9.0%2F438adbaf79c251a1a803fd0c3180bf1f42f362ea"
   checksum: 891c46d8d487432c0ec3b9cfa7c3633989f372de1eb3d2e0421a68a39288a96c9ce790063a0c2f4cb382190d1d6458311b8dcf70a89fc31582e033feb87b243b
+  languageName: node
+  linkType: hard
+
+"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.1":
+  version: 1.9.1
+  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.9.1::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.9.1%2F7755d08528b30dcb16e5d4a967fad3f4e28e8297"
+  checksum: a443c3b9db708c58765ca81b4640d9903c881543d4d82c6f9af7f4974d41b18f5e290e88d08d32f623af12e9b74fb7cb24a06864d6eaf5822b774effecc4dce4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Korjattu AKR:n ja OTR:n otsikkotasojen eteneminen saavutettavuusselostesivulla. Selosteet vastaavat nyt ainakin suunnilleen Figman-leiskan vastinetta.

## Check-lista

- [x] yarn.lock päivitetty
- [x] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
