### PR TITLE
AKR(Frontend): ordered some localisations for re-deploying image similar to ga-875

### DIFF
--- a/frontend/packages/akr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/akr/public/i18n/fi-FI/translation.json
@@ -466,12 +466,12 @@
         "title": "Valitettavasti etsimääsi sivua ei löytynyt"
       },
       "statisticsPage": {
-        "title": "Tilastojen lataus",
         "contactRequests": "Yhteydenottopyynnöt",
+        "daily": "Päivittäin",
         "emails": "Sähköpostit",
-        "yearly": "Vuosittain",
         "monthly": "Kuukausittain",
-        "daily": "Päivittäin"
+        "title": "Tilastojen lataus",
+        "yearly": "Vuosittain"
       },
       "translator": {
         "languagePairs": "Kieliparit",


### PR DESCRIPTION
Järjestetty uudelleen suomenkielisiä lokalisaatioita virkailijan tilastointisivulla, näihin ei ollutkaan käännöksiä muille kieilille. Tän kun mergaa niin saa sopivan tuotantoversion pallerolle ajoon.