### PR TITLE
SHARED:VKT(Frontend): OPHVKTKEH-158 navigaation blokkauksen päivitys

### DIFF
--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.9.6] - 2023-05-17
+
+### Changed
+
+- useNavigationProtection now accepts baseUrl parameter
+
 ## [1.9.5] - 2023-05-11
 
 ### Changed

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/hooks/useNavigationProtection/useBlocker.ts
+++ b/frontend/packages/shared/src/hooks/useNavigationProtection/useBlocker.ts
@@ -8,7 +8,11 @@ import { UNSAFE_NavigationContext } from 'react-router';
 // added back to a recent version of react-router v6.
 // For reference, see the issue at https://github.com/remix-run/react-router/issues/8139
 
-export const useBlocker = (blocker: Blocker, when: boolean) => {
+export const useBlocker = (
+  blocker: Blocker,
+  when: boolean,
+  baseUrl?: string
+) => {
   const navigator = useContext(UNSAFE_NavigationContext).navigator as History;
 
   useEffect(() => {
@@ -21,10 +25,18 @@ export const useBlocker = (blocker: Blocker, when: boolean) => {
             tx.retry();
           },
         };
-        blocker(autoUnblockingTx);
+        if (
+          !baseUrl ||
+          !autoUnblockingTx.location.pathname.includes(baseUrl) ||
+          autoUnblockingTx.action === 'PUSH'
+        ) {
+          blocker(autoUnblockingTx);
+        } else {
+          autoUnblockingTx.retry();
+        }
       });
 
       return unblock;
     }
-  }, [navigator, blocker, when]);
+  }, [navigator, blocker, when, baseUrl]);
 };

--- a/frontend/packages/shared/src/hooks/useNavigationProtection/useNavigationProtection.ts
+++ b/frontend/packages/shared/src/hooks/useNavigationProtection/useNavigationProtection.ts
@@ -7,10 +7,13 @@ export const useNavigationProtection = (
   showConfirmationDialog: (
     confirmNavigation: () => void,
     cancelNavigation: () => void
-  ) => void
+  ) => void,
+  baseUrl?: string
 ) => {
-  const { showPrompt, confirmNavigation, cancelNavigation } =
-    useCallbackPrompt(when);
+  const { showPrompt, confirmNavigation, cancelNavigation } = useCallbackPrompt(
+    when,
+    baseUrl
+  );
 
   useEffect(() => {
     if (showPrompt) {

--- a/frontend/packages/vkt/package.json
+++ b/frontend/packages/vkt/package.json
@@ -25,6 +25,6 @@
     "vkt:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.5"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.6"
   }
 }

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -13,7 +13,7 @@ import { PublicEnrollmentTimer } from 'components/publicEnrollment/PublicEnrollm
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
 import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
-//import { useNavigationProtection } from 'hooks/useNavigationProtection';
+import { useNavigationProtection } from 'hooks/useNavigationProtection';
 import {
   loadPublicEnrollment,
   resetPublicEnrollment,
@@ -68,13 +68,13 @@ export const PublicEnrollmentGrid = ({
     }
   }, [cancelStatus, navigate, dispatch]);
 
-  /*
   useNavigationProtection(
     activeStep > PublicEnrollmentFormStep.Authenticate &&
       activeStep < PublicEnrollmentFormStep.Preview &&
-      cancelStatus === APIResponseStatus.NotStarted
+      cancelStatus === APIResponseStatus.NotStarted,
+    '/vkt/ilmoittaudu'
   );
-  */
+
   const isLoading = [status].includes(APIResponseStatus.InProgress);
   const isPreviewStepActive = activeStep === PublicEnrollmentFormStep.Preview;
   const isDoneStepActive = activeStep >= PublicEnrollmentFormStep.Done;

--- a/frontend/packages/vkt/src/hooks/useNavigationProtection.ts
+++ b/frontend/packages/vkt/src/hooks/useNavigationProtection.ts
@@ -7,7 +7,7 @@ import {
 
 import { useCommonTranslation } from 'configs/i18n';
 
-export const useNavigationProtection = (when: boolean) => {
+export const useNavigationProtection = (when: boolean, baseUrl?: string) => {
   const translateCommon = useCommonTranslation();
   const { showDialog } = useDialog();
 
@@ -35,5 +35,5 @@ export const useNavigationProtection = (when: boolean) => {
     [showDialog, translateCommon]
   );
 
-  useCommonNavigationProtection(when, showConfirmationDialog);
+  useCommonNavigationProtection(when, showConfirmationDialog, baseUrl);
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2786,7 +2786,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.5":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.6":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -2796,7 +2796,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.vkt@workspace:packages/vkt"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.5"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.6"
   languageName: unknown
   linkType: soft
 
@@ -11806,6 +11806,13 @@ __metadata:
   dependencies:
     kind-of: ^6.0.2
   checksum: 39b3dd9630a774aba288a680e7d2901f5c0eae7b8387fc5c8ea559918b29b3da144b7bdb990d7ccd9e11be05508ac9e459ce51d01fd65e583282f6ffafcba2e7
+  languageName: node
+  linkType: hard
+
+"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.5":
+  version: 1.9.5
+  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.9.5::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.9.5%2Fd847aa514c13127f9f0625e424d711370704e601"
+  checksum: 936e0c26a09b1f8462f30e42a6dbc6bacf712daf24f5de071299a1a294920219f12035ee2613cb91806c6e5b658ef29646da7b9b26dd342fc967a237ecbd3ee5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Navigation Protection ottaa nyt vastaan optionaalisen baseUrl:n ja mikäli navikoidessa sekä vanhasta, että uudesta osoitteesta löytyy sama base, annetaan navigoinnin tapahtua ilman varoitusta / modaalia.

## Check-lista

- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
