### PR TITLE
AKR:VKT:SHARED(Frontend): OPHAKRKEH-502 yhteydenottopyynnön ja ilmoittautumisen saavutettavuus- ja käytettävyysparannukset

### DIFF
--- a/backend/akr/src/main/resources/email-templates/contact-request-requester.html
+++ b/backend/akr/src/main/resources/email-templates/contact-request-requester.html
@@ -93,7 +93,7 @@
         <br/>
 
         <p>
-            Please, don't reply this message - it is generated automatically.
+            Please, don't reply to this message - it is generated automatically.
         </p>
         <p>
             Kind regards<br/>

--- a/frontend/packages/akr/package.json
+++ b/frontend/packages/akr/package.json
@@ -22,6 +22,6 @@
     "akr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.3"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.4"
   }
 }

--- a/frontend/packages/akr/public/i18n/en-GB/common.json
+++ b/frontend/packages/akr/public/i18n/en-GB/common.json
@@ -1,7 +1,7 @@
 {
   "akr": {
     "common": {
-      "acceptTerms": null,
+      "acceptTerms": "Accept conditions",
       "akrLogoAlt": "Logo: Authorised translator’s examination system.",
       "appNameAbbreviation": "AKR",
       "appTitle": "Register of authorised translators | Finnish National Agency for Education",

--- a/frontend/packages/akr/public/i18n/en-GB/common.json
+++ b/frontend/packages/akr/public/i18n/en-GB/common.json
@@ -26,6 +26,7 @@
       "ophLogoToFrontPageAlt": "Finnish National Agency for Education – To front page of register of authorised translators.",
       "phase": "Stage",
       "register": "Register",
+      "requiredFieldsInfo": "Fields marked with a star (*) are mandatory.",
       "save": "Save",
       "send": "Send",
       "yes": "Yes"

--- a/frontend/packages/akr/public/i18n/en-GB/common.json
+++ b/frontend/packages/akr/public/i18n/en-GB/common.json
@@ -1,6 +1,7 @@
 {
   "akr": {
     "common": {
+      "acceptTerms": null,
       "akrLogoAlt": "Logo: Authorised translator’s examination system.",
       "appNameAbbreviation": "AKR",
       "appTitle": "Register of authorised translators | Finnish National Agency for Education",

--- a/frontend/packages/akr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/akr/public/i18n/en-GB/translation.json
@@ -139,7 +139,7 @@
           "title": "Cancel contact request"
         },
         "characters": "characters",
-        "chosenTranslatorsForLanguagePair": "The translators selected from the language pair",
+        "chosenTranslatorsForLanguagePair": "The translators chosen from the language pair",
         "description": "You can use this contact request form to leave a contact request to the authorised translators you have selected. Please write a description of the required translation in as much detail as possible to your message.",
         "doneStep": {
           "description": "This page will automatically redirect you back to the home page. If nothing happens, click the button below.",
@@ -442,7 +442,7 @@
         "noSearchResults": "No search results",
         "note": "When searching by language pair, the possible search options are from the languages of Finland (Finnish, Swedish and Sámi languages) into foreign languages or vice versa, and between the languages of Finland. To ensure equal visibility, the translators are randomly reordered once a day within the search engine.",
         "requestContact": "Contact",
-        "requestContactAriaLabel": null,
+        "requestContactAriaLabel": "Contact chosen translators from listing.",
         "title": "Register of Authorised Translators"
       },
       "meetingDatesPage": {

--- a/frontend/packages/akr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/akr/public/i18n/en-GB/translation.json
@@ -442,6 +442,7 @@
         "noSearchResults": "No search results",
         "note": "When searching by language pair, the possible search options are from the languages of Finland (Finnish, Swedish and Sámi languages) into foreign languages or vice versa, and between the languages of Finland. To ensure equal visibility, the translators are randomly reordered once a day within the search engine.",
         "requestContact": "Contact",
+        "requestContactAriaLabel": null,
         "title": "Register of Authorised Translators"
       },
       "meetingDatesPage": {

--- a/frontend/packages/akr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/akr/public/i18n/en-GB/translation.json
@@ -442,7 +442,7 @@
         "noSearchResults": "No search results",
         "note": "When searching by language pair, the possible search options are from the languages of Finland (Finnish, Swedish and Sámi languages) into foreign languages or vice versa, and between the languages of Finland. To ensure equal visibility, the translators are randomly reordered once a day within the search engine.",
         "requestContact": "Contact",
-        "requestContactAriaLabel": "Contact chosen translators from listing.",
+        "requestContactAriaLabel": "Contact chosen translators from the following table.",
         "title": "Register of Authorised Translators"
       },
       "meetingDatesPage": {

--- a/frontend/packages/akr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/akr/public/i18n/en-GB/translation.json
@@ -164,7 +164,7 @@
         },
         "privacyStatement": {
           "ariaLabel": "Privacy policy",
-          "label": "I have read the <0></0> of this service and accept it.",
+          "label": "I have read the <0></0> of this service and accept it (mandatory).",
           "linkLabel": "privacy policy statement"
         },
         "recipients": "Recipients",

--- a/frontend/packages/akr/public/i18n/en-GB/translation.json
+++ b/frontend/packages/akr/public/i18n/en-GB/translation.json
@@ -139,7 +139,7 @@
           "title": "Cancel contact request"
         },
         "characters": "characters",
-        "chosenTranslatorsForLanguagePair": "The translators you have selected from the language pair",
+        "chosenTranslatorsForLanguagePair": "The translators selected from the language pair",
         "description": "You can use this contact request form to leave a contact request to the authorised translators you have selected. Please write a description of the required translation in as much detail as possible to your message.",
         "doneStep": {
           "description": "This page will automatically redirect you back to the home page. If nothing happens, click the button below.",
@@ -159,11 +159,15 @@
           "phoneNumber": "Telephone number",
           "writeMessageHere": "Message"
         },
+        "previewAndSend": {
+          "yourMessage": "Your message"
+        },
         "privacyStatement": {
           "ariaLabel": "Privacy policy",
           "label": "I have read the <0></0> of this service and accept it.",
           "linkLabel": "privacy policy statement"
         },
+        "recipients": "Recipients",
         "steps": {
           "active": "Active",
           "completed": "Completed",
@@ -178,6 +182,11 @@
           "accessibility": {
             "deselectTranslator": "Delete the translator"
           }
+        },
+        "writeMessage": {
+          "mandatory": "mandatory",
+          "message": "Message",
+          "title": "Write your message"
         }
       },
       "examinationDatesListing": {

--- a/frontend/packages/akr/public/i18n/fi-FI/common.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/common.json
@@ -1,6 +1,7 @@
 {
   "akr": {
     "common": {
+      "acceptTerms": "Hyväksy ehdot",
       "akrLogoAlt": "Logo: Auktorisoidun kääntäjän tutkintojärjestelmä.",
       "appNameAbbreviation": "AKR",
       "appTitle": "Auktorisoitujen kääntäjien rekisteri | Opetushallitus",

--- a/frontend/packages/akr/public/i18n/fi-FI/common.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/common.json
@@ -26,6 +26,7 @@
       "ophLogoToFrontPageAlt": "Opetushallitus/Utbildningsstyrelsen – Auktorisoitujen kääntäjien rekisterin etusivulle.",
       "phase": "Vaihe",
       "register": "Rekisteri",
+      "requiredFieldsInfo": "Tähdellä (*) merkityt kentät ovat pakollisia.",
       "save": "Tallenna",
       "send": "Lähetä",
       "statistics": "Tilastot",

--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -147,7 +147,7 @@
           "title": "Peruuta yhteydenottopyyntö"
         },
         "characters": "merkkiä",
-        "chosenTranslatorsForLanguagePair": "Valitsemasi kääntäjät kieliparista",
+        "chosenTranslatorsForLanguagePair": "Valitut kääntäjät kieliparista",
         "description": "Tällä yhteydenottolomakkeella voit jättää valitsemillesi auktorisoiduille kääntäjille yhteydenottopyynnön. Kirjoitathan viestiin mahdollisimman tarkan kuvauksen tarvittavasta käännöstyöstä.",
         "doneStep": {
           "description": "Tämä sivu ohjaa sinut automaattisesti takaisin etusivulle. Jos mitään ei tapahdu voit klikata alla olevasta napista.",
@@ -160,18 +160,22 @@
         },
         "formLabels": {
           "contactInfo": "Yhteystietosi",
-          "email": "Sähköpostiosoite",
+          "email": "Sähköposti",
           "firstName": "Etunimi",
           "lastName": "Sukunimi",
           "message": "Viesti",
           "phoneNumber": "Puhelinnumero",
           "writeMessageHere": "Viesti"
         },
+        "previewAndSend": {
+          "yourMessage": "Viestisi"
+        },
         "privacyStatement": {
           "ariaLabel": "Tietosuojaseloste",
           "label": "Olen lukenut tämän palvelun <0></0> ja hyväksyn sen.",
           "linkLabel": "tietosuojaselosteen"
         },
+        "recipients": "Vastaanottajat",
         "steps": {
           "active": "Aktiivinen",
           "completed": "Suoritettu",
@@ -186,6 +190,11 @@
           "accessibility": {
             "deselectTranslator": "Poista kääntäjä"
           }
+        },
+        "writeMessage": {
+          "mandatory": "pakollinen",
+          "message": "Viesti",
+          "title": "Kirjoita viestisi"
         }
       },
       "examinationDatesListing": {

--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -172,7 +172,7 @@
         },
         "privacyStatement": {
           "ariaLabel": "Tietosuojaseloste",
-          "label": "Olen lukenut tämän palvelun <0></0> ja hyväksyn sen.",
+          "label": "Olen lukenut tämän palvelun <0></0> ja hyväksyn sen (pakollinen).",
           "linkLabel": "tietosuojaselosteen"
         },
         "recipients": "Vastaanottajat",

--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -451,6 +451,7 @@
         "noSearchResults": "Ei hakutuloksia",
         "note": "Kieliparilla haettaessa mahdolliset hakuvaihtoehdot ovat kotimaisista kielistä (suomi, ruotsi, saamen kielet) vieraisiin kieliin tai toisinpäin sekä kotimaisten kielten välillä. Yhdenvertaisen näkyvyyden turvaamiseksi kääntäjät arvotaan hakukoneessa satunnaisjärjestykseen kerran vuorokaudessa.",
         "requestContact": "Ota yhteyttä",
+        "requestContactAriaLabel": "Ota yhteyttä seuraavasta taulukosta valitsemiisi henkilöihin.",
         "title": "Auktorisoitujen kääntäjien rekisteri"
       },
       "meetingDatesPage": {

--- a/frontend/packages/akr/public/i18n/sv-SE/common.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/common.json
@@ -26,6 +26,7 @@
       "ophLogoToFrontPageAlt": "Opetushallitus/Utbildningsstyrelsen – Till framsidan av register över auktoriserade translatorer.",
       "phase": "Skede",
       "register": "Register",
+      "requiredFieldsInfo": "Fält markerade med en stjärna (*) är obligatoriska.",
       "save": "Spara",
       "send": "Sänd",
       "yes": "Ja"

--- a/frontend/packages/akr/public/i18n/sv-SE/common.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/common.json
@@ -1,7 +1,7 @@
 {
   "akr": {
     "common": {
-      "acceptTerms": null,
+      "acceptTerms": "Acceptera villkoren",
       "akrLogoAlt": "Logo: Examenssystemet för auktoriserade translatorer.",
       "appNameAbbreviation": "AKR",
       "appTitle": "Register över auktoriserade translatorer | Utbildningsstyrelsen",

--- a/frontend/packages/akr/public/i18n/sv-SE/common.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/common.json
@@ -1,6 +1,7 @@
 {
   "akr": {
     "common": {
+      "acceptTerms": null,
       "akrLogoAlt": "Logo: Examenssystemet för auktoriserade translatorer.",
       "appNameAbbreviation": "AKR",
       "appTitle": "Register över auktoriserade translatorer | Utbildningsstyrelsen",

--- a/frontend/packages/akr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/translation.json
@@ -442,6 +442,7 @@
         "noSearchResults": "Inga sökresultat",
         "note": "När du söker med språkpar är de möjliga sökalternativen från inhemska språk (finska, svenska, samiska) till främmande språk eller tvärtom samt mellan inhemska språk. För att säkerställa likvärdig synlighet lottas translatorerna i slumpmässig ordning i sökmotorn en gång om dagen.",
         "requestContact": "Kontakta",
+        "requestContactAriaLabel": null,
         "title": "Register över auktoriserade translatorer"
       },
       "meetingDatesPage": {

--- a/frontend/packages/akr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/translation.json
@@ -139,7 +139,7 @@
           "title": "Avbryt kontaktförfrågan"
         },
         "characters": "tecken",
-        "chosenTranslatorsForLanguagePair": "Translatorerna du valt med språkparet",
+        "chosenTranslatorsForLanguagePair": "Translatorerna valt med språkparet",
         "description": "Med denna blankett kan du lämna en kontaktförfrågan till vald auktoriserad translator. Skriv en så noggrann beskrivning som möjligt av översättningsarbetet i meddelandet.",
         "doneStep": {
           "description": "Denna sida leder dig automatiskt tillbaka till framsidan. Om ingenting händer kan du klicka på knappen ovan.",
@@ -152,18 +152,22 @@
         },
         "formLabels": {
           "contactInfo": "Dina kontaktuppgifter",
-          "email": "E-postadress",
+          "email": "E-post",
           "firstName": "Förnamn",
           "lastName": "Efternamn",
           "message": "Meddelande",
           "phoneNumber": "Telefonnummer",
           "writeMessageHere": "Meddelande"
         },
+        "previewAndSend": {
+          "yourMessage": "Ditt meddelande"
+        },
         "privacyStatement": {
           "ariaLabel": "Dataskyddsbeskrivning",
           "label": "Jag har läst <0></0> av den här tjänsten och accepterar den.",
           "linkLabel": "dataskyddsbeskrivningen"
         },
+        "recipients": "Mottagare",
         "steps": {
           "active": "Aktiv",
           "completed": "Utfört",
@@ -178,6 +182,11 @@
           "accessibility": {
             "deselectTranslator": "Ta bort translator"
           }
+        },
+        "writeMessage": {
+          "mandatory": "obligatorisk",
+          "message": "Meddelande",
+          "title": "Skriv ditt meddelande"
         }
       },
       "examinationDatesListing": {

--- a/frontend/packages/akr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/translation.json
@@ -164,7 +164,7 @@
         },
         "privacyStatement": {
           "ariaLabel": "Dataskyddsbeskrivning",
-          "label": "Jag har läst <0></0> av den här tjänsten och accepterar den.",
+          "label": "Jag har läst <0></0> av den här tjänsten och accepterar den (obligatorisk).",
           "linkLabel": "dataskyddsbeskrivningen"
         },
         "recipients": "Mottagare",

--- a/frontend/packages/akr/public/i18n/sv-SE/translation.json
+++ b/frontend/packages/akr/public/i18n/sv-SE/translation.json
@@ -139,7 +139,7 @@
           "title": "Avbryt kontaktförfrågan"
         },
         "characters": "tecken",
-        "chosenTranslatorsForLanguagePair": "Translatorerna valt med språkparet",
+        "chosenTranslatorsForLanguagePair": "Valda translatorer i språkparet",
         "description": "Med denna blankett kan du lämna en kontaktförfrågan till vald auktoriserad translator. Skriv en så noggrann beskrivning som möjligt av översättningsarbetet i meddelandet.",
         "doneStep": {
           "description": "Denna sida leder dig automatiskt tillbaka till framsidan. Om ingenting händer kan du klicka på knappen ovan.",
@@ -164,7 +164,7 @@
         },
         "privacyStatement": {
           "ariaLabel": "Dataskyddsbeskrivning",
-          "label": "Jag har läst <0></0> av den här tjänsten och accepterar den (obligatorisk).",
+          "label": "Jag har läst <0></0> av den här tjänsten och accepterar den (obligatoriskt).",
           "linkLabel": "dataskyddsbeskrivningen"
         },
         "recipients": "Mottagare",
@@ -184,7 +184,7 @@
           }
         },
         "writeMessage": {
-          "mandatory": "obligatorisk",
+          "mandatory": "obligatoriskt",
           "message": "Meddelande",
           "title": "Skriv ditt meddelande"
         }
@@ -442,7 +442,7 @@
         "noSearchResults": "Inga sökresultat",
         "note": "När du söker med språkpar är de möjliga sökalternativen från inhemska språk (finska, svenska, samiska) till främmande språk eller tvärtom samt mellan inhemska språk. För att säkerställa likvärdig synlighet lottas translatorerna i slumpmässig ordning i sökmotorn en gång om dagen.",
         "requestContact": "Kontakta",
-        "requestContactAriaLabel": null,
+        "requestContactAriaLabel": "Kontakta valda translatorer i tabellen.",
         "title": "Register över auktoriserade translatorer"
       },
       "meetingDatesPage": {

--- a/frontend/packages/akr/src/components/contactRequest/steps/FillContactDetails.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/FillContactDetails.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 import { CustomTextField, Text } from 'shared/components';
-import { TextFieldTypes } from 'shared/enums';
+import { InputAutoComplete, TextFieldTypes } from 'shared/enums';
 import { InputFieldUtils, StringUtils } from 'shared/utils';
 
 import { StepHeading } from 'components/contactRequest/ContactRequestFormUtils';
@@ -10,13 +10,6 @@ import { ContactRequestFormStep } from 'enums/contactRequest';
 import { ContactDetails } from 'interfaces/contactRequest';
 import { updateContactRequest } from 'redux/reducers/contactRequest';
 import { contactRequestSelector } from 'redux/selectors/contactRequest';
-
-enum InputAutoComplete {
-  FirstName = 'given-name',
-  LastName = 'family-name',
-  Email = 'email',
-  PhoneNumber = 'tel',
-}
 
 export const FillContactDetails = ({
   disableNext,

--- a/frontend/packages/akr/src/components/contactRequest/steps/FillContactDetails.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/FillContactDetails.tsx
@@ -11,6 +11,13 @@ import { ContactDetails } from 'interfaces/contactRequest';
 import { updateContactRequest } from 'redux/reducers/contactRequest';
 import { contactRequestSelector } from 'redux/selectors/contactRequest';
 
+enum InputAutoComplete {
+  FirstName = 'given-name',
+  LastName = 'family-name',
+  Email = 'email',
+  PhoneNumber = 'tel',
+}
+
 export const FillContactDetails = ({
   disableNext,
   onDataChanged,
@@ -109,12 +116,14 @@ export const FillContactDetails = ({
             value={request?.firstName}
             type={TextFieldTypes.Text}
             required
+            autoComplete={InputAutoComplete.FirstName}
           />
           <CustomTextField
             {...getCustomTextFieldAttributes('lastName')}
             type={TextFieldTypes.Text}
             value={request?.lastName}
             required
+            autoComplete={InputAutoComplete.LastName}
           />
         </div>
         <div className="grid-columns gapped">
@@ -123,11 +132,13 @@ export const FillContactDetails = ({
             type={TextFieldTypes.Email}
             value={request?.email}
             required
+            autoComplete={InputAutoComplete.Email}
           />
           <CustomTextField
             {...getCustomTextFieldAttributes('phoneNumber')}
             value={request?.phoneNumber}
             type={TextFieldTypes.PhoneNumber}
+            autoComplete={InputAutoComplete.PhoneNumber}
           />
         </div>
       </div>

--- a/frontend/packages/akr/src/components/contactRequest/steps/FillContactDetails.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/FillContactDetails.tsx
@@ -1,14 +1,10 @@
 import { ChangeEvent, useEffect, useState } from 'react';
-import { CustomTextField, H3 } from 'shared/components';
+import { CustomTextField, Text } from 'shared/components';
 import { TextFieldTypes } from 'shared/enums';
 import { InputFieldUtils, StringUtils } from 'shared/utils';
 
-import {
-  ChosenTranslators,
-  ChosenTranslatorsHeading,
-  StepHeading,
-} from 'components/contactRequest/ContactRequestFormUtils';
-import { useAppTranslation } from 'configs/i18n';
+import { StepHeading } from 'components/contactRequest/ContactRequestFormUtils';
+import { useAppTranslation, useCommonTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { ContactRequestFormStep } from 'enums/contactRequest';
 import { ContactDetails } from 'interfaces/contactRequest';
@@ -26,6 +22,7 @@ export const FillContactDetails = ({
   const { t } = useAppTranslation({
     keyPrefix: 'akr',
   });
+  const translateCommon = useCommonTranslation();
 
   // State
   const [fieldErrors, setFieldErrors] = useState({
@@ -105,44 +102,33 @@ export const FillContactDetails = ({
     <div className="rows">
       <StepHeading step={ContactRequestFormStep.FillContactDetails} />
       <div className="rows gapped">
-        <ChosenTranslatorsHeading />
-        <ChosenTranslators />
-        <div className="rows gapped">
-          <H3>
-            {t(
-              'component.contactRequestForm.steps.' +
-                ContactRequestFormStep[
-                  ContactRequestFormStep.FillContactDetails
-                ]
-            )}
-          </H3>
-          <div className="grid-columns gapped">
-            <CustomTextField
-              {...getCustomTextFieldAttributes('firstName')}
-              value={request?.firstName}
-              type={TextFieldTypes.Text}
-              required
-            />
-            <CustomTextField
-              {...getCustomTextFieldAttributes('lastName')}
-              type={TextFieldTypes.Text}
-              value={request?.lastName}
-              required
-            />
-          </div>
-          <div className="grid-columns gapped">
-            <CustomTextField
-              {...getCustomTextFieldAttributes('email')}
-              type={TextFieldTypes.Email}
-              value={request?.email}
-              required
-            />
-            <CustomTextField
-              {...getCustomTextFieldAttributes('phoneNumber')}
-              value={request?.phoneNumber}
-              type={TextFieldTypes.PhoneNumber}
-            />
-          </div>
+        <Text>{translateCommon('requiredFieldsInfo')}</Text>
+        <div className="grid-columns gapped">
+          <CustomTextField
+            {...getCustomTextFieldAttributes('firstName')}
+            value={request?.firstName}
+            type={TextFieldTypes.Text}
+            required
+          />
+          <CustomTextField
+            {...getCustomTextFieldAttributes('lastName')}
+            type={TextFieldTypes.Text}
+            value={request?.lastName}
+            required
+          />
+        </div>
+        <div className="grid-columns gapped">
+          <CustomTextField
+            {...getCustomTextFieldAttributes('email')}
+            type={TextFieldTypes.Email}
+            value={request?.email}
+            required
+          />
+          <CustomTextField
+            {...getCustomTextFieldAttributes('phoneNumber')}
+            value={request?.phoneNumber}
+            type={TextFieldTypes.PhoneNumber}
+          />
         </div>
       </div>
     </div>

--- a/frontend/packages/akr/src/components/contactRequest/steps/PreviewAndSend.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/PreviewAndSend.tsx
@@ -69,7 +69,9 @@ export const PreviewAndSend = ({
         <DisplayContactInfo />
         <div className="rows gapped-xs">
           <H2>{t('yourMessage')}</H2>
-          <Text>{request?.message}</Text>
+          <Text className="contact-request-page__grid__preview-and-send__message">
+            {request?.message}
+          </Text>
         </div>
         <div className="rows gapped-xs">
           <H2>{translateCommon('acceptTerms')}</H2>

--- a/frontend/packages/akr/src/components/contactRequest/steps/PreviewAndSend.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/PreviewAndSend.tsx
@@ -2,9 +2,8 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Checkbox, FormControlLabel } from '@mui/material';
 import { useEffect } from 'react';
 import { Trans } from 'react-i18next';
-import { CustomTextField, ExtLink, H3 } from 'shared/components';
+import { ExtLink, H2, Text } from 'shared/components';
 import { Color } from 'shared/enums';
-import { InputFieldUtils } from 'shared/utils';
 
 import {
   ChosenTranslators,
@@ -43,7 +42,7 @@ export const PreviewAndSend = ({
   disableNext: (disabled: boolean) => void;
 }) => {
   const { t } = useAppTranslation({
-    keyPrefix: 'akr.component.contactRequestForm',
+    keyPrefix: 'akr.component.contactRequestForm.previewAndSend',
   });
 
   // Redux
@@ -58,32 +57,19 @@ export const PreviewAndSend = ({
     dispatch(updateContactRequest({ confirmation: !request?.confirmation }));
   };
 
-  const getMessageHelperText = () => {
-    return `${request?.message?.length} / ${
-      InputFieldUtils.defaultMaxTextAreaLength
-    } ${t('characters')}`;
-  };
-
   return (
     <div className="rows">
       <StepHeading step={ContactRequestFormStep.PreviewAndSend} />
       <div className="rows gapped">
-        <ChosenTranslatorsHeading />
-        <ChosenTranslators />
+        <div className="rows gapped-xs">
+          <ChosenTranslatorsHeading />
+          <ChosenTranslators />
+        </div>
         <DisplayContactInfo />
-        <H3>{t('formLabels.message')}</H3>
-        <CustomTextField
-          disabled
-          data-testid="contact-request-page__message-text"
-          defaultValue={request?.message}
-          InputProps={{
-            readOnly: true,
-          }}
-          showHelperText
-          helperText={getMessageHelperText()}
-          multiline
-          fullWidth
-        />
+        <div className="rows gapped-xxs">
+          <H2>{t('yourMessage')}</H2>
+          <Text>{request?.message}</Text>
+        </div>
         <FormControlLabel
           control={
             <Checkbox

--- a/frontend/packages/akr/src/components/contactRequest/steps/PreviewAndSend.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/PreviewAndSend.tsx
@@ -11,7 +11,7 @@ import {
   DisplayContactInfo,
   StepHeading,
 } from 'components/contactRequest/ContactRequestFormUtils';
-import { useAppTranslation } from 'configs/i18n';
+import { useAppTranslation, useCommonTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
 import { ContactRequestFormStep } from 'enums/contactRequest';
@@ -44,6 +44,7 @@ export const PreviewAndSend = ({
   const { t } = useAppTranslation({
     keyPrefix: 'akr.component.contactRequestForm.previewAndSend',
   });
+  const translateCommon = useCommonTranslation();
 
   // Redux
   const { request } = useAppSelector(contactRequestSelector);
@@ -60,28 +61,31 @@ export const PreviewAndSend = ({
   return (
     <div className="rows">
       <StepHeading step={ContactRequestFormStep.PreviewAndSend} />
-      <div className="rows gapped">
+      <div className="rows gapped-xxl">
         <div className="rows gapped-xs">
           <ChosenTranslatorsHeading />
           <ChosenTranslators />
         </div>
         <DisplayContactInfo />
-        <div className="rows gapped-xxs">
+        <div className="rows gapped-xs">
           <H2>{t('yourMessage')}</H2>
           <Text>{request?.message}</Text>
         </div>
-        <FormControlLabel
-          control={
-            <Checkbox
-              onClick={handleCheckboxClick}
-              color={Color.Secondary}
-              data-testid="contact-request-page__privacy-statement-checkbox"
-              checked={request?.confirmation}
-            />
-          }
-          label={<PrivacyStatementCheckboxLabel />}
-          className="contact-request-page__grid__privacy-statement-checkbox-label"
-        />
+        <div className="rows gapped-xs">
+          <H2>{translateCommon('acceptTerms')}</H2>
+          <FormControlLabel
+            control={
+              <Checkbox
+                onClick={handleCheckboxClick}
+                color={Color.Secondary}
+                data-testid="contact-request-page__privacy-statement-checkbox"
+                checked={request?.confirmation}
+              />
+            }
+            label={<PrivacyStatementCheckboxLabel />}
+            className="contact-request-page__grid__privacy-statement-checkbox-label"
+          />
+        </div>
       </div>
     </div>
   );

--- a/frontend/packages/akr/src/components/contactRequest/steps/VerifySelectedTranslators.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/VerifySelectedTranslators.tsx
@@ -1,32 +1,62 @@
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import { IconButton } from '@mui/material';
 import { useEffect } from 'react';
-import { Text } from 'shared/components';
-import { Color } from 'shared/enums';
+import { CustomButton, Text } from 'shared/components';
+import { Color, Variant } from 'shared/enums';
 
 import {
   ChosenTranslatorsHeading,
   StepHeading,
 } from 'components/contactRequest/ContactRequestFormUtils';
-import { useAppTranslation } from 'configs/i18n';
+import { useAppTranslation, useCommonTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { ContactRequestFormStep } from 'enums/contactRequest';
 import { deselectPublicTranslator } from 'redux/reducers/publicTranslator';
 import { selectedPublicTranslatorsForLanguagePair } from 'redux/selectors/publicTranslator';
+
+const TranslatorRow = ({
+  id,
+  firstName,
+  lastName,
+}: {
+  id: number;
+  firstName: string;
+  lastName: string;
+}) => {
+  const { t } = useAppTranslation({
+    keyPrefix: 'akr.component.contactRequestForm.verifySelectedTranslatorsStep',
+  });
+  const translateCommon = useCommonTranslation();
+
+  const dispatch = useAppDispatch();
+
+  const deselectTranslator = () => dispatch(deselectPublicTranslator(id));
+
+  const deselectButtonAriaLabel =
+    t('accessibility.deselectTranslator') + ': ' + firstName + ' ' + lastName;
+
+  return (
+    <div className="columns gapped">
+      <Text>
+        {firstName} {lastName}
+      </Text>
+      <CustomButton
+        data-testid={`contact-request-page__deselect-translator-id-${id}-btn`}
+        variant={Variant.Outlined}
+        onClick={deselectTranslator}
+        color={Color.Secondary}
+        aria-label={deselectButtonAriaLabel}
+      >
+        {translateCommon('delete')}
+      </CustomButton>
+    </div>
+  );
+};
 
 export const VerifySelectedTranslators = ({
   disableNext,
 }: {
   disableNext: (disabled: boolean) => void;
 }) => {
-  const { t } = useAppTranslation({
-    keyPrefix: 'akr.component.contactRequestForm.verifySelectedTranslatorsStep',
-  });
   const translators = useAppSelector(selectedPublicTranslatorsForLanguagePair);
-  const dispatch = useAppDispatch();
-
-  const deselectTranslator = (id: number) =>
-    dispatch(deselectPublicTranslator(id));
 
   useEffect(
     () => disableNext(translators.length == 0),
@@ -38,33 +68,15 @@ export const VerifySelectedTranslators = ({
       <StepHeading step={ContactRequestFormStep.VerifyTranslators} />
       <div className="rows gapped">
         <ChosenTranslatorsHeading />
-        <div className="rows gapped-xxs">
-          {translators.map(({ id, firstName, lastName }) => {
-            const ariaLabel =
-              t('accessibility.deselectTranslator') +
-              ': ' +
-              firstName +
-              ' ' +
-              lastName;
-
-            return (
-              <div
-                className="columns"
-                key={id}
-                data-testid={`contact-request-page__chosen-translator-id-${id}`}
-              >
-                <Text>
-                  {firstName} {lastName}
-                </Text>
-                <IconButton
-                  aria-label={ariaLabel}
-                  onClick={() => deselectTranslator(id)}
-                >
-                  <DeleteOutlineIcon color={Color.Error} />
-                </IconButton>
-              </div>
-            );
-          })}
+        <div className="rows gapped-xs">
+          {translators.map(({ id, firstName, lastName }) => (
+            <TranslatorRow
+              key={id}
+              id={id}
+              firstName={firstName}
+              lastName={lastName}
+            />
+          ))}
         </div>
       </div>
     </div>

--- a/frontend/packages/akr/src/components/contactRequest/steps/VerifySelectedTranslators.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/VerifySelectedTranslators.tsx
@@ -38,32 +38,34 @@ export const VerifySelectedTranslators = ({
       <StepHeading step={ContactRequestFormStep.VerifyTranslators} />
       <div className="rows gapped">
         <ChosenTranslatorsHeading />
-        {translators.map(({ id, firstName, lastName }) => {
-          const ariaLabel =
-            t('accessibility.deselectTranslator') +
-            ': ' +
-            firstName +
-            ' ' +
-            lastName;
+        <div className="rows gapped-xxs">
+          {translators.map(({ id, firstName, lastName }) => {
+            const ariaLabel =
+              t('accessibility.deselectTranslator') +
+              ': ' +
+              firstName +
+              ' ' +
+              lastName;
 
-          return (
-            <div
-              className="columns"
-              key={id}
-              data-testid={`contact-request-page__chosen-translator-id-${id}`}
-            >
-              <Text>
-                {firstName} {lastName}
-              </Text>
-              <IconButton
-                aria-label={ariaLabel}
-                onClick={() => deselectTranslator(id)}
+            return (
+              <div
+                className="columns"
+                key={id}
+                data-testid={`contact-request-page__chosen-translator-id-${id}`}
               >
-                <DeleteOutlineIcon color={Color.Error} />
-              </IconButton>
-            </div>
-          );
-        })}
+                <Text>
+                  {firstName} {lastName}
+                </Text>
+                <IconButton
+                  aria-label={ariaLabel}
+                  onClick={() => deselectTranslator(id)}
+                >
+                  <DeleteOutlineIcon color={Color.Error} />
+                </IconButton>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/frontend/packages/akr/src/components/contactRequest/steps/WriteMessage.tsx
+++ b/frontend/packages/akr/src/components/contactRequest/steps/WriteMessage.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useEffect } from 'react';
-import { CustomTextField, H3 } from 'shared/components';
+import { CustomTextField, H2, Text } from 'shared/components';
 import { TextFieldTypes } from 'shared/enums';
 import { useWindowProperties } from 'shared/hooks';
 import { InputFieldUtils, StringUtils } from 'shared/utils';
@@ -7,7 +7,6 @@ import { InputFieldUtils, StringUtils } from 'shared/utils';
 import {
   ChosenTranslators,
   ChosenTranslatorsHeading,
-  DisplayContactInfo,
   StepHeading,
 } from 'components/contactRequest/ContactRequestFormUtils';
 import { translateOutsideComponent, useAppTranslation } from 'configs/i18n';
@@ -80,20 +79,20 @@ export const WriteMessage = ({
     <div className="rows">
       <StepHeading step={ContactRequestFormStep.WriteMessage} />
       <div className="rows gapped">
-        <ChosenTranslatorsHeading />
-        <ChosenTranslators />
-        {!isPhone && <DisplayContactInfo />}
-        <div className="rows gapped">
-          <H3>
-            {t(
-              `steps.${
-                ContactRequestFormStep[ContactRequestFormStep.WriteMessage]
-              }`
-            )}
-          </H3>
+        <div className="rows gapped-xs">
+          <ChosenTranslatorsHeading />
+          <ChosenTranslators />
+        </div>
+        <H2>{t('writeMessage.title')}</H2>
+        <div className="rows gapped-xxs">
+          <Text>
+            <span className="bold">{t('writeMessage.message')}</span>
+            {' ('}
+            {t('writeMessage.mandatory')}
+            {')'}
+          </Text>
           <CustomTextField
-            id="contact-request-page__message-field"
-            label={t('formLabels.writeMessageHere')}
+            data-testid="contact-request-page__message-field"
             value={request?.message}
             type={TextFieldTypes.Textarea}
             onChange={handleMessageFieldChange}

--- a/frontend/packages/akr/src/components/publicTranslator/listing/ContactRequestButton.tsx
+++ b/frontend/packages/akr/src/components/publicTranslator/listing/ContactRequestButton.tsx
@@ -25,6 +25,7 @@ export const ContactRequestButton = () => {
       onClick={handleButtonClick}
       disabled={selectedTranslators.length == 0}
       data-testid="public-translators__contact-request-btn"
+      aria-label={t('requestContactAriaLabel')}
     >
       {t('requestContact')}
     </CustomButton>

--- a/frontend/packages/akr/src/components/publicTranslator/listing/PublicTranslatorListingRow.tsx
+++ b/frontend/packages/akr/src/components/publicTranslator/listing/PublicTranslatorListingRow.tsx
@@ -1,5 +1,5 @@
-import { Checkbox, TableCell, TableRow } from '@mui/material';
-import { H2, H3, Text } from 'shared/components';
+import { Checkbox, TableCell, TableRow, Typography } from '@mui/material';
+import { Text } from 'shared/components';
 import { Color, Severity } from 'shared/enums';
 import { useToast, useWindowProperties } from 'shared/hooks';
 
@@ -93,11 +93,15 @@ export const PublicTranslatorListingRow = ({
   const renderPhoneTableCells = () => (
     <TableCell>
       <div className="rows gapped">
-        <H2>{`${lastName} ${firstName}`}</H2>
+        <Typography variant="h2" component="p">
+          {`${lastName} ${firstName}`}
+        </Typography>
         <div className="columns gapped space-between">
           <div className="rows gapped">
             <div>
-              <H3>{t('pages.translator.languagePairs')}</H3>
+              <Typography variant="h3" component="p">
+                {t('pages.translator.languagePairs')}
+              </Typography>
               <PublicTranslatorListingRowLanguagePairs
                 fromLang={fromLang}
                 toLang={toLang}
@@ -105,7 +109,9 @@ export const PublicTranslatorListingRow = ({
               />
             </div>
             <div>
-              <H3>{t('pages.translator.town')}</H3>
+              <Typography variant="h3" component="p">
+                {t('pages.translator.town')}
+              </Typography>
               <Text>{getTownDescription(town, country)}</Text>
             </div>
           </div>

--- a/frontend/packages/akr/src/styles/pages/_contact-request-page.scss
+++ b/frontend/packages/akr/src/styles/pages/_contact-request-page.scss
@@ -65,6 +65,10 @@
       max-width: 80%;
     }
 
+    &__preview-and-send__message {
+      white-space: pre-wrap;
+    }
+
     &__privacy-statement-checkbox-label {
       margin-right: 0;
 

--- a/frontend/packages/akr/src/tests/cypress/integration/contact-request/contact_request.spec.ts
+++ b/frontend/packages/akr/src/tests/cypress/integration/contact-request/contact_request.spec.ts
@@ -2,7 +2,6 @@ import { APIEndpoints } from 'enums/api';
 import {
   expectTextForId,
   fillContactDetailsStep,
-  LONG_TEST_MESSAGE,
   onContactRequestPage,
   previewAndSendStep,
   TEST_TRANSLATOR_IDS,
@@ -100,8 +99,8 @@ describe('ContactRequestPage', () => {
 
     onContactRequestPage.fillFieldByLabel(/etunimi/i, ' ');
     onContactRequestPage.fillFieldByLabel(/sukunimi/i, ' ');
-    onContactRequestPage.fillFieldByLabel(/sähköpostiosoite/i, ' ');
-    onContactRequestPage.blurFieldByLabel(/sähköpostiosoite/i);
+    onContactRequestPage.fillFieldByLabel(/sähköposti/i, ' ');
+    onContactRequestPage.blurFieldByLabel(/sähköposti/i);
 
     cy.findAllByText(/tieto on pakollinen/i)
       .should('be.visible')
@@ -118,30 +117,21 @@ describe('ContactRequestPage', () => {
     );
     onContactRequestPage.blurFieldByLabel(/puhelinnumero/i);
     onContactRequestPage.isNextDisabled();
-    onContactRequestPage.fillFieldByLabel(
-      /sähköpostiosoite/i,
-      'wrong.email.com'
-    );
-    onContactRequestPage.blurFieldByLabel(/sähköpostiosoite/i);
+    onContactRequestPage.fillFieldByLabel(/sähköposti/i, 'wrong.email.com');
+    onContactRequestPage.blurFieldByLabel(/sähköposti/i);
     onContactRequestPage.isNextDisabled();
 
     cy.findByText(/sähköpostiosoite on virheellinen/i).should('be.visible');
     cy.findByText(/puhelinnumero on virheellinen/i).should('be.visible');
   });
 
-  it('should show an error if the message field is empty or its length exceeds the limit', () => {
+  it('should show an error if the message field is empty', () => {
     verifyTranslatorsStep();
     fillContactDetailsStep();
     onContactRequestPage.next();
 
-    onContactRequestPage.blurFieldByLabel(/^viesti/i);
+    onContactRequestPage.fillMessage('{enter}');
     cy.findByText(/tieto on pakollinen/i).should('be.visible');
-    onContactRequestPage.isNextDisabled();
-
-    onContactRequestPage.pasteToFieldByLabel(/^viesti/i, LONG_TEST_MESSAGE);
-    onContactRequestPage.elements.byLabel(/^viesti/i).type('{enter}');
-
-    cy.findByText(/teksti on liian pitkä/i).should('be.visible');
     onContactRequestPage.isNextDisabled();
   });
 

--- a/frontend/packages/akr/src/tests/cypress/support/page-objects/contactRequestPage.ts
+++ b/frontend/packages/akr/src/tests/cypress/support/page-objects/contactRequestPage.ts
@@ -5,9 +5,7 @@ import { ContactDetails } from 'interfaces/contactRequest';
 class ContactRequestPage {
   elements = {
     deselectTranslatorButton: (id: string) =>
-      cy
-        .findByTestId(`contact-request-page__chosen-translator-id-${id}`)
-        .findByTestId('DeleteOutlineIcon'),
+      cy.findByTestId(`contact-request-page__deselect-translator-id-${id}-btn`),
     previousButton: () => cy.findByTestId('contact-request-page__previous-btn'),
     nextButton: () => cy.findByTestId('contact-request-page__next-btn'),
     cancelButton: () => cy.findByTestId('contact-request-page__cancel-btn'),

--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.9.4] - 2023-05-10
+
+### Added
+
+- `InputAutoComplete` enum
+
 ## [1.9.3] - 2023-04-14
 
 ### Changed

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/enums/common.ts
+++ b/frontend/packages/shared/src/enums/common.ts
@@ -123,3 +123,14 @@ export enum Variant {
   Outlined = 'outlined',
   Contained = 'contained',
 }
+
+export enum InputAutoComplete {
+  FirstName = 'given-name',
+  LastName = 'family-name',
+  Email = 'email',
+  PhoneNumber = 'tel',
+  Street = 'street-address',
+  PostalCode = 'postal-code',
+  Town = 'address-level2',
+  Country = 'country-name',
+}

--- a/frontend/packages/vkt/package.json
+++ b/frontend/packages/vkt/package.json
@@ -25,6 +25,6 @@
     "vkt:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.3"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.4"
   }
 }

--- a/frontend/packages/vkt/public/i18n/fi-FI/common.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/common.json
@@ -1,6 +1,7 @@
 {
   "vkt": {
     "common": {
+      "acceptTerms": "Hyväksy ehdot",
       "appNameAbbreviation": "VKT",
       "appTitle": "Valtionhallinnon kielitutkinnot - Opetushallitus",
       "back": "Takaisin",

--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -118,7 +118,7 @@
             },
             "privacyStatement": {
               "ariaLabel": "Tietosuojaseloste",
-              "label": "Olen lukenut tämän palvelun <0></0> ja hyväksyn sen.",
+              "label": "Olen lukenut tämän palvelun <0></0> ja hyväksyn sen (pakollinen).",
               "linkLabel": "tietosuojaselosteen"
             }
           },

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/FillContactDetails.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/FillContactDetails.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 import { CustomTextField, H2, Text } from 'shared/components';
-import { TextFieldTypes } from 'shared/enums';
+import { InputAutoComplete, TextFieldTypes } from 'shared/enums';
 import { TextField } from 'shared/interfaces';
 import { FieldErrors, getErrors, hasErrors } from 'shared/utils';
 
@@ -12,11 +12,6 @@ import {
   PublicEnrollmentContactDetails,
 } from 'interfaces/publicEnrollment';
 import { updatePublicEnrollment } from 'redux/reducers/publicEnrollment';
-
-export enum InputAutoComplete {
-  Email = 'email',
-  PhoneNumber = 'tel',
-}
 
 const fields: Array<TextField<PublicEnrollmentContactDetails>> = [
   {

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/FillContactDetails.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/FillContactDetails.tsx
@@ -13,6 +13,11 @@ import {
 } from 'interfaces/publicEnrollment';
 import { updatePublicEnrollment } from 'redux/reducers/publicEnrollment';
 
+export enum InputAutoComplete {
+  Email = 'email',
+  PhoneNumber = 'tel',
+}
+
 const fields: Array<TextField<PublicEnrollmentContactDetails>> = [
   {
     name: 'email',
@@ -143,6 +148,7 @@ export const FillContactDetails = ({
             {...getCustomTextFieldAttributes('email')}
             type={TextFieldTypes.Email}
             value={enrollment.email}
+            autoComplete={InputAutoComplete.Email}
           />
           <CustomTextField
             {...getCustomTextFieldAttributes('emailConfirmation')}
@@ -161,6 +167,7 @@ export const FillContactDetails = ({
         className="phone-number"
         value={enrollment.phoneNumber}
         type={TextFieldTypes.PhoneNumber}
+        autoComplete={InputAutoComplete.PhoneNumber}
       />
     </div>
   );

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/Preview.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/Preview.tsx
@@ -183,6 +183,8 @@ export const Preview = ({
   isLoading: boolean;
   setIsStepValid: (isValid: boolean) => void;
 }) => {
+  const translateCommon = useCommonTranslation();
+
   useEffect(() => {
     setIsStepValid(enrollment.privacyStatementConfirmation);
   }, [setIsStepValid, enrollment]);
@@ -206,18 +208,21 @@ export const Preview = ({
       />
       <ExamEventDetails enrollment={enrollment} />
       <CertificateShippingDetails enrollment={enrollment} />
-      <FormControlLabel
-        control={
-          <Checkbox
-            onClick={handleCheckboxClick}
-            color={Color.Secondary}
-            checked={enrollment.privacyStatementConfirmation}
-            disabled={isLoading}
-          />
-        }
-        label={<PrivacyStatementCheckboxLabel />}
-        className="public-enrollment__grid__preview__privacy-statement-checkbox-label"
-      />
+      <div className="rows gapped">
+        <H2>{translateCommon('acceptTerms')}</H2>
+        <FormControlLabel
+          control={
+            <Checkbox
+              onClick={handleCheckboxClick}
+              color={Color.Secondary}
+              checked={enrollment.privacyStatementConfirmation}
+              disabled={isLoading}
+            />
+          }
+          label={<PrivacyStatementCheckboxLabel />}
+          className="public-enrollment__grid__preview__privacy-statement-checkbox-label"
+        />
+      </div>
     </div>
   );
 };

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/CertificateShipping.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/CertificateShipping.tsx
@@ -11,6 +11,13 @@ import { CertificateShippingTextFields } from 'interfaces/common/enrollment';
 import { PublicEnrollment } from 'interfaces/publicEnrollment';
 import { updatePublicEnrollment } from 'redux/reducers/publicEnrollment';
 
+enum InputAutoComplete {
+  Street = 'street-address',
+  PostalCode = 'postal-code',
+  Town = 'address-level2',
+  Country = 'country-name',
+}
+
 const fields: Array<TextField<CertificateShippingTextFields>> = [
   {
     name: 'street',
@@ -148,18 +155,22 @@ export const CertificateShipping = ({
           <CustomTextField
             {...getCustomTextFieldAttributes('street')}
             value={enrollment.street}
+            autoComplete={InputAutoComplete.Street}
           />
           <CustomTextField
             {...getCustomTextFieldAttributes('postalCode')}
             value={enrollment.postalCode}
+            autoComplete={InputAutoComplete.PostalCode}
           />
           <CustomTextField
             {...getCustomTextFieldAttributes('town')}
             value={enrollment.town}
+            autoComplete={InputAutoComplete.Town}
           />
           <CustomTextField
             {...getCustomTextFieldAttributes('country')}
             value={enrollment.country}
+            autoComplete={InputAutoComplete.Country}
           />
         </div>
       </Collapse>

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/CertificateShipping.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/CertificateShipping.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, Collapse, FormControlLabel } from '@mui/material';
 import { ChangeEvent, useEffect, useState } from 'react';
 import { CustomTextField, H3 } from 'shared/components';
-import { Color, TextFieldTypes } from 'shared/enums';
+import { Color, InputAutoComplete, TextFieldTypes } from 'shared/enums';
 import { TextField } from 'shared/interfaces';
 import { getErrors, hasErrors } from 'shared/utils';
 
@@ -10,13 +10,6 @@ import { useAppDispatch } from 'configs/redux';
 import { CertificateShippingTextFields } from 'interfaces/common/enrollment';
 import { PublicEnrollment } from 'interfaces/publicEnrollment';
 import { updatePublicEnrollment } from 'redux/reducers/publicEnrollment';
-
-enum InputAutoComplete {
-  Street = 'street-address',
-  PostalCode = 'postal-code',
-  Town = 'address-level2',
-  Country = 'country-name',
-}
 
 const fields: Array<TextField<CertificateShippingTextFields>> = [
   {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2686,7 +2686,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.akr@workspace:packages/akr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.2"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.4"
   languageName: unknown
   linkType: soft
 
@@ -2694,7 +2694,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.otr@workspace:packages/otr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.2"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.3"
   languageName: unknown
   linkType: soft
 
@@ -2786,7 +2786,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.2":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.4":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -2796,7 +2796,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.vkt@workspace:packages/vkt"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.1"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.4"
   languageName: unknown
   linkType: soft
 
@@ -2805,7 +2805,7 @@ __metadata:
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.yki@workspace:packages/yki"
   dependencies:
     multer: ^1.4.5-lts.1
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.0"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.3"
   languageName: unknown
   linkType: soft
 
@@ -11809,17 +11809,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.0":
-  version: 1.9.0
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.9.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.9.0%2F438adbaf79c251a1a803fd0c3180bf1f42f362ea"
-  checksum: 891c46d8d487432c0ec3b9cfa7c3633989f372de1eb3d2e0421a68a39288a96c9ce790063a0c2f4cb382190d1d6458311b8dcf70a89fc31582e033feb87b243b
-  languageName: node
-  linkType: hard
-
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.1":
-  version: 1.9.1
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.9.1::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.9.1%2F7755d08528b30dcb16e5d4a967fad3f4e28e8297"
-  checksum: a443c3b9db708c58765ca81b4640d9903c881543d4d82c6f9af7f4974d41b18f5e290e88d08d32f623af12e9b74fb7cb24a06864d6eaf5822b774effecc4dce4
+"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.3":
+  version: 1.9.3
+  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.9.3::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.9.3%2F67bc93e272b4bbf678b047bedecb3034c2ad6c5d"
+  checksum: 47ce70b0591b84b506b8bbdc85817461ef318c1c28b870a058a02c4cc3a9d0d4cb786c712ebf4bb49abb93eb9557cbd336e08d1ce59708279cee3d195823e662
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Yhteydenottopyynnön osalta muutettu sekä mobiili- että desktopnäkymät kattamaan samat tiedot. Vastaanottajia / valittuja kääntäjiä ei ole tarve näyttää kuin alussa kun voi vielä tiputtaa jotain valintoja pois sekä viestin kirjoittamisen että esikatselun yhteydessä. Omia yhteystietoja ei tarvitse näyttää kuin esikatselun aikana.

Tehty myös otsikkotasojen parannuksia ja jonkin verran tekstimuutoksia ja pieniä tekstilisäyksiä (kuten "Tähdellä (*) merkityt kentät ovat pakollisia."). Muutokset tsekattu Emman kanssa läpi untuvalla.

Käännökset ovat toistaiseksi omasta päästä heitettyjä. Ruotsinkielisen yo. kenttien pakollisuushuomion nappasin google translatella ja tsekkasin lopuksi että kirjoitusasu ja termit pitäisivät olla oikein. Nämä käännökset ois hyvä kyllä virkailijoiden kanssa vielä tsekata läpi.

## Check-lista
- [x] yarn.lock päivitetty
- [x] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
- [x] Tekstimuutokset viety Sharepointiin
- [x] Käännökset tsekattu OPH:n virkailijoiden kanssa
