### PR TITLE
AKR:OTR:VKT:Shared(Frontend): OPHAKRKEH-498 virkailijaUI:n ja footerin käytettävyyskorjauksia

### DIFF
--- a/frontend/packages/akr/package.json
+++ b/frontend/packages/akr/package.json
@@ -22,6 +22,6 @@
     "akr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.2"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.3"
   }
 }

--- a/frontend/packages/akr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/akr/public/i18n/en-GB/translation.json
@@ -195,10 +195,6 @@
         "upcoming": "Forthcoming"
       },
       "footer": {
-        "accessibility": {
-          "ophPhone": "Telephone number of the Finnish National Agency for Education",
-          "waveAriaLabel": "Wavy vector image"
-        },
         "address": {
           "name": "Finnish National Agency for Education",
           "phone": {

--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -203,10 +203,6 @@
         "upcoming": "Tulevat"
       },
       "footer": {
-        "accessibility": {
-          "ophPhone": "Opetushallituksen puhelinnumero",
-          "waveAriaLabel": "Aaltoileva vektorikuvio"
-        },
         "address": {
           "name": "Opetushallitus",
           "phone": {

--- a/frontend/packages/akr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/translation.json
@@ -195,10 +195,6 @@
         "upcoming": "Kommande"
       },
       "footer": {
-        "accessibility": {
-          "ophPhone": "Utbildningsstyrelsens telefonnummer",
-          "waveAriaLabel": "Vektordiagram med vågor"
-        },
         "address": {
           "name": "Utbildningsstyrelsen",
           "phone": {

--- a/frontend/packages/akr/src/components/clerkTranslator/examinationDates/AddExaminationDate.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/examinationDates/AddExaminationDate.tsx
@@ -1,11 +1,11 @@
 import AddIcon from '@mui/icons-material/Add';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { Typography } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
 import { useState } from 'react';
 import {
   CustomButton,
   CustomDatePicker,
-  H3,
   LoadingProgressIndicator,
   Text,
 } from 'shared/components';
@@ -74,7 +74,9 @@ export const AddExaminationDate = () => {
   return (
     <div className="columns gapped">
       <div className="rows gapped flex-grow-3">
-        <H3>{t('header')}</H3>
+        <Typography component="h2" variant="h3">
+          {t('header')}
+        </Typography>
         <div className="columns gapped">
           <CustomDatePicker
             value={value}

--- a/frontend/packages/akr/src/components/clerkTranslator/examinationDates/ExaminationDatesListing.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/examinationDates/ExaminationDatesListing.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/system';
 import { FC } from 'react';
 import {
   CustomIconButton,
-  H3,
+  H2,
   ManagedPaginatedTable,
   Text,
 } from 'shared/components';
@@ -89,14 +89,10 @@ const ListingHeader: FC = () => {
   const translateCommon = useCommonTranslation();
 
   return (
-    <TableHead>
+    <TableHead className="heading-text">
       <TableRow>
-        <TableCell>
-          <H3>{t('header')}</H3>
-        </TableCell>
-        <TableCell align="right">
-          <H3>{translateCommon('delete')}</H3>
-        </TableCell>
+        <TableCell>{t('header')}</TableCell>
+        <TableCell align="right">{translateCommon('delete')}</TableCell>
       </TableRow>
     </TableHead>
   );
@@ -134,7 +130,7 @@ export const ExaminationDatesListing: FC = () => {
           justifyContent="center"
           alignItems="center"
         >
-          <H3>{t('errors.loadingFailed')}</H3>
+          <H2>{t('errors.loadingFailed')}</H2>
         </Box>
       );
     case APIResponseStatus.Success:

--- a/frontend/packages/akr/src/components/clerkTranslator/listing/ClerkTranslatorListing.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/listing/ClerkTranslatorListing.tsx
@@ -2,7 +2,7 @@ import { Checkbox, TableCell, TableHead, TableRow } from '@mui/material';
 import { Box } from '@mui/system';
 import { FC, useCallback } from 'react';
 import { Link } from 'react-router-dom';
-import { H2, H3, ManagedPaginatedTable, Text } from 'shared/components';
+import { H2, ManagedPaginatedTable, Text } from 'shared/components';
 import { APIResponseStatus, Color } from 'shared/enums';
 import { DateUtils } from 'shared/utils';
 
@@ -170,7 +170,7 @@ const ListingHeader: FC = () => {
   };
 
   return (
-    <TableHead>
+    <TableHead className="heading-text">
       <TableRow>
         <TableCell padding="checkbox">
           <Checkbox
@@ -180,13 +180,9 @@ const ListingHeader: FC = () => {
             onClick={onCheckboxClick}
           />
         </TableCell>
-        <TableCell>
-          <H3>{t('name')}</H3>
-        </TableCell>
+        <TableCell>{t('name')}</TableCell>
         {Object.values(AuthorisationColumn).map((columnName, idx) => (
-          <TableCell key={idx}>
-            <H3>{t(columnName)}</H3>
-          </TableCell>
+          <TableCell key={idx}>{t(columnName)}</TableCell>
         ))}
       </TableRow>
     </TableHead>
@@ -217,7 +213,7 @@ export const ClerkTranslatorListing: FC = () => {
           justifyContent="center"
           alignItems="center"
         >
-          <H3>{t('errors.loadingFailed')}</H3>
+          <H2>{t('errors.loadingFailed')}</H2>
         </Box>
       );
     case APIResponseStatus.Success:

--- a/frontend/packages/akr/src/components/clerkTranslator/meetingDates/AddMeetingDate.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/meetingDates/AddMeetingDate.tsx
@@ -1,11 +1,11 @@
 import AddIcon from '@mui/icons-material/Add';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { Typography } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
 import { useState } from 'react';
 import {
   CustomButton,
   CustomDatePicker,
-  H3,
   LoadingProgressIndicator,
   Text,
 } from 'shared/components';
@@ -74,7 +74,9 @@ export const AddMeetingDate = () => {
   return (
     <div className="columns gapped">
       <div className="rows gapped flex-grow-3">
-        <H3>{t('header')}</H3>
+        <Typography component="h2" variant="h3">
+          {t('header')}
+        </Typography>
         <div className="columns gapped">
           <CustomDatePicker
             value={value}

--- a/frontend/packages/akr/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/system';
 import { FC } from 'react';
 import {
   CustomIconButton,
-  H3,
+  H2,
   ManagedPaginatedTable,
   Text,
 } from 'shared/components';
@@ -88,14 +88,10 @@ const ListingHeader: FC = () => {
   const translateCommon = useCommonTranslation();
 
   return (
-    <TableHead>
+    <TableHead className="heading-text">
       <TableRow>
-        <TableCell>
-          <H3>{t('header')}</H3>
-        </TableCell>
-        <TableCell align="right">
-          <H3>{translateCommon('delete')}</H3>
-        </TableCell>
+        <TableCell>{t('header')}</TableCell>
+        <TableCell align="right">{translateCommon('delete')}</TableCell>
       </TableRow>
     </TableHead>
   );
@@ -130,7 +126,7 @@ export const MeetingDatesListing: FC = () => {
           justifyContent="center"
           alignItems="center"
         >
-          <H3>{t('errors.loadingFailed')}</H3>
+          <H2>{t('errors.loadingFailed')}</H2>
         </Box>
       );
     case APIResponseStatus.Success:

--- a/frontend/packages/akr/src/components/clerkTranslator/overview/AuthorisationListing.tsx
+++ b/frontend/packages/akr/src/components/clerkTranslator/overview/AuthorisationListing.tsx
@@ -63,7 +63,7 @@ export const AuthorisationListing = ({
         className={combinedClassNames}
         data-testid="clerk-translator-details__authorisations-table"
       >
-        <TableHead>
+        <TableHead className="heading-text">
           <TableRow>
             <TableCell>{t('fields.languagePair')}</TableCell>
             <TableCell>{t('fields.basis')}</TableCell>

--- a/frontend/packages/akr/src/components/layouts/Footer.tsx
+++ b/frontend/packages/akr/src/components/layouts/Footer.tsx
@@ -1,9 +1,8 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { Divider, Paper } from '@mui/material';
+import { Divider, Paper, Typography } from '@mui/material';
 import {
   CustomButtonLink,
   ExtLink,
-  H2,
   OPHLogoViewer,
   Svg,
   Text,
@@ -34,11 +33,7 @@ export const Footer = () => {
     <footer>
       {showFooter && (
         <>
-          <Svg
-            className="footer__wave"
-            src={FooterWave}
-            alt={t('accessibility.waveAriaLabel')}
-          />
+          <Svg className="footer__wave" src={FooterWave} alt="" />
           <Paper className="footer" elevation={3}>
             <div className="footer__info-row">
               <div className="footer__container footer__container__links">
@@ -61,7 +56,9 @@ export const Footer = () => {
                   aria-label={t('links.akrHomepage.ariaLabel')}
                 />
                 <div className="footer__container__links__contact">
-                  <H2 className="heading-text">{t('links.contact.title')}:</H2>
+                  <Typography component="h2" variant="h3">
+                    {t('links.contact.title')}:
+                  </Typography>
                   <ExtLink
                     className="footer__container__links__contact__email"
                     href={`mailto:${translateCommon('contactEmail')}`}
@@ -70,7 +67,9 @@ export const Footer = () => {
                 </div>
               </div>
               <div className="footer__container footer__container__contact-details">
-                <H2 className="heading-text">{t('address.name')}</H2>
+                <Typography component="h2" variant="h3">
+                  {t('address.name')}
+                </Typography>
                 <br />
                 <Text>{t('address.street')}</Text>
                 <Text>{t('address.zipCity')}</Text>
@@ -83,7 +82,6 @@ export const Footer = () => {
                     className="inline-text"
                     text={t('address.phone.number')}
                     href={`tel:${t('address.phone.number')}`}
-                    aria-label={t('accessibility.ophPhone')}
                   />
                 </div>
               </div>
@@ -95,7 +93,6 @@ export const Footer = () => {
                 />
               </div>
             </div>
-
             <div className="footer__logo-row">
               <Divider className="footer__logo-row__divider">
                 <OPHLogoViewer

--- a/frontend/packages/akr/src/tests/jest/components/layouts/__snapshots__/Footer.test.tsx.snap
+++ b/frontend/packages/akr/src/tests/jest/components/layouts/__snapshots__/Footer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Footer should render Footer correctly 1`] = `
 <footer>
   <img
-    alt="accessibility.waveAriaLabel"
+    alt=""
     className="footer__wave"
     src="test"
   />
@@ -109,7 +109,7 @@ exports[`Footer should render Footer correctly 1`] = `
           className="footer__container__links__contact"
         >
           <h2
-            className="MuiTypography-root MuiTypography-h2 heading-text css-1sra7t5-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-h3 css-gepadz-MuiTypography-root"
           >
             links.contact.title
             :
@@ -141,7 +141,7 @@ exports[`Footer should render Footer correctly 1`] = `
         className="footer__container footer__container__contact-details"
       >
         <h2
-          className="MuiTypography-root MuiTypography-h2 heading-text css-1sra7t5-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-h3 css-gepadz-MuiTypography-root"
         >
           address.name
         </h2>
@@ -166,7 +166,6 @@ exports[`Footer should render Footer correctly 1`] = `
             address.phone.title
           </p>
           <a
-            aria-label="accessibility.ophPhone"
             className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit inline-text css-1y942vo-MuiButtonBase-root-MuiButton-root"
             href="tel:address.phone.number"
             onBlur={[Function]}

--- a/frontend/packages/otr/package.json
+++ b/frontend/packages/otr/package.json
@@ -25,6 +25,6 @@
     "otr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.2"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.3"
   }
 }

--- a/frontend/packages/otr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/otr/public/i18n/en-GB/translation.json
@@ -127,10 +127,6 @@
         }
       },
       "footer": {
-        "accessibility": {
-          "ophPhone": "Telephone number of the Finnish National Agency for Education",
-          "waveAriaLabel": "Wavy vector image"
-        },
         "address": {
           "name": "Finnish National Agency for Education",
           "phone": {

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -127,10 +127,6 @@
         }
       },
       "footer": {
-        "accessibility": {
-          "ophPhone": "Opetushallituksen puhelinnumero",
-          "waveAriaLabel": "Aaltoileva vektorikuvio"
-        },
         "address": {
           "name": "Opetushallitus",
           "phone": {

--- a/frontend/packages/otr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/otr/public/i18n/sv-SE/translation.json
@@ -127,10 +127,6 @@
         }
       },
       "footer": {
-        "accessibility": {
-          "ophPhone": "Utbildningsstyrelsens telefonnummer",
-          "waveAriaLabel": "Vektordiagram med vågor"
-        },
         "address": {
           "name": "Utbildningsstyrelsen",
           "phone": {

--- a/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListing.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListing.tsx
@@ -1,11 +1,6 @@
 import { Box } from '@mui/system';
 import { useEffect } from 'react';
-import {
-  CustomCircularProgress,
-  H2,
-  H3,
-  PaginatedTable,
-} from 'shared/components';
+import { CustomCircularProgress, H2, PaginatedTable } from 'shared/components';
 import { APIResponseStatus, Color } from 'shared/enums';
 
 import { ClerkInterpreterListingHeader } from 'components/clerkInterpreter/listing/ClerkInterpreterListingHeader';
@@ -56,7 +51,7 @@ export const ClerkInterpreterListing = () => {
           justifyContent="center"
           alignItems="center"
         >
-          <H3>{t('errors.loadingFailed')}</H3>
+          <H2>{t('errors.loadingFailed')}</H2>
         </Box>
       );
     case APIResponseStatus.Success:

--- a/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingHeader.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/listing/ClerkInterpreterListingHeader.tsx
@@ -1,5 +1,4 @@
 import { TableCell, TableHead, TableRow } from '@mui/material';
-import { H3 } from 'shared/components';
 
 import { useAppTranslation } from 'configs/i18n';
 
@@ -9,26 +8,14 @@ export const ClerkInterpreterListingHeader = () => {
   });
 
   return (
-    <TableHead>
+    <TableHead className="heading-text">
       <TableRow>
-        <TableCell>
-          <H3>{t('name')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('languagePairs')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('examinationType')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('beginDate')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('endDate')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('permissionToPublish')}</H3>
-        </TableCell>
+        <TableCell>{t('name')}</TableCell>
+        <TableCell>{t('languagePairs')}</TableCell>
+        <TableCell>{t('examinationType')}</TableCell>
+        <TableCell>{t('beginDate')}</TableCell>
+        <TableCell>{t('endDate')}</TableCell>
+        <TableCell>{t('permissionToPublish')}</TableCell>
       </TableRow>
     </TableHead>
   );

--- a/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationListing.tsx
+++ b/frontend/packages/otr/src/components/clerkInterpreter/overview/QualificationListing.tsx
@@ -59,7 +59,7 @@ export const QualificationListing = ({
         className={combinedClassNames}
         data-testid="clerk-interpreter-details__qualifications-table"
       >
-        <TableHead>
+        <TableHead className="heading-text">
           <TableRow>
             <TableCell>{t('fields.languagePair')}</TableCell>
             <TableCell>{t('fields.examinationType')}</TableCell>

--- a/frontend/packages/otr/src/components/layouts/Footer.tsx
+++ b/frontend/packages/otr/src/components/layouts/Footer.tsx
@@ -1,9 +1,8 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { Divider, Paper } from '@mui/material';
+import { Divider, Paper, Typography } from '@mui/material';
 import {
   CustomButtonLink,
   ExtLink,
-  H2,
   OPHLogoViewer,
   Svg,
   Text,
@@ -29,11 +28,7 @@ export const Footer = () => {
     <footer>
       {!isAuthenticated && (
         <>
-          <Svg
-            className="footer__wave"
-            src={FooterWave}
-            alt={t('accessibility.waveAriaLabel')}
-          />
+          <Svg className="footer__wave" src={FooterWave} alt="" />
           <Paper className="footer" elevation={3}>
             <div className="footer__info-row">
               <div className="footer__container footer__container__links">
@@ -56,7 +51,9 @@ export const Footer = () => {
                   aria-label={t('links.otrHomepage.ariaLabel')}
                 />
                 <div className="footer__container__links__contact">
-                  <H2 className="heading-text">{t('links.contact.title')}:</H2>
+                  <Typography component="h2" variant="h3">
+                    {t('links.contact.title')}:
+                  </Typography>
                   <ExtLink
                     className="footer__container__links__contact__email"
                     href={`mailto:${translateCommon('contactEmail')}`}
@@ -65,7 +62,9 @@ export const Footer = () => {
                 </div>
               </div>
               <div className="footer__container footer__container__contact-details">
-                <H2 className="heading-text">{t('address.name')}</H2>
+                <Typography component="h2" variant="h3">
+                  {t('address.name')}
+                </Typography>
                 <br />
                 <Text>{t('address.street')}</Text>
                 <Text>{t('address.zipCity')}</Text>
@@ -78,7 +77,6 @@ export const Footer = () => {
                     className="inline-text"
                     text={t('address.phone.number')}
                     href={`tel:${t('address.phone.number')}`}
-                    aria-label={t('accessibility.ophPhone')}
                   />
                 </div>
               </div>

--- a/frontend/packages/otr/src/components/meetingDate/AddMeetingDate.tsx
+++ b/frontend/packages/otr/src/components/meetingDate/AddMeetingDate.tsx
@@ -1,11 +1,11 @@
 import AddIcon from '@mui/icons-material/Add';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { Typography } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
 import { useState } from 'react';
 import {
   CustomButton,
   CustomDatePicker,
-  H3,
   LoadingProgressIndicator,
   Text,
 } from 'shared/components';
@@ -74,7 +74,9 @@ export const AddMeetingDate = () => {
   return (
     <div className="columns gapped">
       <div className="rows gapped flex-grow-3">
-        <H3>{t('header')}</H3>
+        <Typography component="h2" variant="h3">
+          {t('header')}
+        </Typography>
         <div className="columns gapped">
           <CustomDatePicker
             value={value}

--- a/frontend/packages/otr/src/components/meetingDate/MeetingDatesListing.tsx
+++ b/frontend/packages/otr/src/components/meetingDate/MeetingDatesListing.tsx
@@ -2,7 +2,7 @@ import DeleteIcon from '@mui/icons-material/DeleteOutline';
 import { TableCell, TableHead, TableRow } from '@mui/material';
 import { Box } from '@mui/system';
 import { FC } from 'react';
-import { CustomIconButton, H3, PaginatedTable, Text } from 'shared/components';
+import { CustomIconButton, H2, PaginatedTable, Text } from 'shared/components';
 import { APIResponseStatus, Color, Severity, Variant } from 'shared/enums';
 import { useDialog } from 'shared/hooks';
 import { DateUtils } from 'shared/utils';
@@ -77,14 +77,10 @@ const ListingHeader: FC = () => {
   const translateCommon = useCommonTranslation();
 
   return (
-    <TableHead>
+    <TableHead className="heading-text">
       <TableRow>
-        <TableCell>
-          <H3>{t('header')}</H3>
-        </TableCell>
-        <TableCell align="right">
-          <H3>{translateCommon('delete')}</H3>
-        </TableCell>
+        <TableCell>{t('header')}</TableCell>
+        <TableCell align="right">{translateCommon('delete')}</TableCell>
       </TableRow>
     </TableHead>
   );
@@ -111,7 +107,7 @@ export const MeetingDatesListing: FC = () => {
           justifyContent="center"
           alignItems="center"
         >
-          <H3>{t('errors.loadingFailed')}</H3>
+          <H2>{t('errors.loadingFailed')}</H2>
         </Box>
       );
     case APIResponseStatus.Success:

--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.9.3] - 2023-04-14
+
+### Changed
+
+- Removed h2 and h3 heading-text
+
 ## [1.9.2] - 2023-03-30
 
 ### Changed

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/styles/abstracts/common/_typography.scss
+++ b/frontend/packages/shared/src/styles/abstracts/common/_typography.scss
@@ -10,9 +10,7 @@
 }
 
 .heading-text,
-thead.heading-text th,
-h2.heading-text,
-h3.heading-text {
+thead.heading-text th {
   font-size: 1.6rem;
   font-weight: 700;
 }

--- a/frontend/packages/vkt/package.json
+++ b/frontend/packages/vkt/package.json
@@ -25,6 +25,6 @@
     "vkt:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.1"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.3"
   }
 }

--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -2,10 +2,6 @@
   "vkt": {
     "component": {
       "footer": {
-        "accessibility": {
-          "ophPhone": "Opetushallituksen puhelinnumero",
-          "waveAriaLabel": "Aaltoileva vektorikuvio"
-        },
         "address": {
           "name": "Opetushallitus",
           "phone": {

--- a/frontend/packages/vkt/src/components/clerkEnrollment/listing/ClerkEnrollmentListingHeader.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/listing/ClerkEnrollmentListingHeader.tsx
@@ -1,5 +1,4 @@
 import { TableCell, TableHead, TableRow } from '@mui/material';
-import { H3 } from 'shared/components';
 
 import { useClerkTranslation } from 'configs/i18n';
 
@@ -9,20 +8,12 @@ export const ClerkEnrollmentListingHeader = () => {
   });
 
   return (
-    <TableHead>
+    <TableHead className="heading-text">
       <TableRow>
-        <TableCell>
-          <H3>{t('firstName')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('lastName')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('examEventCoverage')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('registrationTime')}</H3>
-        </TableCell>
+        <TableCell>{t('firstName')}</TableCell>
+        <TableCell>{t('lastName')}</TableCell>
+        <TableCell>{t('examEventCoverage')}</TableCell>
+        <TableCell>{t('registrationTime')}</TableCell>
         <TableCell />
       </TableRow>
     </TableHead>

--- a/frontend/packages/vkt/src/components/clerkExamEvent/listing/ClerkExamEventListingHeader.tsx
+++ b/frontend/packages/vkt/src/components/clerkExamEvent/listing/ClerkExamEventListingHeader.tsx
@@ -1,5 +1,4 @@
 import { TableCell, TableHead, TableRow } from '@mui/material';
-import { H3 } from 'shared/components';
 
 import { useClerkTranslation } from 'configs/i18n';
 
@@ -9,23 +8,13 @@ export const ClerkExamEventListingHeader = () => {
   });
 
   return (
-    <TableHead>
+    <TableHead className="heading-text">
       <TableRow>
-        <TableCell>
-          <H3>{t('language')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('examDate')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('registrationCloses')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('fillings')}</H3>
-        </TableCell>
-        <TableCell>
-          <H3>{t('hidden')}</H3>
-        </TableCell>
+        <TableCell>{t('language')}</TableCell>
+        <TableCell>{t('examDate')}</TableCell>
+        <TableCell>{t('registrationCloses')}</TableCell>
+        <TableCell>{t('fillings')}</TableCell>
+        <TableCell>{t('hidden')}</TableCell>
       </TableRow>
     </TableHead>
   );

--- a/frontend/packages/vkt/src/components/layouts/Footer.tsx
+++ b/frontend/packages/vkt/src/components/layouts/Footer.tsx
@@ -1,10 +1,9 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { Divider, Paper } from '@mui/material';
+import { Divider, Paper, Typography } from '@mui/material';
 import { useLocation } from 'react-router-dom';
 import {
   CustomButtonLink,
   ExtLink,
-  H2,
   OPHLogoViewer,
   Svg,
   Text,
@@ -37,11 +36,7 @@ export const Footer = () => {
     <footer>
       {showFooter && (
         <>
-          <Svg
-            className="footer__wave"
-            src={FooterWave}
-            alt={t('accessibility.waveAriaLabel')}
-          />
+          <Svg className="footer__wave" src={FooterWave} alt="" />
           <Paper className="footer" elevation={3}>
             <div className="footer__info-row">
               <div className="footer__container footer__container__links">
@@ -64,7 +59,9 @@ export const Footer = () => {
                   aria-label={translateCommon('vktHomepage.ariaLabel')}
                 />
                 <div className="footer__container__links__contact">
-                  <H2 className="heading-text">{t('links.contact.title')}:</H2>
+                  <Typography component="h2" variant="h3">
+                    {t('links.contact.title')}:
+                  </Typography>
                   <ExtLink
                     className="footer__container__links__contact__email"
                     href={`mailto:${translateCommon('contactEmail')}`}
@@ -73,7 +70,9 @@ export const Footer = () => {
                 </div>
               </div>
               <div className="footer__container footer__container__contact-details">
-                <H2 className="heading-text">{t('address.name')}</H2>
+                <Typography component="h2" variant="h3">
+                  {t('address.name')}
+                </Typography>
                 <br />
                 <Text>{t('address.street')}</Text>
                 <Text>{t('address.zipCity')}</Text>
@@ -86,7 +85,6 @@ export const Footer = () => {
                     className="inline-text"
                     text={t('address.phone.number')}
                     href={`tel:${t('address.phone.number')}`}
-                    aria-label={t('accessibility.ophPhone')}
                   />
                 </div>
               </div>

--- a/frontend/packages/vkt/src/components/publicExamEvent/listing/PublicExamEventListing.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/listing/PublicExamEventListing.tsx
@@ -1,12 +1,7 @@
 import { SelectChangeEvent } from '@mui/material';
 import { Box } from '@mui/system';
 import { useEffect, useRef } from 'react';
-import {
-  CustomCircularProgress,
-  H2,
-  H3,
-  PaginatedTable,
-} from 'shared/components';
+import { CustomCircularProgress, H2, PaginatedTable } from 'shared/components';
 import { APIResponseStatus, Color } from 'shared/enums';
 import { useWindowProperties } from 'shared/hooks';
 
@@ -70,7 +65,7 @@ export const PublicExamEventListing = ({
           justifyContent="center"
           alignItems="center"
         >
-          <H3>{translateCommon('errors.loadingFailed')}</H3>
+          <H2>{translateCommon('errors.loadingFailed')}</H2>
         </Box>
       );
     case APIResponseStatus.Success:

--- a/frontend/packages/vkt/src/tests/jest/components/layouts/__snapshots__/Footer.test.tsx.snap
+++ b/frontend/packages/vkt/src/tests/jest/components/layouts/__snapshots__/Footer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Footer should render Footer correctly 1`] = `
 <footer>
   <img
-    alt="accessibility.waveAriaLabel"
+    alt=""
     className="footer__wave"
     src="test"
   />
@@ -109,7 +109,7 @@ exports[`Footer should render Footer correctly 1`] = `
           className="footer__container__links__contact"
         >
           <h2
-            className="MuiTypography-root MuiTypography-h2 heading-text css-1sra7t5-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-h3 css-gepadz-MuiTypography-root"
           >
             links.contact.title
             :
@@ -141,7 +141,7 @@ exports[`Footer should render Footer correctly 1`] = `
         className="footer__container footer__container__contact-details"
       >
         <h2
-          className="MuiTypography-root MuiTypography-h2 heading-text css-1sra7t5-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-h3 css-gepadz-MuiTypography-root"
         >
           address.name
         </h2>
@@ -166,7 +166,6 @@ exports[`Footer should render Footer correctly 1`] = `
             address.phone.title
           </p>
           <a
-            aria-label="accessibility.ophPhone"
             className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit inline-text css-1y942vo-MuiButtonBase-root-MuiButton-root"
             href="tel:address.phone.number"
             onBlur={[Function]}

--- a/frontend/packages/yki/package.json
+++ b/frontend/packages/yki/package.json
@@ -26,7 +26,7 @@
     "yki:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.0"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.3"
   },
   "devDependencies": {
     "multer": "^1.4.5-lts.1"

--- a/frontend/packages/yki/public/i18n/en-GB/common.json
+++ b/frontend/packages/yki/public/i18n/en-GB/common.json
@@ -1,6 +1,7 @@
 {
   "yki": {
     "common": {
+      "actions": "Actions",
       "appTitle": "National Certificates of Language Proficiency (YKI) | Finnish National Agency for Education",
       "contactEmail": "kielitutkinnot@oph.fi",
       "dates": {

--- a/frontend/packages/yki/public/i18n/fi-FI/common.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/common.json
@@ -1,6 +1,7 @@
 {
   "yki": {
     "common": {
+      "actions": "Toiminnot",
       "appTitle": "Yleiset kielitutkinnot | Opetushallitus",
       "back": "Takaisin",
       "buttons": {

--- a/frontend/packages/yki/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/public.json
@@ -50,10 +50,6 @@
         }
       },
       "footer": {
-        "accessibility": {
-          "ophPhone": "Opetushallituksen puhelinnumero",
-          "waveAriaLabel": "Aaltoileva vektorikuvio"
-        },
         "address": {
           "name": "Opetushallitus",
           "phone": {

--- a/frontend/packages/yki/public/i18n/sv-SE/common.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/common.json
@@ -1,6 +1,7 @@
 {
   "yki": {
     "common": {
+      "actions": "Funktioner",
       "appTitle": "Allmänna språkexamina | Utbildningsstyrelsen",
       "contactEmail": "kielitutkinnot@oph.fi",
       "dates": {

--- a/frontend/packages/yki/src/components/layouts/Footer.tsx
+++ b/frontend/packages/yki/src/components/layouts/Footer.tsx
@@ -24,11 +24,7 @@ export const Footer = () => {
 
   return (
     <footer>
-      <Svg
-        className="footer__wave"
-        src={FooterWave}
-        alt={t('accessibility.waveAriaLabel')}
-      />
+      <Svg className="footer__wave" src={FooterWave} alt="" />
       <Paper className="footer" elevation={3}>
         <div className="footer__info-row">
           <div className="footer__container footer__container__links">
@@ -71,7 +67,6 @@ export const Footer = () => {
                 className="inline-text"
                 text={t('address.phone.number')}
                 href={`tel:${t('address.phone.number')}`}
-                aria-label={t('accessibility.ophPhone')}
               />
             </div>
           </div>

--- a/frontend/packages/yki/src/components/reassessment/PublicEvaluationPeriodListing.tsx
+++ b/frontend/packages/yki/src/components/reassessment/PublicEvaluationPeriodListing.tsx
@@ -1,4 +1,4 @@
-import { H3, NormalTable } from 'shared/components';
+import { H2, NormalTable } from 'shared/components';
 
 import { PublicEvaluationPeriodListingHeader } from 'components/reassessment/PublicEvaluationPeriodListingHeader';
 import { PublicEvaluationPeriodListingRow } from 'components/reassessment/PublicEvaluationPeriodListingRow';
@@ -22,7 +22,7 @@ export const PublicEvaluationPeriodListing = () => {
 
   return (
     <>
-      <H3>{t('heading')}</H3>
+      <H2>{t('heading')}</H2>
       <NormalTable
         className=""
         header={<PublicEvaluationPeriodListingHeader />}

--- a/frontend/packages/yki/src/components/reassessment/PublicEvaluationPeriodListingHeader.tsx
+++ b/frontend/packages/yki/src/components/reassessment/PublicEvaluationPeriodListingHeader.tsx
@@ -8,7 +8,7 @@ export const PublicEvaluationPeriodListingHeader = () => {
   });
 
   return (
-    <TableHead>
+    <TableHead className="heading-text">
       <TableRow>
         <TableCell>{t('examination')}</TableCell>
         <TableCell>{t('examDate')} </TableCell>

--- a/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingHeader.tsx
+++ b/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingHeader.tsx
@@ -1,5 +1,4 @@
 import { TableCell, TableHead, TableRow } from '@mui/material';
-import { H3 } from 'shared/components';
 import { useWindowProperties } from 'shared/hooks';
 
 import { useCommonTranslation } from 'configs/i18n';
@@ -10,28 +9,16 @@ export const PublicExamSessionListingHeader = () => {
 
   // TODO Handle case where isPhone is true
   return (
-    <TableHead>
+    <TableHead className="heading-text">
       {!isPhone && (
         <TableRow>
-          <TableCell>
-            <H3>{translateCommon('examSession')}</H3>
-          </TableCell>
-          <TableCell>
-            <H3>{translateCommon('date')}</H3>
-          </TableCell>
-          <TableCell>
-            <H3>{translateCommon('institution')}</H3>
-          </TableCell>
-          <TableCell>
-            <H3>{translateCommon('registrationPeriod')}</H3>
-          </TableCell>
-          <TableCell>
-            <H3>{translateCommon('price')}</H3>
-          </TableCell>
-          <TableCell>
-            <H3>{translateCommon('placesAvailable')}</H3>
-          </TableCell>
-          <TableCell />
+          <TableCell>{translateCommon('examSession')}</TableCell>
+          <TableCell>{translateCommon('date')}</TableCell>
+          <TableCell>{translateCommon('institution')}</TableCell>
+          <TableCell>{translateCommon('registrationPeriod')}</TableCell>
+          <TableCell>{translateCommon('price')}</TableCell>
+          <TableCell>{translateCommon('placesAvailable')}</TableCell>
+          <TableCell>{translateCommon('actions')}</TableCell>
         </TableRow>
       )}
     </TableHead>

--- a/frontend/packages/yki/src/components/skeletons/PublicEvaluationPeriodListingSkeleton.tsx
+++ b/frontend/packages/yki/src/components/skeletons/PublicEvaluationPeriodListingSkeleton.tsx
@@ -1,5 +1,5 @@
 import { TableCell, TableRow } from '@mui/material';
-import { CustomSkeleton, H3, NormalTable } from 'shared/components';
+import { CustomSkeleton, H2, NormalTable } from 'shared/components';
 import { SkeletonVariant } from 'shared/enums';
 
 import { PublicEvaluationPeriodListingHeader } from 'components/reassessment/PublicEvaluationPeriodListingHeader';
@@ -27,7 +27,7 @@ export const PublicEvaluationPeriodListingSkeleton = () => {
         className="full-max-width"
         variant={SkeletonVariant.Text}
       >
-        <H3>{t('heading')}</H3>
+        <H2>{t('heading')}</H2>
       </CustomSkeleton>
       <CustomSkeleton
         ariaLabel={translateCommon('loadingContent')}


### PR DESCRIPTION
## Yhteenveto

Korjattu otsikkotasojen etenemistä AKR:ssä, OTR:ssä ja VKT:ssä virkailijan käyttöliittymissä. Koskettu myös hieman heading-text:ien käyttöön liittyvään toteutukseen kun havaittu, että yki-ui:ssa toteutettu `label` elementit Typographya käyttäen joka sopi myös kätevästi muotoilemaan H2-elementtejä H3:n kokoisiksio.

Elementit jotka tulisi olla labeleina tai legend:ejä jätetty tässä huomioimatta.

## Check-lista

- [ ] yarn.lock päivitetty
- [x] sharepoint käännösexcelit päivitetty
