### PR TITLE
VKT(Backend): OPHVKTKEH-146 confirmation email sent on successful enrollment

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/api/PublicController.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/PublicController.java
@@ -84,7 +84,7 @@ public class PublicController {
     @RequestBody @Valid PublicEnrollmentCreateDTO dto,
     @PathVariable final long reservationId,
     final HttpSession session
-  ) {
+  ) throws IOException, InterruptedException {
     final Person person = publicPersonService.getPerson(SessionUtil.getPersonId(session));
 
     publicEnrollmentService.createEnrollment(dto, reservationId, person);

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/clerk/ClerkEnrollmentController.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/clerk/ClerkEnrollmentController.java
@@ -11,6 +11,7 @@ import fi.oph.vkt.api.dto.clerk.ClerkEnrollmentUpdateDTO;
 import fi.oph.vkt.service.ClerkEnrollmentService;
 import fi.oph.vkt.service.receipt.ReceiptData;
 import fi.oph.vkt.service.receipt.ReceiptRenderer;
+import fi.oph.vkt.util.localisation.Language;
 import io.swagger.v3.oas.annotations.Operation;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -69,7 +70,8 @@ public class ClerkEnrollmentController {
     final String filename = String.format("VKT_kuitti_%d.pdf", enrollmentId);
     response.addHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
 
-    final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollmentId);
+    // TODO: possibility to download swedish receipt?
+    final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollmentId, Language.FI);
     final ByteArrayInputStream bis = new ByteArrayInputStream(receiptRenderer.getReceiptPdfBytes(receiptData));
     return ResponseEntity.ok().body(new InputStreamResource(bis));
   }

--- a/backend/vkt/src/main/java/fi/oph/vkt/model/EmailType.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/model/EmailType.java
@@ -2,4 +2,5 @@ package fi.oph.vkt.model;
 
 public enum EmailType {
   ENROLLMENT_CONFIRMATION,
+  ENROLLMENT_TO_QUEUE_CONFIRMATION,
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
@@ -1,0 +1,167 @@
+package fi.oph.vkt.service;
+
+import fi.oph.vkt.model.EmailType;
+import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Person;
+import fi.oph.vkt.model.type.ExamLanguage;
+import fi.oph.vkt.service.email.EmailAttachmentData;
+import fi.oph.vkt.service.email.EmailData;
+import fi.oph.vkt.service.email.EmailService;
+import fi.oph.vkt.service.receipt.ReceiptData;
+import fi.oph.vkt.service.receipt.ReceiptRenderer;
+import fi.oph.vkt.util.TemplateRenderer;
+import fi.oph.vkt.util.localisation.Language;
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PublicEnrollmentEmailService {
+
+  private final EmailService emailService;
+  private final ReceiptRenderer receiptRenderer;
+  private final TemplateRenderer templateRenderer;
+
+  @Transactional
+  public void sendEnrollmentConfirmationEmail(final Enrollment enrollment, final Person person)
+    throws IOException, InterruptedException {
+    final Map<String, Object> templateParams = getEmailParams(enrollment);
+
+    final String recipientName = person.getFirstName() + " " + person.getLastName();
+    final String recipientAddress = enrollment.getEmail();
+    final String subject = "Vahvistus tutkintoon ilmoittautumisesta | Samma på svenska";
+    final String body = templateRenderer.renderEnrollmentConfirmationEmailBody(templateParams);
+
+    final List<EmailAttachmentData> attachments = List.of(
+      createReceiptAttachment(enrollment, Language.FI),
+      createReceiptAttachment(enrollment, Language.SV)
+    );
+
+    createEmail(recipientName, recipientAddress, subject, body, attachments, EmailType.ENROLLMENT_CONFIRMATION);
+  }
+
+  @Transactional
+  public void sendEnrollmentToQueueConfirmationEmail(final Enrollment enrollment, final Person person) {
+    final Map<String, Object> templateParams = getEmailParams(enrollment);
+
+    final String recipientName = person.getFirstName() + " " + person.getLastName();
+    final String recipientAddress = enrollment.getEmail();
+    final String subject = "Vahvistus ilmoittautumisesta tutkinnon jonotuspaikalle | Samma på svenska";
+    final String body = templateRenderer.renderEnrollmentToQueueConfirmationEmailBody(templateParams);
+
+    createEmail(recipientName, recipientAddress, subject, body, List.of(), EmailType.ENROLLMENT_TO_QUEUE_CONFIRMATION);
+  }
+
+  private Map<String, Object> getEmailParams(final Enrollment enrollment) {
+    final ExamEvent examEvent = enrollment.getExamEvent();
+
+    final Map<String, Object> params = new HashMap<>(Map.of());
+
+    if (examEvent.getLanguage() == ExamLanguage.FI) {
+      params.put("examLanguageFI", "suomi");
+      params.put("examLanguageSV", "finska");
+    } else {
+      params.put("examLanguageFI", "ruotsi");
+      params.put("examLanguageSV", "svenska");
+    }
+
+    params.put("examLevelFI", "erinomainen");
+    params.put("examLevelSV", "utmärkt");
+
+    params.put("examDate", examEvent.getDate().format(DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+
+    params.put(
+      "skillsFI",
+      joinNonEmptyStrings(
+        Stream.of(
+          enrollment.isTextualSkill() ? "kirjallinen taito" : "",
+          enrollment.isOralSkill() ? "suullinen taito" : "",
+          enrollment.isUnderstandingSkill() ? "ymmärtämisen taito" : ""
+        )
+      )
+    );
+    params.put(
+      "skillsSV",
+      joinNonEmptyStrings(
+        Stream.of(
+          enrollment.isTextualSkill() ? "kirjallinen taito" : "",
+          enrollment.isOralSkill() ? "suullinen taito" : "",
+          enrollment.isUnderstandingSkill() ? "ymmärtämisen taito" : ""
+        )
+      )
+    );
+
+    params.put(
+      "partialExamsFI",
+      joinNonEmptyStrings(
+        Stream.of(
+          enrollment.isWritingPartialExam() ? "kirjoittaminen" : "",
+          enrollment.isReadingComprehensionPartialExam() ? "tekstin ymmärtäminen" : "",
+          enrollment.isSpeakingPartialExam() ? "puhuminen" : "",
+          enrollment.isSpeechComprehensionPartialExam() ? "puheen ymmärtäminen" : ""
+        )
+      )
+    );
+    params.put(
+      "partialExamsSV",
+      joinNonEmptyStrings(
+        Stream.of(
+          enrollment.isWritingPartialExam() ? "kirjoittaminen" : "",
+          enrollment.isReadingComprehensionPartialExam() ? "tekstin ymmärtäminen" : "",
+          enrollment.isSpeakingPartialExam() ? "puhuminen" : "",
+          enrollment.isSpeechComprehensionPartialExam() ? "puheen ymmärtäminen" : ""
+        )
+      )
+    );
+
+    return params;
+  }
+
+  private String joinNonEmptyStrings(final Stream<String> stream) {
+    return stream.filter(s -> !s.isEmpty()).collect(Collectors.joining(", "));
+  }
+
+  private EmailAttachmentData createReceiptAttachment(final Enrollment enrollment, final Language language)
+    throws IOException, InterruptedException {
+    final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId(), language);
+    final byte[] receiptBytes = receiptRenderer.getReceiptPdfBytes(receiptData);
+
+    final String attachmentNamePrefix = language == Language.FI ? "Maksukuitti" : "Betalningkvittot";
+
+    return EmailAttachmentData
+      .builder()
+      .name(attachmentNamePrefix + " " + receiptData.dateOfReceipt() + ".pdf")
+      .contentType("application/pdf")
+      .data(receiptBytes)
+      .build();
+  }
+
+  private void createEmail(
+    final String recipientName,
+    final String recipientAddress,
+    final String subject,
+    final String body,
+    final List<EmailAttachmentData> attachments,
+    final EmailType emailType
+  ) {
+    final EmailData emailData = EmailData
+      .builder()
+      .recipientName(recipientName)
+      .recipientAddress(recipientAddress)
+      .subject(subject)
+      .body(body)
+      .attachments(attachments)
+      .build();
+
+    emailService.saveEmail(emailType, emailData);
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/email/EmailData.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/email/EmailData.java
@@ -11,7 +11,7 @@ public record EmailData(
   @NonNull String recipientAddress,
   @NonNull String subject,
   @NonNull String body,
-  List<EmailAttachmentData> attachments
+  @NonNull List<EmailAttachmentData> attachments
 ) {
   public static EmailData createFromEmail(final Email email) {
     return EmailData

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/email/EmailService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/email/EmailService.java
@@ -7,7 +7,6 @@ import fi.oph.vkt.repository.EmailAttachmentRepository;
 import fi.oph.vkt.repository.EmailRepository;
 import fi.oph.vkt.service.email.sender.EmailSender;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,20 +31,21 @@ public class EmailService {
     email.setRecipientAddress(emailData.recipientAddress());
     email.setSubject(emailData.subject());
     email.setBody(emailData.body());
-    Optional
-      .ofNullable(emailData.attachments())
-      .ifPresent(attachments ->
-        attachments.forEach(emailAttachmentData -> {
-          final EmailAttachment emailAttachment = new EmailAttachment();
-          emailAttachment.setEmail(email);
-          emailAttachment.setName(emailAttachmentData.name());
-          emailAttachment.setContentType(emailAttachmentData.contentType());
-          emailAttachment.setData(emailAttachmentData.data());
-          email.getAttachments().add(emailAttachment);
-        })
-      );
+
+    emailData
+      .attachments()
+      .forEach(emailAttachmentData -> {
+        final EmailAttachment emailAttachment = new EmailAttachment();
+        emailAttachment.setEmail(email);
+        emailAttachment.setName(emailAttachmentData.name());
+        emailAttachment.setContentType(emailAttachmentData.contentType());
+        emailAttachment.setData(emailAttachmentData.data());
+        email.getAttachments().add(emailAttachment);
+      });
+
     emailRepository.save(email);
     emailAttachmentRepository.saveAll(email.getAttachments());
+
     return emailRepository.saveAndFlush(email).getId();
   }
 

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
@@ -5,9 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jhonnymertz.wkhtmltopdf.wrapper.Pdf;
 import com.github.jhonnymertz.wkhtmltopdf.wrapper.configurations.WrapperConfig;
 import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.model.type.ExamLanguage;
+import fi.oph.vkt.model.type.ExamLevel;
 import fi.oph.vkt.repository.EnrollmentRepository;
 import fi.oph.vkt.util.EnrollmentUtil;
 import fi.oph.vkt.util.TemplateRenderer;
+import fi.oph.vkt.util.localisation.Language;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -24,11 +27,12 @@ public class ReceiptRenderer {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd.MM.yyyy");
   public static final TypeReference<Map<String, Object>> TYPE_REF = new TypeReference<>() {};
-  private final TemplateRenderer templateRenderer;
+
   private final EnrollmentRepository enrollmentRepository;
+  private final TemplateRenderer templateRenderer;
 
   @Transactional(readOnly = true)
-  public ReceiptData getReceiptData(final long enrollmentId) {
+  public ReceiptData getReceiptData(final long enrollmentId, final Language language) {
     final Enrollment enrollment = enrollmentRepository.getReferenceById(enrollmentId);
     final String personName = enrollment.getPerson().getLastName() + ", " + enrollment.getPerson().getFirstName();
     final String dateOfReceipt = DATE_FORMAT.format(LocalDate.now());
@@ -37,13 +41,18 @@ public class ReceiptRenderer {
     // TODO Paid amount should be taken from actual payment
     final String totalAmount = String.format("%d €", EnrollmentUtil.calculateExaminationPaymentSum(enrollment));
 
+    final String receiptItemName = language == Language.FI
+      ? "Valtionhallinnon kielitutkinnot (VKT), tutkintomaksu"
+      : "Valtionhallinnon kielitutkinnot (VKT), examensavgift";
+
     final String additionalInfo1 = String.format(
       "%s, %s, %s",
-      getLang(enrollment),
-      getLevel(enrollment),
+      getLang(enrollment, language),
+      getLevel(enrollment, language),
       DATE_FORMAT.format(enrollment.getExamEvent().getDate())
     );
-    final String additionalInfo2 = "Osallistuja: " + personName;
+    final String additionalInfo2 = language == Language.FI ? "Osallistuja: " + personName : "Deltagaren: " + personName;
+
     return ReceiptData
       .builder()
       .dateOfReceipt(dateOfReceipt)
@@ -53,7 +62,7 @@ public class ReceiptRenderer {
       .item(
         ReceiptItem
           .builder()
-          .name("Valtionhallinnon kielitutkinnot (VKT) tutkintomaksu")
+          .name(receiptItemName)
           .value(totalAmount)
           .additionalInfos(List.of(additionalInfo1, additionalInfo2))
           .build()
@@ -61,17 +70,32 @@ public class ReceiptRenderer {
       .build();
   }
 
-  private static String getLang(final Enrollment enrollment) {
-    return switch (enrollment.getExamEvent().getLanguage()) {
-      case FI -> "Suomi";
-      case SV -> "Ruotsi";
-    };
+  private static String getLang(final Enrollment enrollment, final Language language) {
+    final ExamLanguage examLanguage = enrollment.getExamEvent().getLanguage();
+
+    if (examLanguage == ExamLanguage.FI && language == Language.FI) {
+      return "Suomi";
+    } else if (examLanguage == ExamLanguage.FI && language == Language.SV) {
+      return "Finska";
+    } else if (examLanguage == ExamLanguage.SV & language == Language.FI) {
+      return "Ruotsi";
+    } else if (examLanguage == ExamLanguage.SV && language == Language.SV) {
+      return "Svenska";
+    }
+
+    return "-";
   }
 
-  private static String getLevel(final Enrollment enrollment) {
-    return switch (enrollment.getExamEvent().getLevel()) {
-      case EXCELLENT -> "Erinomainen";
-    };
+  private static String getLevel(final Enrollment enrollment, final Language language) {
+    final ExamLevel examLevel = enrollment.getExamEvent().getLevel();
+
+    if (examLevel == ExamLevel.EXCELLENT && language == Language.FI) {
+      return "erinomainen";
+    } else if (examLevel == ExamLevel.EXCELLENT && language == Language.SV) {
+      return "utmärkt";
+    }
+
+    return "-";
   }
 
   public byte[] getReceiptPdfBytes(final ReceiptData data) throws IOException, InterruptedException {

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/TemplateRenderer.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/TemplateRenderer.java
@@ -12,6 +12,14 @@ public class TemplateRenderer {
 
   private final TemplateEngine templateEngine;
 
+  public String renderEnrollmentConfirmationEmailBody(final Map<String, Object> params) {
+    return renderTemplate("enrollment-confirmation", params);
+  }
+
+  public String renderEnrollmentToQueueConfirmationEmailBody(final Map<String, Object> params) {
+    return renderTemplate("enrollment-to-queue-confirmation", params);
+  }
+
   public String renderReceipt(final Map<String, Object> params) {
     return renderTemplate("receipt", params);
   }

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/localisation/Language.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/localisation/Language.java
@@ -1,0 +1,6 @@
+package fi.oph.vkt.util.localisation;
+
+public enum Language {
+  FI,
+  SV,
+}

--- a/backend/vkt/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/backend/vkt/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -532,4 +532,10 @@
         </addColumn>
         <dropNotNullConstraint tableName="person" columnName="identity_number" columnDataType="VARCHAR(255)"/>
     </changeSet>
+
+    <changeSet id="2023-05-03-add-enrollment-to-queue-confirmation-email_type" author="mikhuttu">
+        <insert tableName="email_type">
+            <column name="name" value="ENROLLMENT_TO_QUEUE_CONFIRMATION"/>
+        </insert>
+    </changeSet>
 </databaseChangeLog>

--- a/backend/vkt/src/main/resources/email-templates/enrollment-confirmation.html
+++ b/backend/vkt/src/main/resources/email-templates/enrollment-confirmation.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="fi">
+    <body>
+        <p>
+            Hei,
+        </p>
+        <p>
+            Olet ilmoittautunut valtionhallinnon kielitutkintoon. Ohessa tiedot ilmoittautumisestasi. Liitteenä myös maksukuitti suomeksi ja ruotsiksi.
+        </p>
+        <br/>
+
+        <p>
+            Tutkinnon kieli: <span th:text="${examLanguageFI}"></span><br/>
+            Tutkinnon taso: <span th:text="${examLevelFI}"></span><br/>
+            Tutkintopäivä: <span th:text="${examDate}"></span><br/>
+            Valitsemasi taidot: <span th:text="${skillsFI}"></span><br/>
+            Valitsemasi osakokeet: <span th:text="${partialExamsFI}"></span><br/>
+        </p>
+        <br/>
+
+        <p>
+            Älä vastaa tähän viestiin - viesti on lähetetty automaattisesti.
+        </p>
+        <p style="border-bottom: 1px solid black; padding-bottom: 15px;">
+            Ystävällisin terveisin<br/>
+            Opetushallitus
+        </p>
+
+        <p>
+            Hei,
+        </p>
+        <p>
+            Olet ilmoittautunut valtionhallinnon kielitutkintoon. Ohessa tiedot ilmoittautumisestasi. Liitteenä myös maksukuitti suomeksi ja ruotsiksi.
+        </p>
+        <br/>
+
+        <p>
+            Tutkinnon kieli: <span th:text="${examLanguageSV}"></span><br/>
+            Tutkinnon taso: <span th:text="${examLevelSV}"></span><br/>
+            Tutkintopäivä: <span th:text="${examDate}"></span><br/>
+            Valitsemasi taidot: <span th:text="${skillsSV}"></span><br/>
+            Valitsemasi osakokeet: <span th:text="${partialExamsSV}"></span><br/>
+        </p>
+        <br/>
+
+        <p>
+            Svara inte till detta meddelande, det har skickats automatiskt.
+        </p>
+        <p>
+            Med vänlig hälsning<br/>
+            Utbildningsstyrelsen
+        </p>
+    </body>
+</html>

--- a/backend/vkt/src/main/resources/email-templates/enrollment-to-queue-confirmation.html
+++ b/backend/vkt/src/main/resources/email-templates/enrollment-to-queue-confirmation.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="fi">
+    <body>
+        <p>
+            Hei,
+        </p>
+        <p>
+            Olet ilmoittautunut jonotuspaikalle valtionhallinnon kielitutkintoon. Sinuun ollaan yhteydessä mikäli tutkintotilaisuuteen vapautuu peruutuspaikkoja. Ohessa tiedot ilmoittautumisestasi.
+        </p>
+        <br/>
+
+        <p>
+            Tutkinnon kieli: <span th:text="${examLanguageFI}"></span><br/>
+            Tutkinnon taso: <span th:text="${examLevelFI}"></span><br/>
+            Tutkintopäivä: <span th:text="${examDate}"></span><br/>
+            Valitsemasi taidot: <span th:text="${skillsFI}"></span><br/>
+            Valitsemasi osakokeet: <span th:text="${partialExamsFI}"></span><br/>
+        </p>
+        <br/>
+
+        <p>
+            Älä vastaa tähän viestiin - viesti on lähetetty automaattisesti.
+        </p>
+        <p style="border-bottom: 1px solid black; padding-bottom: 15px;">
+            Ystävällisin terveisin<br/>
+            Opetushallitus
+        </p>
+
+        <p>
+            Hei,
+        </p>
+        <p>
+            Olet ilmoittautunut jonotuspaikalle valtionhallinnon kielitutkintoon. Sinuun ollaan yhteydessä mikäli tutkintotilaisuuteen vapautuu peruutuspaikkoja. Ohessa tiedot ilmoittautumisestasi.
+        </p>
+        <br/>
+
+        <p>
+            Tutkinnon kieli: <span th:text="${examLanguageSV}"></span><br/>
+            Tutkinnon taso: <span th:text="${examLevelSV}"></span><br/>
+            Tutkintopäivä: <span th:text="${examDate}"></span><br/>
+            Valitsemasi taidot: <span th:text="${skillsSV}"></span><br/>
+            Valitsemasi osakokeet: <span th:text="${partialExamsSV}"></span><br/>
+        </p>
+        <br/>
+
+        <p>
+            Svara inte till detta meddelande, det har skickats automatiskt.
+        </p>
+        <p>
+            Med vänlig hälsning<br/>
+            Utbildningsstyrelsen
+        </p>
+    </body>
+</html>

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
@@ -1,0 +1,223 @@
+package fi.oph.vkt.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fi.oph.vkt.Factory;
+import fi.oph.vkt.model.Email;
+import fi.oph.vkt.model.EmailAttachment;
+import fi.oph.vkt.model.EmailType;
+import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Person;
+import fi.oph.vkt.model.type.ExamLanguage;
+import fi.oph.vkt.model.type.ExamLevel;
+import fi.oph.vkt.repository.EmailAttachmentRepository;
+import fi.oph.vkt.repository.EmailRepository;
+import fi.oph.vkt.service.email.EmailService;
+import fi.oph.vkt.service.email.sender.EmailSender;
+import fi.oph.vkt.service.receipt.ReceiptData;
+import fi.oph.vkt.service.receipt.ReceiptItem;
+import fi.oph.vkt.service.receipt.ReceiptRenderer;
+import fi.oph.vkt.util.TemplateRenderer;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WithMockUser
+@DataJpaTest
+public class PublicEnrollmentEmailServiceTest {
+
+  @Resource
+  private EmailRepository emailRepository;
+
+  @Resource
+  private EmailAttachmentRepository emailAttachmentRepository;
+
+  @MockBean
+  private EmailSender emailSender;
+
+  @MockBean
+  private TemplateRenderer templateRenderer;
+
+  @Resource
+  private TestEntityManager entityManager;
+
+  private PublicEnrollmentEmailService publicEnrollmentEmailService;
+
+  @BeforeEach
+  public void setup() throws IOException, InterruptedException {
+    final EmailService emailService = new EmailService(emailRepository, emailAttachmentRepository, emailSender);
+    final ReceiptRenderer receiptRenderer = mock(ReceiptRenderer.class);
+
+    when(receiptRenderer.getReceiptData(anyLong(), any()))
+      .thenReturn(
+        ReceiptData
+          .builder()
+          .dateOfReceipt("20.02.2025")
+          .payerName("Payer")
+          .paymentDate("19.02.2025")
+          .totalAmount("500")
+          .item(ReceiptItem.builder().name("A").value("B").additionalInfos(List.of()).build())
+          .build()
+      );
+    when(receiptRenderer.getReceiptPdfBytes(any())).thenReturn(new byte[] { 'a', 'b', 'c' });
+
+    publicEnrollmentEmailService = new PublicEnrollmentEmailService(emailService, receiptRenderer, templateRenderer);
+  }
+
+  @Test
+  public void testSendEnrollmentConfirmationEmail() throws IOException, InterruptedException {
+    final ExamEvent examEvent = Factory.examEvent();
+    examEvent.setLanguage(ExamLanguage.FI);
+    examEvent.setLevel(ExamLevel.EXCELLENT);
+    examEvent.setDate(LocalDate.of(2025, 3, 12));
+
+    final Person person = Factory.person();
+    person.setFirstName("Foo");
+    person.setLastName("Bar");
+
+    // Enrollment with oral skill and both its partial exams set
+    final Enrollment enrollment = Factory.enrollment(examEvent, person);
+    enrollment.setOralSkill(true);
+    enrollment.setTextualSkill(false);
+    enrollment.setUnderstandingSkill(false);
+    enrollment.setSpeakingPartialExam(true);
+    enrollment.setSpeechComprehensionPartialExam(true);
+    enrollment.setWritingPartialExam(false);
+    enrollment.setReadingComprehensionPartialExam(false);
+    enrollment.setEmail("foo.bar@vkt.test");
+
+    entityManager.persist(examEvent);
+    entityManager.persist(person);
+    entityManager.persist(enrollment);
+
+    final Map<String, Object> expectedTemplateParams = Map.of(
+      "examLanguageFI",
+      "suomi",
+      "examLanguageSV",
+      "finska",
+      "examLevelFI",
+      "erinomainen",
+      "examLevelSV",
+      "utmärkt",
+      "examDate",
+      "12.03.2025",
+      "skillsFI",
+      "suullinen taito",
+      "skillsSV",
+      "suullinen taito",
+      "partialExamsFI",
+      "puhuminen, puheen ymmärtäminen",
+      "partialExamsSV",
+      "puhuminen, puheen ymmärtäminen"
+    );
+
+    when(templateRenderer.renderEnrollmentConfirmationEmailBody(expectedTemplateParams))
+      .thenReturn("<html>enrollment</html>");
+
+    publicEnrollmentEmailService.sendEnrollmentConfirmationEmail(enrollment, person);
+
+    final List<Email> emails = emailRepository.findAll();
+    assertEquals(1, emails.size());
+    final Email email = emails.get(0);
+
+    assertEquals(EmailType.ENROLLMENT_CONFIRMATION, email.getEmailType());
+    assertEquals("Foo Bar", email.getRecipientName());
+    assertEquals("foo.bar@vkt.test", email.getRecipientAddress());
+    assertTrue(email.getSubject().contains("Vahvistus tutkintoon ilmoittautumisesta"));
+    assertEquals("<html>enrollment</html>", email.getBody());
+    assertNull(email.getSentAt());
+    assertNull(email.getError());
+    assertNull(email.getExtId());
+
+    final List<EmailAttachment> attachments = email.getAttachments();
+    assertEquals(2, attachments.size());
+    final EmailAttachment attachment = attachments.get(0);
+
+    assertTrue(attachments.stream().anyMatch(a -> a.getName().equals("Maksukuitti 20.02.2025.pdf")));
+    assertTrue(attachments.stream().anyMatch(a -> a.getName().equals("Betalningkvittot 20.02.2025.pdf")));
+    assertTrue(attachments.stream().allMatch(a -> attachment.getContentType().equals("application/pdf")));
+  }
+
+  @Test
+  public void testSendEnrollmentToQueueConfirmationEmail() throws IOException, InterruptedException {
+    final ExamEvent examEvent = Factory.examEvent();
+    examEvent.setLanguage(ExamLanguage.SV);
+    examEvent.setLevel(ExamLevel.EXCELLENT);
+    examEvent.setDate(LocalDate.of(2025, 3, 12));
+
+    final Person person = Factory.person();
+    person.setFirstName("Foo");
+    person.setLastName("Bar");
+
+    // Enrollment with textual and understanding skills, and all their partial exams set
+    final Enrollment enrollment = Factory.enrollment(examEvent, person);
+    enrollment.setOralSkill(false);
+    enrollment.setTextualSkill(true);
+    enrollment.setUnderstandingSkill(true);
+    enrollment.setSpeakingPartialExam(false);
+    enrollment.setSpeechComprehensionPartialExam(true);
+    enrollment.setWritingPartialExam(true);
+    enrollment.setReadingComprehensionPartialExam(true);
+    enrollment.setEmail("foo.bar@vkt.test");
+
+    entityManager.persist(examEvent);
+    entityManager.persist(person);
+    entityManager.persist(enrollment);
+
+    final Map<String, Object> expectedTemplateParams = Map.of(
+      "examLanguageFI",
+      "ruotsi",
+      "examLanguageSV",
+      "svenska",
+      "examLevelFI",
+      "erinomainen",
+      "examLevelSV",
+      "utmärkt",
+      "examDate",
+      "12.03.2025",
+      "skillsFI",
+      "kirjallinen taito, ymmärtämisen taito",
+      "skillsSV",
+      "kirjallinen taito, ymmärtämisen taito",
+      "partialExamsFI",
+      "kirjoittaminen, tekstin ymmärtäminen, puheen ymmärtäminen",
+      "partialExamsSV",
+      "kirjoittaminen, tekstin ymmärtäminen, puheen ymmärtäminen"
+    );
+
+    when(templateRenderer.renderEnrollmentToQueueConfirmationEmailBody(expectedTemplateParams))
+      .thenReturn("<html>enrollment-to-queue</html>");
+
+    publicEnrollmentEmailService.sendEnrollmentToQueueConfirmationEmail(enrollment, person);
+
+    final List<Email> emails = emailRepository.findAll();
+    assertEquals(1, emails.size());
+    final Email email = emails.get(0);
+
+    assertEquals(EmailType.ENROLLMENT_TO_QUEUE_CONFIRMATION, email.getEmailType());
+    assertEquals("Foo Bar", email.getRecipientName());
+    assertEquals("foo.bar@vkt.test", email.getRecipientAddress());
+    assertTrue(email.getSubject().contains("Vahvistus ilmoittautumisesta tutkinnon jonotuspaikalle"));
+    assertEquals("<html>enrollment-to-queue</html>", email.getBody());
+    assertNull(email.getSentAt());
+    assertNull(email.getError());
+    assertNull(email.getExtId());
+
+    assertEquals(0, email.getAttachments().size());
+  }
+}

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentServiceTest.java
@@ -6,7 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fi.oph.vkt.Factory;
@@ -25,6 +29,7 @@ import fi.oph.vkt.repository.PersonRepository;
 import fi.oph.vkt.repository.ReservationRepository;
 import fi.oph.vkt.util.exception.APIException;
 import fi.oph.vkt.util.exception.APIExceptionType;
+import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -36,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.env.Environment;
 import org.springframework.security.test.context.support.WithMockUser;
 
@@ -54,6 +60,9 @@ public class PublicEnrollmentServiceTest {
   @Resource
   private PersonRepository personRepository;
 
+  @MockBean
+  private PublicEnrollmentEmailService publicEnrollmentEmailServiceMock;
+
   @Resource
   private ReservationRepository reservationRepository;
 
@@ -63,7 +72,10 @@ public class PublicEnrollmentServiceTest {
   private PublicEnrollmentService publicEnrollmentService;
 
   @BeforeEach
-  public void setup() {
+  public void setup() throws IOException, InterruptedException {
+    doNothing().when(publicEnrollmentEmailServiceMock).sendEnrollmentConfirmationEmail(any(), any());
+    doNothing().when(publicEnrollmentEmailServiceMock).sendEnrollmentToQueueConfirmationEmail(any(), any());
+
     final Environment environment = mock(Environment.class);
     when(environment.getRequiredProperty("app.reservation.duration")).thenReturn(ONE_MINUTE.toString());
 
@@ -76,8 +88,9 @@ public class PublicEnrollmentServiceTest {
         enrollmentRepository,
         examEventRepository,
         personRepository,
-        reservationRepository,
-        publicReservationService
+        publicEnrollmentEmailServiceMock,
+        publicReservationService,
+        reservationRepository
       );
   }
 
@@ -302,7 +315,7 @@ public class PublicEnrollmentServiceTest {
   }
 
   @Test
-  public void testCreateEnrollmentWithDigitalCertificateConsent() {
+  public void testCreateEnrollmentWithDigitalCertificateConsent() throws IOException, InterruptedException {
     final ExamEvent examEvent = Factory.examEvent();
     final Person person = Factory.person();
     final Reservation reservation = Factory.reservation(examEvent, person);
@@ -317,10 +330,13 @@ public class PublicEnrollmentServiceTest {
     assertCreatedEnrollment(EnrollmentStatus.PAID, dto);
 
     assertEquals(0, reservationRepository.count());
+
+    verify(publicEnrollmentEmailServiceMock, times(1)).sendEnrollmentConfirmationEmail(any(), any());
+    verify(publicEnrollmentEmailServiceMock, times(0)).sendEnrollmentToQueueConfirmationEmail(any(), any());
   }
 
   @Test
-  public void testCreateEnrollmentWithoutDigitalCertificateConsent() {
+  public void testCreateEnrollmentWithoutDigitalCertificateConsent() throws IOException, InterruptedException {
     final ExamEvent examEvent = Factory.examEvent();
     final Person person = Factory.person();
     final Reservation reservation = Factory.reservation(examEvent, person);
@@ -333,6 +349,9 @@ public class PublicEnrollmentServiceTest {
 
     publicEnrollmentService.createEnrollment(dto, reservation.getId(), person);
     assertCreatedEnrollment(EnrollmentStatus.PAID, dto);
+
+    verify(publicEnrollmentEmailServiceMock, times(1)).sendEnrollmentConfirmationEmail(any(), any());
+    verify(publicEnrollmentEmailServiceMock, times(0)).sendEnrollmentToQueueConfirmationEmail(any(), any());
   }
 
   private PublicEnrollmentCreateDTO.PublicEnrollmentCreateDTOBuilder createDTOBuilder() {
@@ -387,7 +406,7 @@ public class PublicEnrollmentServiceTest {
   }
 
   @Test
-  public void testCreateEnrollmentToQueue() {
+  public void testCreateEnrollmentToQueue() throws IOException, InterruptedException {
     final ExamEvent examEvent = Factory.examEvent();
     final Person person = Factory.person();
 
@@ -398,5 +417,8 @@ public class PublicEnrollmentServiceTest {
 
     publicEnrollmentService.createEnrollmentToQueue(dto, examEvent.getId(), person.getId());
     assertCreatedEnrollment(EnrollmentStatus.QUEUED, dto);
+
+    verify(publicEnrollmentEmailServiceMock, times(0)).sendEnrollmentConfirmationEmail(any(), any());
+    verify(publicEnrollmentEmailServiceMock, times(1)).sendEnrollmentToQueueConfirmationEmail(any(), any());
   }
 }

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/email/sender/EmailSenderViestintapalveluTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/email/sender/EmailSenderViestintapalveluTest.java
@@ -54,6 +54,7 @@ class EmailSenderViestintapalveluTest {
       .recipientAddress("vastaanottaja@invalid")
       .subject("testiotsikko")
       .body("testiviesti")
+      .attachments(List.of())
       .build();
 
     final String extId = sender.sendEmail(emailData);

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererTest.java
@@ -7,8 +7,12 @@ import fi.oph.vkt.Factory;
 import fi.oph.vkt.model.Enrollment;
 import fi.oph.vkt.model.ExamEvent;
 import fi.oph.vkt.model.Person;
+import fi.oph.vkt.model.type.ExamLanguage;
+import fi.oph.vkt.model.type.ExamLevel;
 import fi.oph.vkt.repository.EnrollmentRepository;
 import fi.oph.vkt.util.TemplateRenderer;
+import fi.oph.vkt.util.localisation.Language;
+import java.time.LocalDate;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,11 +25,11 @@ import org.springframework.security.test.context.support.WithMockUser;
 @DataJpaTest
 class ReceiptRendererTest {
 
-  @MockBean
-  private TemplateRenderer templateRenderer;
-
   @Resource
   private EnrollmentRepository enrollmentRepository;
+
+  @MockBean
+  private TemplateRenderer templateRenderer;
 
   @Resource
   private TestEntityManager entityManager;
@@ -34,20 +38,37 @@ class ReceiptRendererTest {
 
   @BeforeEach
   public void setup() {
-    receiptRenderer = new ReceiptRenderer(templateRenderer, enrollmentRepository);
+    receiptRenderer = new ReceiptRenderer(enrollmentRepository, templateRenderer);
   }
 
   @Test
   public void testGetReceiptData() {
     final ExamEvent examEvent = Factory.examEvent();
+    examEvent.setLanguage(ExamLanguage.SV);
+    examEvent.setLevel(ExamLevel.EXCELLENT);
+    examEvent.setDate(LocalDate.of(2024, 10, 7));
+
     final Person person = Factory.person();
+    person.setFirstName("Foo");
+    person.setLastName("Bar");
+
     final Enrollment enrollment = Factory.enrollment(examEvent, person);
+
     entityManager.persist(examEvent);
     entityManager.persist(person);
     entityManager.persist(enrollment);
 
-    final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId());
+    final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId(), Language.FI);
     assertNotNull(receiptData);
+    assertEquals("Bar, Foo", receiptData.payerName());
     assertEquals("454 €", receiptData.totalAmount());
+
+    final ReceiptItem receiptItem = receiptData.item();
+    assertEquals("Valtionhallinnon kielitutkinnot (VKT), tutkintomaksu", receiptItem.name());
+    assertEquals("454 €", receiptItem.value());
+
+    assertEquals(2, receiptItem.additionalInfos().size());
+    assertEquals("Ruotsi, erinomainen, 07.10.2024", receiptItem.additionalInfos().get(0));
+    assertEquals("Osallistuja: Bar, Foo", receiptData.item().additionalInfos().get(1));
   }
 }

--- a/backend/vkt/src/test/java/fi/oph/vkt/util/TemplateRendererTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/util/TemplateRendererTest.java
@@ -1,5 +1,6 @@
 package fi.oph.vkt.util;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -16,6 +17,52 @@ class TemplateRendererTest {
 
   @Resource
   private TemplateRenderer templateRenderer;
+
+  @Test
+  public void testRenderEnrollmentConfirmation() {
+    final Map<String, Object> params = getCommonEnrollmentConfirmationParams();
+    final String content = templateRenderer.renderEnrollmentConfirmationEmailBody(params);
+
+    assertCommonEnrollmentConfirmationEmailContent(content);
+    assertTrue(content.contains("maksukuitti"));
+  }
+
+  @Test
+  public void testRenderEnrollmentToQueueConfirmation() {
+    final Map<String, Object> params = getCommonEnrollmentConfirmationParams();
+    final String content = templateRenderer.renderEnrollmentToQueueConfirmationEmailBody(params);
+
+    assertCommonEnrollmentConfirmationEmailContent(content);
+    assertFalse(content.contains("maksukuitti"));
+  }
+
+  private Map<String, Object> getCommonEnrollmentConfirmationParams() {
+    return Map.of(
+      "examLanguageFI",
+      "suomi",
+      "examLevelFI",
+      "erinomainen",
+      "examDate",
+      "10.06.2023",
+      "skillsFI",
+      "kirjallinen taito, suullinen taito",
+      "partialExamsFI",
+      "kirjoittaminen, tekstin ymmärtäminen, puhuminen",
+      "examLanguageSV",
+      "finska"
+    );
+  }
+
+  private void assertCommonEnrollmentConfirmationEmailContent(final String emailContent) {
+    assertNotNull(emailContent);
+    assertTrue(emailContent.contains("<html "));
+    assertTrue(emailContent.contains("suomi"));
+    assertTrue(emailContent.contains("erinomainen"));
+    assertTrue(emailContent.contains("10.06.2023"));
+    assertTrue(emailContent.contains("kirjallinen taito, suullinen taito"));
+    assertTrue(emailContent.contains("kirjoittaminen, tekstin ymmärtäminen, puhuminen"));
+    assertTrue(emailContent.contains("finska"));
+  }
 
   @Test
   public void testRenderReceipt() {


### PR DESCRIPTION
## Yhteenveto

Ilmoittautuessa tutkintotilaisuuteen lähetetään tästä vahvistusmaili maksukuitin kera. Jos taas ilmoittautuu jonoon / varasijalle, lähtee tästä hieman erilainen vahvistusmaili, jossa tosin pääpiirteittäin samanlainen sisältö. Katsotaan virkailijoiden kanssa noihin sopivat sisällöt ja että onko tarvetta englanninkieliselle versiolle. Eri kieliset maksukuitit tarttis varmaan myös toteuttaa ja tästä toinen tiketti OPHVKTKEH-147 boardilla.

Maksukuitin generointia varten oli jo toiminto olemassa niin riitti luoda sähköpostipohja ja lisätä kuitin tulostus vain ilmoittautumisputkeen.

Versio commitista 330cb21 pallerolla nyt ajossa.
