### PR TITLE
OPHVKTKEH-137: ilmoflown käytettävyys- ja saavutettavuusparannuksia

### DIFF
--- a/frontend/packages/vkt/public/i18n/fi-FI/common.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/common.json
@@ -111,6 +111,7 @@
         "enrollment": "Ilmoittautuminen",
         "frontPage": "Etusivu"
       },
+      "requiredFieldsInfo": "Tähdellä (*) merkityt kentät ovat pakollisia.",
       "rowsPerPageLabel": "Tulokset per sivu",
       "save": "Tallenna",
       "vktHomepage": {

--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -87,7 +87,7 @@
             "emailConfirmation": "Vahvista sähköpostiosoite",
             "mismatchingEmailsError": "Sähköpostiosoitekenttien sisällöt eivät vastaa toisiaan",
             "phoneNumber": "Puhelinnumero",
-            "title": "Yhteystiedot"
+            "title": "Täytä yhteystietosi"
           },
           "partialExamsSelection": {
             "partialExamsTitle": "Valitse osakokeet",
@@ -98,13 +98,23 @@
             "identityNumber": "Henkilötunnus",
             "dateOfBirth": "Syntymäaika",
             "lastName": "Sukunimi",
-            "title": "Nimi ja henkilötunnus"
+            "title": "Henkilötietosi"
           },
           "preview": {
+            "certificateShippingDetails": {
+              "addressLabel": "Toimitusosoite",
+              "title": "Tutkintotodistuksen toimitus"
+            },
             "contactDetails": {
               "email": "Sähköpostiosoite",
               "phoneNumber": "Puhelinnumero",
-              "title": "Yhteystiedot"
+              "title": "Yhteystietosi"
+            },
+            "examEventDetails": {
+              "previousEnrollmentLabel": "Olen osallistunut valtionhallinnon kielitutkintoon aikaisemmin",
+              "selectedSkillsLabel": "Valitut tutkinnot",
+              "selectedPartialExamsLabel": "Valitut osakokeet",
+              "title": "Tutkinnon tiedot"
             },
             "privacyStatement": {
               "ariaLabel": "Tietosuojaseloste",

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
@@ -93,12 +93,17 @@ export const PublicEnrollmentControlButtons = ({
   };
 
   const handleSubmitBtnClick = () => {
-    dispatch(
-      loadPublicEnrollmentSave({
-        enrollment,
-        reservationDetails,
-      })
-    );
+    if (isStepValid) {
+      setShowValidation(false);
+      dispatch(
+        loadPublicEnrollmentSave({
+          enrollment,
+          reservationDetails,
+        })
+      );
+    } else {
+      setShowValidation(true);
+    }
   };
 
   const CancelButton = () => (

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
@@ -43,7 +43,6 @@ export const PublicEnrollmentStepContents = ({
           enrollment={enrollment}
           isLoading={isLoading}
           setIsStepValid={setIsStepValid}
-          showValidation={showValidation}
         />
       );
     case PublicEnrollmentFormStep.Payment:

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/FillContactDetails.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/FillContactDetails.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useEffect, useState } from 'react';
-import { CustomTextField, H3 } from 'shared/components';
+import { CustomTextField, H2, Text } from 'shared/components';
 import { TextFieldTypes } from 'shared/enums';
 import { TextField } from 'shared/interfaces';
 import { FieldErrors, getErrors, hasErrors } from 'shared/utils';
@@ -135,8 +135,9 @@ export const FillContactDetails = ({
   return (
     <div className="margin-top-xxl rows gapped">
       <PersonDetails />
-      <div className="margin-top-sm rows gapped">
-        <H3>{t('title')}</H3>
+      <div className="margin-top-lg rows gapped">
+        <H2>{t('title')}</H2>
+        <Text>{translateCommon('requiredFieldsInfo')}</Text>
         <div className="grid-2-columns gapped">
           <CustomTextField
             {...getCustomTextFieldAttributes('email')}

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/PersonDetails.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/PersonDetails.tsx
@@ -1,8 +1,9 @@
-import { CustomTextField, H3 } from 'shared/components';
+import { H2, Text } from 'shared/components';
 import { DateUtils } from 'shared/utils';
 
 import { usePublicTranslation } from 'configs/i18n';
 import { useAppSelector } from 'configs/redux';
+import { PublicPerson } from 'interfaces/publicPerson';
 import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
 
 export const PersonDetails = () => {
@@ -17,34 +18,31 @@ export const PersonDetails = () => {
     return null;
   }
 
+  const displayField = (field: keyof PublicPerson) => {
+    const value =
+      field === 'dateOfBirth'
+        ? DateUtils.formatOptionalDate(person.dateOfBirth)
+        : person[field];
+
+    return (
+      <div className="rows">
+        <Text className="bold">
+          {t(field)}
+          {':'}
+        </Text>
+        <Text>{value}</Text>
+      </div>
+    );
+  };
+
   return (
     <div className="rows gapped">
-      <H3>{t('title')}</H3>
+      <H2>{t('title')}</H2>
       <div className="grid-columns gapped">
-        <CustomTextField
-          label={t('lastName')}
-          value={person.lastName}
-          disabled
-        />
-        <CustomTextField
-          label={t('firstName')}
-          value={person.firstName}
-          disabled
-        />
-        {person.identityNumber && (
-          <CustomTextField
-            label={t('identityNumber')}
-            value={person.identityNumber}
-            disabled
-          />
-        )}
-        {person.dateOfBirth && (
-          <CustomTextField
-            label={t('dateOfBirth')}
-            value={DateUtils.formatOptionalDate(person.dateOfBirth)}
-            disabled
-          />
-        )}
+        {displayField('lastName')}
+        {displayField('firstName')}
+        {person.identityNumber && displayField('identityNumber')}
+        {person.dateOfBirth && displayField('dateOfBirth')}
       </div>
     </div>
   );

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/SelectExam.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/SelectExam.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { Text } from 'shared/components';
 
-import { CertificateShipping } from 'components/publicEnrollment/steps/CertificateShipping';
-import { PartialExamsSelection } from 'components/publicEnrollment/steps/PartialExamsSelection';
-import { PreviousEnrollment } from 'components/publicEnrollment/steps/PreviousEnrollment';
+import { CertificateShipping } from 'components/publicEnrollment/steps/selectExam/CertificateShipping';
+import { PartialExamsSelection } from 'components/publicEnrollment/steps/selectExam/PartialExamsSelection';
+import { PreviousEnrollment } from 'components/publicEnrollment/steps/selectExam/PreviousEnrollment';
 import { useCommonTranslation } from 'configs/i18n';
 import { PublicEnrollment } from 'interfaces/publicEnrollment';
 
@@ -21,31 +21,31 @@ export const SelectExam = ({
 }) => {
   const translateCommon = useCommonTranslation();
 
+  const [isValidPreviousEnrollment, setIsValidPreviousEnrollment] =
+    useState(false);
   const [isValidPartialExamsSelection, setIsValidPartialExamsSelection] =
     useState(false);
   const [isValidCertificateShipping, setIsValidCertificateShipping] =
     useState(false);
-  const [isValidPreviousEnrollment, setIsValidPreviousEnrollment] =
-    useState(false);
 
+  const setPreviousEnrollment = (isValid: boolean) =>
+    setIsValidPreviousEnrollment(isValid);
   const setPartialExamsSelection = (isValid: boolean) =>
     setIsValidPartialExamsSelection(isValid);
   const setCertificateShipping = (isValid: boolean) =>
     setIsValidCertificateShipping(isValid);
-  const setPreviousEnrollment = (isValid: boolean) =>
-    setIsValidPreviousEnrollment(isValid);
 
   useEffect(() => {
     setIsStepValid(
-      isValidPartialExamsSelection &&
-        isValidCertificateShipping &&
-        isValidPreviousEnrollment
+      isValidPreviousEnrollment &&
+        isValidPartialExamsSelection &&
+        isValidCertificateShipping
     );
   }, [
     setIsStepValid,
+    isValidPreviousEnrollment,
     isValidPartialExamsSelection,
     isValidCertificateShipping,
-    isValidPreviousEnrollment,
   ]);
 
   return (
@@ -59,8 +59,8 @@ export const SelectExam = ({
       <PreviousEnrollment
         enrollment={enrollment}
         editingDisabled={isLoading}
-        showValidation={showValidation}
         setValid={setPreviousEnrollment}
+        showValidation={showValidation}
       />
       <PartialExamsSelection
         enrollment={enrollment}

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/CertificateShipping.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/CertificateShipping.tsx
@@ -41,7 +41,7 @@ export const CertificateShipping = ({
 }: {
   enrollment: PublicEnrollment;
   editingDisabled: boolean;
-  setValid?: (isValid: boolean) => void;
+  setValid: (isValid: boolean) => void;
   showValidation: boolean;
 }) => {
   const translateCommon = useCommonTranslation();
@@ -54,10 +54,6 @@ export const CertificateShipping = ({
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (!setValid) {
-      return;
-    }
-
     if (enrollment.digitalCertificateConsent) {
       setValid(true);
 

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/PartialExamsSelection.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/PartialExamsSelection.tsx
@@ -45,7 +45,7 @@ export const PartialExamsSelection = ({
 }: {
   enrollment: PublicEnrollment;
   editingDisabled: boolean;
-  setValid?: (disabled: boolean) => void;
+  setValid: (disabled: boolean) => void;
 }) => {
   const { t } = usePublicTranslation({
     keyPrefix: 'vkt.component.publicEnrollment.steps.partialExamsSelection',
@@ -54,9 +54,7 @@ export const PartialExamsSelection = ({
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (setValid) {
-      setValid(EnrollmentUtils.isValidPartialExamsAndSkills(enrollment));
-    }
+    setValid(EnrollmentUtils.isValidPartialExamsAndSkills(enrollment));
   }, [setValid, enrollment]);
 
   const toggleSkill = (fieldName: keyof PartialExamsAndSkills) => {

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/PreviousEnrollment.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/PreviousEnrollment.tsx
@@ -44,7 +44,7 @@ export const PreviousEnrollment = ({
 }: {
   enrollment: PublicEnrollment;
   editingDisabled: boolean;
-  setValid?: (isValid: boolean) => void;
+  setValid: (isValid: boolean) => void;
   showValidation: boolean;
 }) => {
   const translateCommon = useCommonTranslation();
@@ -59,10 +59,6 @@ export const PreviousEnrollment = ({
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (!setValid) {
-      return;
-    }
-
     if (enrollment.hasPreviousEnrollment === undefined) {
       setValid(false);
 
@@ -115,15 +111,13 @@ export const PreviousEnrollment = ({
     return !!errors[fieldName];
   };
 
-  const handleBlur = () => {
+  const handleTextFieldBlur = () => {
     if (!dirtyFields.includes('previousEnrollment')) {
       setDirtyFields([...dirtyFields, 'previousEnrollment']);
     }
   };
 
-  const handleChange = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
+  const handleTextFieldChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     dispatch(
       updatePublicEnrollment({
         previousEnrollment: event.target.value,
@@ -185,9 +179,9 @@ export const PreviousEnrollment = ({
         <CustomTextField
           className="margin-top-sm public-enrollment__grid__previous-enrollment__input"
           label={t('label')}
-          value={enrollment.previousEnrollment || ''}
-          onBlur={handleBlur}
-          onChange={handleChange}
+          value={enrollment.previousEnrollment}
+          onBlur={handleTextFieldBlur}
+          onChange={handleTextFieldChange}
           error={showCustomTextFieldError('previousEnrollment')}
           helperText={errors['previousEnrollment']}
           disabled={editingDisabled}

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -40,6 +40,7 @@ const initialState: PublicEnrollmentState = {
     postalCode: '',
     town: '',
     country: '',
+    previousEnrollment: '',
     privacyStatementConfirmation: false,
   },
 };

--- a/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
+++ b/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
@@ -49,6 +49,11 @@
     }
 
     &__preview {
+      &__bullet-list {
+        margin-block-start: 0;
+        padding-inline-start: 2rem;
+      }
+
       &__privacy-statement-checkbox-label {
         margin-right: 0;
         padding-left: 1rem;


### PR DESCRIPTION
## Yhteenveto

- Muutettu disabloituja kenttiä plain tekstiksi labeleineen, vast. homma kuin AKR:ään tehty pullarissa https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/470. Jos koetaan mielenkiintoiseksi, tällaista varten voisi harkita erillistä shared-kirjaston komponenttia.
- Yhteystietojen täyttö sekä Esikatselu näkymiin tehty jonkin verran muutoksia

## Huomautukset

Checkboxien virheväri olisi hyvä saada jollain lailla "Olen lukenut tietosuojaselosteen.." checkboxiin jos lomakkeen yrittää lähettää kun tuo on checkaamatta. En löytänyt suoralta kädeltä tapaa tämän toteutukseen. Vast. toteutuksen voisi kattella myöhemmin myös osakokeiden valintaan jos/kun päädytään lopulta käyttämään checkboxeja näihin. Emman designhan tuohon on vielä auki.

## Check-lista
- [x] UI-muutoksia testattu eri selaimilla
