### PR TITLE
VKT(Backend): OPHVKTKEH-155 & -162 ruotsinkielinen kuitti ja kuitin maksun erittely

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/api/clerk/ClerkEnrollmentController.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/clerk/ClerkEnrollmentController.java
@@ -81,7 +81,9 @@ public class ClerkEnrollmentController {
 
     // TODO: possibility to download swedish receipt?
     final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollmentId, Language.FI);
-    final ByteArrayInputStream bis = new ByteArrayInputStream(receiptRenderer.getReceiptPdfBytes(receiptData));
+    final ByteArrayInputStream bis = new ByteArrayInputStream(
+      receiptRenderer.getReceiptPdfBytes(Language.FI, receiptData)
+    );
     return ResponseEntity.ok().body(new InputStreamResource(bis));
   }
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/clerk/ClerkEnrollmentController.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/clerk/ClerkEnrollmentController.java
@@ -80,9 +80,11 @@ public class ClerkEnrollmentController {
     response.addHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
 
     // TODO: possibility to download swedish receipt?
-    final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollmentId, Language.FI);
+    final Language receiptLanguage = Language.FI;
+
+    final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollmentId, receiptLanguage);
     final ByteArrayInputStream bis = new ByteArrayInputStream(
-      receiptRenderer.getReceiptPdfBytes(Language.FI, receiptData)
+      receiptRenderer.getReceiptPdfBytes(receiptData, receiptLanguage)
     );
     return ResponseEntity.ok().body(new InputStreamResource(bis));
   }

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
@@ -40,7 +40,8 @@ public class PublicEnrollmentEmailService {
 
     final String recipientName = person.getFirstName() + " " + person.getLastName();
     final String recipientAddress = enrollment.getEmail();
-    final String subject = "Vahvistus tutkintoon ilmoittautumisesta | Samma på svenska";
+    final String subject =
+      "Vahvistus ilmoittautumisesta Valtionhallinnon kielitutkintoon (VKT) | Bekräftelse av anmälan till Språkexamen för statsförvaltningen (VKT)";
     final String body = templateRenderer.renderEnrollmentConfirmationEmailBody(templateParams);
 
     final List<EmailAttachmentData> attachments = environment.getRequiredProperty(
@@ -59,7 +60,8 @@ public class PublicEnrollmentEmailService {
 
     final String recipientName = person.getFirstName() + " " + person.getLastName();
     final String recipientAddress = enrollment.getEmail();
-    final String subject = "Vahvistus ilmoittautumisesta tutkinnon jonotuspaikalle | Samma på svenska";
+    final String subject =
+      "Vahvistus ilmoittautumisesta jonotuspaikalle Valtionhallinnon kielitutkintoon (VKT) | Bekräftelse av plats i kön för Språkexamen för statsförvaltningen (VKT)";
     final String body = templateRenderer.renderEnrollmentToQueueConfirmationEmailBody(templateParams);
 
     createEmail(recipientName, recipientAddress, subject, body, List.of(), EmailType.ENROLLMENT_TO_QUEUE_CONFIRMATION);
@@ -78,8 +80,8 @@ public class PublicEnrollmentEmailService {
       params.put("examLanguageSV", "svenska");
     }
 
-    params.put("examLevelFI", "erinomainen");
-    params.put("examLevelSV", "utmärkt");
+    params.put("examLevelFI", "erinomainen taito");
+    params.put("examLevelSV", "utmärkta språkkunskaper");
 
     params.put("examDate", examEvent.getDate().format(DateTimeFormatter.ofPattern("dd.MM.yyyy")));
 
@@ -93,13 +95,15 @@ public class PublicEnrollmentEmailService {
         )
       )
     );
+
+    final String examLanguageSV = (String) params.get("examLanguageSV");
     params.put(
       "skillsSV",
       joinNonEmptyStrings(
         Stream.of(
-          enrollment.isTextualSkill() ? "kirjallinen taito" : "",
-          enrollment.isOralSkill() ? "suullinen taito" : "",
-          enrollment.isUnderstandingSkill() ? "ymmärtämisen taito" : ""
+          enrollment.isTextualSkill() ? "förmåga att använda " + examLanguageSV + " i skrift" : "",
+          enrollment.isOralSkill() ? "förmåga att använda " + examLanguageSV + " i tal" : "",
+          enrollment.isUnderstandingSkill() ? "förmåga att förstå " + examLanguageSV : ""
         )
       )
     );
@@ -119,10 +123,10 @@ public class PublicEnrollmentEmailService {
       "partialExamsSV",
       joinNonEmptyStrings(
         Stream.of(
-          enrollment.isWritingPartialExam() ? "kirjoittaminen" : "",
-          enrollment.isReadingComprehensionPartialExam() ? "tekstin ymmärtäminen" : "",
-          enrollment.isSpeakingPartialExam() ? "puhuminen" : "",
-          enrollment.isSpeechComprehensionPartialExam() ? "puheen ymmärtäminen" : ""
+          enrollment.isWritingPartialExam() ? "skriftlig färdighet" : "",
+          enrollment.isReadingComprehensionPartialExam() ? "textförståelse" : "",
+          enrollment.isSpeakingPartialExam() ? "muntlig färdighet" : "",
+          enrollment.isSpeechComprehensionPartialExam() ? "hörförståelse" : ""
         )
       )
     );

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
@@ -143,7 +143,7 @@ public class PublicEnrollmentEmailService {
     final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId(), language);
     final byte[] receiptBytes = receiptRenderer.getReceiptPdfBytes(receiptData, language);
 
-    final String attachmentNamePrefix = language == Language.FI ? "Maksukuitti" : "Betalningkvitto";
+    final String attachmentNamePrefix = language == Language.FI ? "Maksukuitti" : "Betalningskvitto";
 
     return EmailAttachmentData
       .builder()

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
@@ -143,7 +143,7 @@ public class PublicEnrollmentEmailService {
     final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId(), language);
     final byte[] receiptBytes = receiptRenderer.getReceiptPdfBytes(language, receiptData);
 
-    final String attachmentNamePrefix = language == Language.FI ? "Maksukuitti" : "Betalningkvittot";
+    final String attachmentNamePrefix = language == Language.FI ? "Maksukuitti" : "Betalningkvitto";
 
     return EmailAttachmentData
       .builder()

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
@@ -141,13 +141,13 @@ public class PublicEnrollmentEmailService {
   private EmailAttachmentData createReceiptAttachment(final Enrollment enrollment, final Language language)
     throws IOException, InterruptedException {
     final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId(), language);
-    final byte[] receiptBytes = receiptRenderer.getReceiptPdfBytes(receiptData);
+    final byte[] receiptBytes = receiptRenderer.getReceiptPdfBytes(language, receiptData);
 
     final String attachmentNamePrefix = language == Language.FI ? "Maksukuitti" : "Betalningkvittot";
 
     return EmailAttachmentData
       .builder()
-      .name(attachmentNamePrefix + " " + receiptData.dateOfReceipt() + ".pdf")
+      .name(attachmentNamePrefix + " " + receiptData.date() + ".pdf")
       .contentType("application/pdf")
       .data(receiptBytes)
       .build();

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentEmailService.java
@@ -141,7 +141,7 @@ public class PublicEnrollmentEmailService {
   private EmailAttachmentData createReceiptAttachment(final Enrollment enrollment, final Language language)
     throws IOException, InterruptedException {
     final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId(), language);
-    final byte[] receiptBytes = receiptRenderer.getReceiptPdfBytes(language, receiptData);
+    final byte[] receiptBytes = receiptRenderer.getReceiptPdfBytes(receiptData, language);
 
     final String attachmentNamePrefix = language == Language.FI ? "Maksukuitti" : "Betalningkvitto";
 

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptData.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptData.java
@@ -8,6 +8,7 @@ import lombok.NonNull;
 public record ReceiptData(
   @NonNull String date,
   @NonNull String paymentDate,
+  @NonNull String paymentReference,
   @NonNull String exam,
   @NonNull String participant,
   @NonNull String totalAmount,

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptData.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptData.java
@@ -8,7 +8,6 @@ import lombok.NonNull;
 public record ReceiptData(
   @NonNull String date,
   @NonNull String paymentDate,
-  @NonNull String payer,
   @NonNull String exam,
   @NonNull String participant,
   @NonNull String totalAmount,

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptData.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptData.java
@@ -1,13 +1,16 @@
 package fi.oph.vkt.service.receipt;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.NonNull;
 
 @Builder
 public record ReceiptData(
-  @NonNull String dateOfReceipt,
-  @NonNull String payerName,
+  @NonNull String date,
   @NonNull String paymentDate,
+  @NonNull String payer,
+  @NonNull String exam,
+  @NonNull String participant,
   @NonNull String totalAmount,
-  @NonNull ReceiptItem item
+  @NonNull List<ReceiptItem> items
 ) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptItem.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptItem.java
@@ -1,8 +1,7 @@
 package fi.oph.vkt.service.receipt;
 
-import java.util.List;
 import lombok.Builder;
 import lombok.NonNull;
 
 @Builder
-public record ReceiptItem(@NonNull String name, @NonNull String value, @NonNull List<String> additionalInfos) {}
+public record ReceiptItem(@NonNull String name, @NonNull String amount) {}

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
@@ -47,6 +47,7 @@ public class ReceiptRenderer {
 
     final String date = DATE_FORMAT.format(LocalDate.now());
     final String paymentDate = DATE_FORMAT.format(payment.getModifiedAt());
+    final String paymentReference = payment.getReference();
 
     final String exam = String.format(
       "%s, %s, %s",
@@ -63,6 +64,7 @@ public class ReceiptRenderer {
       .builder()
       .date(date)
       .paymentDate(paymentDate)
+      .paymentReference(paymentReference)
       .exam(exam)
       .participant(participant)
       .totalAmount(totalAmount)

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
@@ -105,7 +105,7 @@ public class ReceiptRenderer {
             ? ReceiptItem
               .builder()
               .name(language == Language.FI ? "Kirjallinen taito" : "Förmåga att använda svenska i skrift")
-              .amount("227 €")
+              .amount(String.format("%s €", EnrollmentUtil.getTextualSkillFee(enrollment) / 100))
               .build()
             : null
         ),
@@ -114,7 +114,7 @@ public class ReceiptRenderer {
             ? ReceiptItem
               .builder()
               .name(language == Language.FI ? "Suullinen taito" : "Förmåga att använda svenska i tal")
-              .amount("227 €")
+              .amount(String.format("%s €", EnrollmentUtil.getOralSkillFee(enrollment) / 100))
               .build()
             : null
         ),
@@ -123,7 +123,7 @@ public class ReceiptRenderer {
             ? ReceiptItem
               .builder()
               .name(language == Language.FI ? "Ymmärtämisen taito" : "Förmåga att förstå svenska")
-              .amount(EnrollmentUtil.isUnderstandingSkillFree(enrollment) ? "0 €" : "227 €")
+              .amount(String.format("%s €", EnrollmentUtil.getUnderstandingSkillFee(enrollment) / 100))
               .build()
             : null
         )

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
@@ -48,13 +48,13 @@ public class ReceiptRenderer {
     final String date = DATE_FORMAT.format(LocalDate.now());
     final String paymentDate = DATE_FORMAT.format(payment.getModifiedAt());
 
-    final String payer = String.format("%s, %s", person.getLastName(), person.getFirstName());
     final String exam = String.format(
       "%s, %s, %s",
       getLang(examLanguage, receiptLanguage),
       getLevelDescription(examEvent, receiptLanguage),
       DATE_FORMAT.format(examEvent.getDate())
     );
+    final String participant = String.format("%s, %s", person.getLastName(), person.getFirstName());
     final String totalAmount = String.format("%s €", payment.getAmount() / 100);
 
     final List<ReceiptItem> items = getReceiptItems(enrollment, examLanguage, receiptLanguage);
@@ -63,9 +63,8 @@ public class ReceiptRenderer {
       .builder()
       .date(date)
       .paymentDate(paymentDate)
-      .payer(payer)
       .exam(exam)
-      .participant(payer)
+      .participant(participant)
       .totalAmount(totalAmount)
       .items(items)
       .build();

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/receipt/ReceiptRenderer.java
@@ -77,7 +77,7 @@ public class ReceiptRenderer {
       return "Suomi";
     } else if (examLanguage == ExamLanguage.FI && receiptLanguage == Language.SV) {
       return "Finska";
-    } else if (examLanguage == ExamLanguage.SV & receiptLanguage == Language.FI) {
+    } else if (examLanguage == ExamLanguage.SV && receiptLanguage == Language.FI) {
       return "Ruotsi";
     } else if (examLanguage == ExamLanguage.SV && receiptLanguage == Language.SV) {
       return "Svenska";

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/EnrollmentUtil.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/EnrollmentUtil.java
@@ -5,11 +5,25 @@ import fi.oph.vkt.model.type.ExamLevel;
 
 public class EnrollmentUtil {
 
-  public static boolean isUnderstandingSkillFree(final Enrollment enrollment) {
+  private static final int SKILL_FEE = 22700;
+
+  public static int getTotalFee(final Enrollment enrollment) {
+    return getTextualSkillFee(enrollment) + getOralSkillFee(enrollment) + getUnderstandingSkillFee(enrollment);
+  }
+
+  public static int getTextualSkillFee(final Enrollment enrollment) {
+    return enrollment.isTextualSkill() ? SKILL_FEE : 0;
+  }
+
+  public static int getOralSkillFee(final Enrollment enrollment) {
+    return enrollment.isOralSkill() ? SKILL_FEE : 0;
+  }
+
+  public static int getUnderstandingSkillFee(final Enrollment enrollment) {
     if (enrollment.isTextualSkill() && enrollment.isOralSkill()) {
-      return true;
+      return 0;
     }
 
-    return enrollment.getExamEvent().getLevel() == ExamLevel.EXCELLENT;
+    return enrollment.getExamEvent().getLevel() == ExamLevel.EXCELLENT ? 0 : SKILL_FEE;
   }
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/EnrollmentUtil.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/EnrollmentUtil.java
@@ -1,15 +1,15 @@
 package fi.oph.vkt.util;
 
 import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.model.type.ExamLevel;
 
 public class EnrollmentUtil {
 
-  public static int calculateExaminationPaymentSum(final Enrollment enrollment) {
-    final int baseValue = 227;
-    final int count =
-      (enrollment.isOralSkill() ? 1 : 0) +
-      (enrollment.isTextualSkill() ? 1 : 0) +
-      (enrollment.isUnderstandingSkill() ? 1 : 0);
-    return baseValue * Math.min(count, 2);
+  public static boolean isUnderstandingSkillFree(final Enrollment enrollment) {
+    if (enrollment.isTextualSkill() && enrollment.isOralSkill()) {
+      return true;
+    }
+
+    return enrollment.getExamEvent().getLevel() == ExamLevel.EXCELLENT;
   }
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/TemplateRenderer.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/TemplateRenderer.java
@@ -1,5 +1,6 @@
 package fi.oph.vkt.util;
 
+import fi.oph.vkt.util.localisation.Language;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,8 +21,11 @@ public class TemplateRenderer {
     return renderTemplate("enrollment-to-queue-confirmation", params);
   }
 
-  public String renderReceipt(final Map<String, Object> params) {
-    return renderTemplate("receipt", params);
+  public String renderReceipt(final Language language, final Map<String, Object> params) {
+    return switch (language) {
+      case FI -> renderTemplate("receipt_fi-FI", params);
+      case SV -> renderTemplate("receipt_sv-SE", params);
+    };
   }
 
   private String renderTemplate(final String template, final Map<String, Object> params) {

--- a/backend/vkt/src/main/resources/email-templates/enrollment-confirmation.html
+++ b/backend/vkt/src/main/resources/email-templates/enrollment-confirmation.html
@@ -5,16 +5,24 @@
             Hei,
         </p>
         <p>
-            Olet ilmoittautunut valtionhallinnon kielitutkintoon. Ohessa tiedot ilmoittautumisestasi. Liitteenä myös maksukuitti suomeksi ja ruotsiksi.
+            Olet ilmoittautunut Valtionhallinnon kielitutkintoon. Ohessa tiedot ilmoittautumisestasi. Liitteenä myös maksukuitti suomeksi ja ruotsiksi.
         </p>
         <br/>
 
         <p>
-            Tutkinnon kieli: <span th:text="${examLanguageFI}"></span><br/>
-            Tutkinnon taso: <span th:text="${examLevelFI}"></span><br/>
-            Tutkintopäivä: <span th:text="${examDate}"></span><br/>
-            Valitsemasi taidot: <span th:text="${skillsFI}"></span><br/>
-            Valitsemasi osakokeet: <span th:text="${partialExamsFI}"></span><br/>
+            <b>Tutkinnon kieli:</b> <span th:text="${examLanguageFI}"></span><br/>
+            <b>Tutkinnon taso:</b> <span th:text="${examLevelFI}"></span><br/>
+            <b>Tutkintopäivä:</b> <span th:text="${examDate}"></span><br/>
+            <b>Valitsemasi taidot:</b> <span th:text="${skillsFI}"></span><br/>
+            <b>Valitsemasi osakokeet:</b> <span th:text="${partialExamsFI}"></span><br/>
+        </p>
+        <br/>
+
+        <p>Saat tarkemmat ohjeet tutkintopäivän kulusta viikkoa ennen tutkintopäivää.</p>
+        <p>Jos sinulla on kysyttävää tutkinnosta, voit lähettää meille sähköpostia osoitteeseen <a href="mailto:kielitutkinnot@oph.fi">kielitutkinnot@oph.fi</a>. Ilmoitathan viipymättä, jos et pysty osallistumaan tutkintoon.</p>
+        <p>
+            Lisätietoa tutkinnosta löydät Opetushallituksen verkkopalvelusta:<br/>
+            <a href="https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/valtionhallinnon-kielitutkinnot">Valtionhallinnon kielitutkinnot (VKT)</a>
         </p>
         <br/>
 
@@ -27,24 +35,32 @@
         </p>
 
         <p>
-            Hei,
+            Hej,
         </p>
         <p>
-            Olet ilmoittautunut valtionhallinnon kielitutkintoon. Ohessa tiedot ilmoittautumisestasi. Liitteenä myös maksukuitti suomeksi ja ruotsiksi.
-        </p>
-        <br/>
-
-        <p>
-            Tutkinnon kieli: <span th:text="${examLanguageSV}"></span><br/>
-            Tutkinnon taso: <span th:text="${examLevelSV}"></span><br/>
-            Tutkintopäivä: <span th:text="${examDate}"></span><br/>
-            Valitsemasi taidot: <span th:text="${skillsSV}"></span><br/>
-            Valitsemasi osakokeet: <span th:text="${partialExamsSV}"></span><br/>
+            Du har anmält dig till Språkexamen för statsförvaltningen (VKT). Uppgifter om din anmälan hittar du nedan. Bifogat finns även kvittot för din examensavgift på finska och på svenska.
         </p>
         <br/>
 
         <p>
-            Svara inte till detta meddelande, det har skickats automatiskt.
+            <b>Examensspråk:</b> <span th:text="${examLanguageSV}"></span><br/>
+            <b>Examensnivå:</b> <span th:text="${examLevelSV}"></span><br/>
+            <b>Examensdatum:</b> <span th:text="${examDate}"></span><br/>
+            <b>Förmågor som du har valt:</b> <span th:text="${skillsSV}"></span><br/>
+            <b>Delprov som du har valt:</b> <span th:text="${partialExamsSV}"></span><br/>
+        </p>
+        <br/>
+
+        <p>Du får närmare anvisningar om examensdagens program en vecka före examensdagen.</p>
+        <p>Om du har frågor om examen, kan du kontakta oss per e-post på adressen <a href="mailto:kielitutkinnot@oph.fi">kielitutkinnot@oph.fi</a>. Vänligen meddela omedelbart om du inte kan delta i examen.</p>
+        <p>
+            Närmare information om examen finns på Utbildningsstyrelsens webbplats:<br/>
+            <a href="https://www.oph.fi/sv/tjanster/statsforvaltningens-sprakexamina">Språkexamina för statsförvaltningen (VKT)</a>
+        </p>
+        <br/>
+
+        <p>
+            Svara inte på detta meddelande, det har skickats automatiskt.
         </p>
         <p>
             Med vänlig hälsning<br/>

--- a/backend/vkt/src/main/resources/email-templates/enrollment-confirmation.html
+++ b/backend/vkt/src/main/resources/email-templates/enrollment-confirmation.html
@@ -18,11 +18,12 @@
         </p>
         <br/>
 
-        <p>Saat tarkemmat ohjeet tutkintopäivän kulusta viikkoa ennen tutkintopäivää.</p>
+        <p>Tutkintotilaisuus järjestetään Opetushallituksen tiloissa osoitteessa Hakaniemenranta 6, 00530 Helsinki.</p>
+        <p>Tutkinnon suorittamiseen kannattaa varata koko päivä. Tutkintotilaisuus alkaa klo 9.00 kirjallisen taidon tutkinnolla ja jatkuu iltapäivällä suullisen taidon tutkinnolla. Tutkinnon päättymisaika riippuu tutkintoon osallistuvien määrästä. Saat tarkemmat ohjeet tutkintopäivän kulusta viikkoa ennen tutkintopäivää.</p>
         <p>Jos sinulla on kysyttävää tutkinnosta, voit lähettää meille sähköpostia osoitteeseen <a href="mailto:kielitutkinnot@oph.fi">kielitutkinnot@oph.fi</a>. Ilmoitathan viipymättä, jos et pysty osallistumaan tutkintoon.</p>
         <p>
             Lisätietoa tutkinnosta löydät Opetushallituksen verkkopalvelusta:<br/>
-            <a href="https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/valtionhallinnon-kielitutkinnot">Valtionhallinnon kielitutkinnot (VKT)</a>
+            <a href="https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/valtionhallinnon-kielitutkinnot" target="_blank">Valtionhallinnon kielitutkinnot (VKT)</a>
         </p>
         <br/>
 
@@ -51,11 +52,12 @@
         </p>
         <br/>
 
-        <p>Du får närmare anvisningar om examensdagens program en vecka före examensdagen.</p>
+        <p>Examenstillfället anordnas hos Utbildningsstyrelsen på adressen Hagnäskajen 6, 00530 Helsingfors.</p>
+        <p>Det är skäl att reservera hela dagen för examen. Examenstillfället börjar klockan 9.00 med provet i skriftlig förmåga och fortsätter på eftermiddagen med provet i muntlig förmåga. Deltagarantalet avgör när examenstillfället slutar. Du får närmare anvisningar om examensdagens program en vecka före examensdagen.</p>
         <p>Om du har frågor om examen, kan du kontakta oss per e-post på adressen <a href="mailto:kielitutkinnot@oph.fi">kielitutkinnot@oph.fi</a>. Vänligen meddela omedelbart om du inte kan delta i examen.</p>
         <p>
             Närmare information om examen finns på Utbildningsstyrelsens webbplats:<br/>
-            <a href="https://www.oph.fi/sv/tjanster/statsforvaltningens-sprakexamina">Språkexamina för statsförvaltningen (VKT)</a>
+            <a href="https://www.oph.fi/sv/tjanster/statsforvaltningens-sprakexamina" target="_blank">Språkexamina för statsförvaltningen (VKT)</a>
         </p>
         <br/>
 

--- a/backend/vkt/src/main/resources/email-templates/enrollment-to-queue-confirmation.html
+++ b/backend/vkt/src/main/resources/email-templates/enrollment-to-queue-confirmation.html
@@ -5,16 +5,23 @@
             Hei,
         </p>
         <p>
-            Olet ilmoittautunut jonotuspaikalle valtionhallinnon kielitutkintoon. Sinuun ollaan yhteydessä mikäli tutkintotilaisuuteen vapautuu peruutuspaikkoja. Ohessa tiedot ilmoittautumisestasi.
+            Olet ilmoittautunut jonotuspaikalle Valtionhallinnon kielitutkintoon. Olemme sinuun yhteydessä, mikäli tutkintotilaisuuteen vapautuu paikkoja. Ohessa tiedot ilmoittautumisestasi.
         </p>
         <br/>
 
         <p>
-            Tutkinnon kieli: <span th:text="${examLanguageFI}"></span><br/>
-            Tutkinnon taso: <span th:text="${examLevelFI}"></span><br/>
-            Tutkintopäivä: <span th:text="${examDate}"></span><br/>
-            Valitsemasi taidot: <span th:text="${skillsFI}"></span><br/>
-            Valitsemasi osakokeet: <span th:text="${partialExamsFI}"></span><br/>
+            <b>Tutkinnon kieli:</b> <span th:text="${examLanguageFI}"></span><br/>
+            <b>Tutkinnon taso:</b> <span th:text="${examLevelFI}"></span><br/>
+            <b>Tutkintopäivä:</b> <span th:text="${examDate}"></span><br/>
+            <b>Valitsemasi taidot:</b> <span th:text="${skillsFI}"></span><br/>
+            <b>Valitsemasi osakokeet:</b> <span th:text="${partialExamsFI}"></span><br/>
+        </p>
+        <br/>
+
+        <p>Jos sinulla on kysyttävää tutkinnosta, voit lähettää meille sähköpostia osoitteeseen <a href="mailto:kielitutkinnot@oph.fi">kielitutkinnot@oph.fi</a>. Ilmoitathan viipymättä, jos et pysty osallistumaan tutkintoon.</p>
+        <p>
+            Lisätietoa tutkinnosta löydät Opetushallituksen verkkopalvelusta:<br/>
+            <a href="https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/valtionhallinnon-kielitutkinnot">Valtionhallinnon kielitutkinnot (VKT)</a>
         </p>
         <br/>
 
@@ -27,24 +34,31 @@
         </p>
 
         <p>
-            Hei,
+            Hej,
         </p>
         <p>
-            Olet ilmoittautunut jonotuspaikalle valtionhallinnon kielitutkintoon. Sinuun ollaan yhteydessä mikäli tutkintotilaisuuteen vapautuu peruutuspaikkoja. Ohessa tiedot ilmoittautumisestasi.
-        </p>
-        <br/>
-
-        <p>
-            Tutkinnon kieli: <span th:text="${examLanguageSV}"></span><br/>
-            Tutkinnon taso: <span th:text="${examLevelSV}"></span><br/>
-            Tutkintopäivä: <span th:text="${examDate}"></span><br/>
-            Valitsemasi taidot: <span th:text="${skillsSV}"></span><br/>
-            Valitsemasi osakokeet: <span th:text="${partialExamsSV}"></span><br/>
+            Du har en plats i kön för Språkexamen för statsförvaltningen (VKT). Vi kommer att kontakta dig om platser blir lediga. Uppgifter om din anmälan hittar du nedan.
         </p>
         <br/>
 
         <p>
-            Svara inte till detta meddelande, det har skickats automatiskt.
+            <b>Examensspråk:</b> <span th:text="${examLanguageSV}"></span><br/>
+            <b>Examensnivå:</b> <span th:text="${examLevelSV}"></span><br/>
+            <b>Examensdatum:</b> <span th:text="${examDate}"></span><br/>
+            <b>Förmågor som du har valt:</b> <span th:text="${skillsSV}"></span><br/>
+            <b>Delprov som du har valt:</b> <span th:text="${partialExamsSV}"></span><br/>
+        </p>
+        <br/>
+
+        <p>Om du har frågor om examen, kan du kontakta oss per e-post på adressen <a href="mailto:kielitutkinnot@oph.fi">kielitutkinnot@oph.fi</a>. Vänligen meddela omedelbart om du inte kan delta i examen.</p>
+        <p>
+            Närmare information om examen finns på Utbildningsstyrelsens webbplats:<br/>
+            <a href="https://www.oph.fi/sv/tjanster/statsforvaltningens-sprakexamina">Språkexamina för statsförvaltningen (VKT)</a>
+        </p>
+        <br/>
+
+        <p>
+            Svara inte på detta meddelande, det har skickats automatiskt.
         </p>
         <p>
             Med vänlig hälsning<br/>

--- a/backend/vkt/src/main/resources/email-templates/enrollment-to-queue-confirmation.html
+++ b/backend/vkt/src/main/resources/email-templates/enrollment-to-queue-confirmation.html
@@ -21,7 +21,7 @@
         <p>Jos sinulla on kysyttävää tutkinnosta, voit lähettää meille sähköpostia osoitteeseen <a href="mailto:kielitutkinnot@oph.fi">kielitutkinnot@oph.fi</a>. Ilmoitathan viipymättä, jos et pysty osallistumaan tutkintoon.</p>
         <p>
             Lisätietoa tutkinnosta löydät Opetushallituksen verkkopalvelusta:<br/>
-            <a href="https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/valtionhallinnon-kielitutkinnot">Valtionhallinnon kielitutkinnot (VKT)</a>
+            <a href="https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/valtionhallinnon-kielitutkinnot" target="_blank">Valtionhallinnon kielitutkinnot (VKT)</a>
         </p>
         <br/>
 
@@ -53,7 +53,7 @@
         <p>Om du har frågor om examen, kan du kontakta oss per e-post på adressen <a href="mailto:kielitutkinnot@oph.fi">kielitutkinnot@oph.fi</a>. Vänligen meddela omedelbart om du inte kan delta i examen.</p>
         <p>
             Närmare information om examen finns på Utbildningsstyrelsens webbplats:<br/>
-            <a href="https://www.oph.fi/sv/tjanster/statsforvaltningens-sprakexamina">Språkexamina för statsförvaltningen (VKT)</a>
+            <a href="https://www.oph.fi/sv/tjanster/statsforvaltningens-sprakexamina" target="_blank">Språkexamina för statsförvaltningen (VKT)</a>
         </p>
         <br/>
 

--- a/backend/vkt/src/main/resources/email-templates/receipt_fi-FI.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_fi-FI.html
@@ -106,8 +106,8 @@
         </td>
         <td>
             <div class="hf_center">
-                <div>Sähköposti: kirjaamo@oph.fi</div>
                 <div>Puhelin: +358 29 533 1000</div>
+                <div>&nbsp;</div>
                 <div>&nbsp;</div>
             </div>
         </td>

--- a/backend/vkt/src/main/resources/email-templates/receipt_fi-FI.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_fi-FI.html
@@ -92,7 +92,7 @@
 
 <div style="font-size: 14px;">
     <p>Hinnat ALV 0%</p>
-    <p>Valtionhallinnon kielitutkinnon tutkintomaksut ovat opetus- ja kulttuuriministeriön asetuksella Opetushallituksen suoritteiden maksullisuudesta (1223/2022) määrättyjä maksuja, joista ei peritä arvonlisäveroa.</p>
+    <p>Valtionhallinnon kielitutkinnon tutkintomaksut ovat opetus- ja kulttuuriministeriön asetuksella Opetushallituksen suoritteiden maksullisuudesta (1371/2021) määrättyjä maksuja, joista ei peritä arvonlisäveroa.</p>
 </div>
 
 <table class="footer">

--- a/backend/vkt/src/main/resources/email-templates/receipt_fi-FI.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_fi-FI.html
@@ -61,6 +61,7 @@
 
 <p>[[${date}]]</p>
 <p>Maksupäivä: [[${paymentDate}]]</p>
+<p>Maksun viite: [[${paymentReference}]]</p>
 <p>Tutkinto: [[${exam}]]</p>
 <p>Osallistuja: [[${participant}]]</p>
 

--- a/backend/vkt/src/main/resources/email-templates/receipt_fi-FI.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_fi-FI.html
@@ -2,6 +2,7 @@
 <html lang="fi">
 <head>
     <meta charset="UTF-8"/>
+    <title>Maksukuitti</title>
     <style>
         body {
             margin: 30px;
@@ -58,30 +59,26 @@
     </tr>
 </table>
 
-<p>
-    [[${dateOfReceipt}]]
-</p>
-<p>
-    Maksupäivä: [[${paymentDate}]]
-</p>
-<p>
-    [[${payerName}]]
-</p>
+<p>[[${date}]]</p>
+<p>Maksupäivä: [[${paymentDate}]]</p>
+<p>Maksajan nimi: [[${payer}]]</p>
+<p>Tutkinto: [[${exam}]]</p>
+<p>Osallistuja: [[${participant}]]</p>
 
 <table style="width: 100%;border-spacing: 0;">
     <tr>
         <td colspan="4" class="cell" style="font-weight: bold; border-width: 1px 1px 0 1px;">
-            [[${item.name}]]
-        </td>
-        <td class="cell" style="border-width: 1px 1px 0 0;">
-            [[${item.value}]]
-        </td>
-    </tr>
-    <tr th:each="additionalInfo : ${item.additionalInfos}">
-        <td colspan="4" class="cell" style="border-width: 0 1px 0 1px;">
-            [[${additionalInfo}]]
+            Valtionhallinnon kielitutkinnot (VKT), tutkintomaksu
         </td>
         <td class="cell" style="border-width: 0 1px 0 0;"></td>
+    </tr>
+    <tr th:each="item : ${items}">
+        <td colspan="4" class="cell" style="border-width: 0 1px 0 1px;">
+            [[${item.name}]]
+        </td>
+        <td class="cell" style="border-width: 0 1px 0 1px;">
+            [[${item.amount}]]
+        </td>
     </tr>
     <tr style="font-weight: bold">
         <td class="cell" colspan="4" style="font-weight: bold; border-width: 1px 1px 1px 1px;">

--- a/backend/vkt/src/main/resources/email-templates/receipt_fi-FI.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_fi-FI.html
@@ -61,7 +61,6 @@
 
 <p>[[${date}]]</p>
 <p>Maksupäivä: [[${paymentDate}]]</p>
-<p>Maksajan nimi: [[${payer}]]</p>
 <p>Tutkinto: [[${exam}]]</p>
 <p>Osallistuja: [[${participant}]]</p>
 

--- a/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
@@ -61,7 +61,7 @@
 
 <p>[[${date}]]</p>
 <p>Betalningsdatum: [[${paymentDate}]]</p>
-<p>Betalnings referens: [[${paymentReference}]]</p>
+<p>Betalningsreferens: [[${paymentReference}]]</p>
 <p>Examen: [[${exam}]]</p>
 <p>Deltagare: [[${participant}]]</p>
 

--- a/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="fi">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Betalningkvittot</title>
+    <style>
+        body {
+            margin: 30px;
+        }
+
+        .header {
+            width: 100%;
+            color: #808080;
+            border-bottom: 1px solid #d3d3d3;
+        }
+
+        .footer {
+            width: 100%;
+            color: #808080;
+            border-top: 1px solid #d3d3d3;
+            margin-top: 200px;
+        }
+
+        .hf_center {
+            text-align: center;
+        }
+
+        .hf_right {
+            text-align: right;
+        }
+
+        .cell {
+            padding: 5px;
+            border-style: solid;
+            border-color: #d3d3d3;
+        }
+    </style>
+</head>
+<body>
+
+<table class="header">
+    <tr>
+        <td>
+            <svg width="51" height="50" fill="none"
+                 xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" clip-rule="evenodd"
+                      d="M14.474 14.389c1.267-2.56 2.742-5.014 4.024-7.15 2.679-4.46 4.518-7.522 1.873-7.218-2.224.283-4.382.95-6.38 1.971A22.745 22.745 0 0 1 16.776.851S8.657 4.2 5.625 13.765a24.817 24.817 0 0 1 4.017-3.146c3.941-2.504 3.228-.611 1.658 3.558-1.113 2.955-2.657 7.053-3.28 11.541 1.067-1.377 2.35-3.355 3.797-5.585.392-.605.796-1.227 1.211-1.861.356-1.34.84-2.643 1.446-3.89v.007zm21.237-1.103c-1.57-.45-3.202.467-4.846 2.227a88.322 88.322 0 0 0-1.8 4.835c-.463 1.345-.945 2.893-1.452 4.52-2.368 7.605-5.277 16.947-9.21 15.506a5.83 5.83 0 0 1-1.186-.584c-.716 1.188-1.379 2.124-1.98 2.697a6.367 6.367 0 0 1-1.798 1.233c9.048 8.934 25.713 8.555 24.765-2.545-1.124-13.132-1.052-18.694-.951-26.432l.01-.823a5.908 5.908 0 0 0-1.55-.626l-.002-.008zm14.61 5.78c.423 1.868.645 3.775.66 5.69l.008.003c-.019.255-.238 1.756-1.57 1.478a2.31 2.31 0 0 1-1.087-.51C46.32 12.477 38.715-3.092 37.465 9.397a52.389 52.389 0 0 0-1.876-2.51c1.708-2.022 2.964-2.26 3.683-2.372 3.41-.533 9.475 7.63 11.049 14.553z"
+                      fill="#5FC82B"/>
+                <path d="M32.169 3.516C20.635-3.528 5.958 36.063 4.859 26.11 2.023 6.925 16.776.85 16.776.85 7.289 3.997-.166 13.673.003 24.847c.17 11.228 6.418 17.667 8.67 18.783 2.852 1.416 5.343.072 6.572-1.14 4.727-4.508 13.268-31.265 20.467-29.192 8.056 1.944 6.988 18.978 7.378 22.244.775 6.51 2.591 5.732 5.121.949 1.696-3.206 2.8-6.9 2.774-11.773 0 0-.12 1.824-1.574 1.519-1.305-.272-1.793-1.02-5.077-6.173C40.895 14.671 35.64 5.641 32.17 3.522"
+                      fill="#0C48D8"/>
+            </svg>
+        </td>
+        <td>
+            <div class="hf_center">Utbildningsstyrelsen</div>
+        </td>
+        <td>
+            <div class="hf_right">Kvitto</div>
+        </td>
+    </tr>
+</table>
+
+<p>[[${date}]]</p>
+<p>Betalningsdatum: [[${paymentDate}]]</p>
+<p>Betalarens namn: [[${payer}]]</p>
+<p>Examen: [[${exam}]]</p>
+<p>Deltagare: [[${participant}]]</p>
+
+<table style="width: 100%;border-spacing: 0;">
+    <tr>
+        <td colspan="4" class="cell" style="font-weight: bold; border-width: 1px 1px 0 1px;">
+            Språkexamina för statsförvaltningen (VKT), examensavgift
+        </td>
+        <td class="cell" style="border-width: 0 1px 0 0;"></td>
+    </tr>
+    <tr th:each="item : ${items}">
+        <td colspan="4" class="cell" style="border-width: 0 1px 0 1px;">
+            [[${item.name}]]
+        </td>
+        <td class="cell" style="border-width: 0 1px 0 1px;">
+            [[${item.amount}]]
+        </td>
+    </tr>
+    <tr style="font-weight: bold">
+        <td class="cell" colspan="4" style="font-weight: bold; border-width: 1px 1px 1px 1px;">
+            Totalt
+        </td>
+        <td class="cell" style="border-width: 1px 1px 1px 0;">
+            [[${totalAmount}]]
+        </td>
+    </tr>
+</table>
+
+<div style="font-size: 14px;">
+    <p>Priser inklusive moms 0%</p>
+    <p>Examensavgifterna för Språkexamina för statsförvaltningen är föreskrivna i undervisnings- och kulturministeriets förordning om Utbildningsstyrelsens avgiftsbelagda prestationer (1371/2021) och är momsfria.</p>
+</div>
+
+<table class="footer">
+    <tr>
+        <td>
+            <div>
+                <div><strong>Utbildningsstyrelsen</strong></div>
+                <div>Hagnäskajen 6</div>
+                <div>PB 380, 00531 Helsingfors</div>
+            </div>
+        </td>
+        <td>
+            <div class="hf_center">
+                <div>E-post: registraturen@oph.fi</div>
+                <div>Telefon: +358 29 533 1000</div>
+                <div>&nbsp;</div>
+            </div>
+        </td>
+        <td>
+            <div class="hf_right">
+                <div>FO-nummer: 2769790-1</div>
+                <div>&nbsp;</div>
+                <div>&nbsp;</div>
+            </div>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
@@ -61,6 +61,7 @@
 
 <p>[[${date}]]</p>
 <p>Betalningsdatum: [[${paymentDate}]]</p>
+<p>Betalnings referens: [[${paymentReference}]]</p>
 <p>Examen: [[${exam}]]</p>
 <p>Deltagare: [[${participant}]]</p>
 

--- a/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
@@ -61,7 +61,6 @@
 
 <p>[[${date}]]</p>
 <p>Betalningsdatum: [[${paymentDate}]]</p>
-<p>Betalarens namn: [[${payer}]]</p>
 <p>Examen: [[${exam}]]</p>
 <p>Deltagare: [[${participant}]]</p>
 

--- a/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
@@ -2,7 +2,7 @@
 <html lang="fi">
 <head>
     <meta charset="UTF-8"/>
-    <title>Betalningkvittot</title>
+    <title>Betalningkvitto</title>
     <style>
         body {
             margin: 30px;
@@ -106,8 +106,8 @@
         </td>
         <td>
             <div class="hf_center">
-                <div>E-post: registraturen@oph.fi</div>
                 <div>Telefon: +358 29 533 1000</div>
+                <div>&nbsp;</div>
                 <div>&nbsp;</div>
             </div>
         </td>

--- a/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
+++ b/backend/vkt/src/main/resources/email-templates/receipt_sv-SE.html
@@ -2,7 +2,7 @@
 <html lang="fi">
 <head>
     <meta charset="UTF-8"/>
-    <title>Betalningkvitto</title>
+    <title>Betalningskvitto</title>
     <style>
         body {
             margin: 30px;

--- a/backend/vkt/src/test/java/fi/oph/vkt/Factory.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/Factory.java
@@ -4,11 +4,13 @@ import fi.oph.vkt.model.Email;
 import fi.oph.vkt.model.EmailType;
 import fi.oph.vkt.model.Enrollment;
 import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Payment;
 import fi.oph.vkt.model.Person;
 import fi.oph.vkt.model.Reservation;
 import fi.oph.vkt.model.type.EnrollmentStatus;
 import fi.oph.vkt.model.type.ExamLanguage;
 import fi.oph.vkt.model.type.ExamLevel;
+import fi.oph.vkt.model.type.PaymentStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -62,6 +64,20 @@ public class Factory {
     person.getEnrollments().add(enrollment);
 
     return enrollment;
+  }
+
+  public static Payment payment(final Enrollment enrollment) {
+    final Payment payment = new Payment();
+    payment.setAmount(22700);
+    payment.setTransactionId("t-123");
+    payment.setReference("RF-test");
+    payment.setPaymentUrl("url");
+    payment.setPaymentStatus(PaymentStatus.OK);
+
+    payment.setEnrollment(enrollment);
+    enrollment.getPayments().add(payment);
+
+    return payment;
   }
 
   public static Reservation reservation(final ExamEvent examEvent, final Person person) {

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PaymentServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PaymentServiceTest.java
@@ -97,8 +97,8 @@ public class PaymentServiceTest {
     );
     final String redirectUrl = paymentService.createPaymentForEnrollment(enrollment.getId(), person);
     final List<Item> items = List.of(
-      Item.builder().units(1).unitPrice(22700).vatPercentage(0).productCode(EnrollmentSkill.ORAL.toString()).build(),
       Item.builder().units(1).unitPrice(22700).vatPercentage(0).productCode(EnrollmentSkill.TEXTUAL.toString()).build(),
+      Item.builder().units(1).unitPrice(22700).vatPercentage(0).productCode(EnrollmentSkill.ORAL.toString()).build(),
       Item
         .builder()
         .units(1)

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
@@ -157,7 +157,7 @@ public class PublicEnrollmentEmailServiceTest {
     final EmailAttachment attachment = attachments.get(0);
 
     assertTrue(attachments.stream().anyMatch(a -> a.getName().equals("Maksukuitti 20.02.2025.pdf")));
-    assertTrue(attachments.stream().anyMatch(a -> a.getName().equals("Betalningkvitto 20.02.2025.pdf")));
+    assertTrue(attachments.stream().anyMatch(a -> a.getName().equals("Betalningskvitto 20.02.2025.pdf")));
     assertTrue(attachments.stream().allMatch(a -> attachment.getContentType().equals("application/pdf")));
   }
 

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
@@ -73,6 +73,7 @@ public class PublicEnrollmentEmailServiceTest {
           .builder()
           .date("20.02.2025")
           .paymentDate("19.02.2025")
+          .paymentReference("RF-123")
           .exam("Suomi, erinomainen taito, 27.03.2025")
           .participant("Bar, Foo")
           .totalAmount("500 €")

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
@@ -157,7 +157,7 @@ public class PublicEnrollmentEmailServiceTest {
     final EmailAttachment attachment = attachments.get(0);
 
     assertTrue(attachments.stream().anyMatch(a -> a.getName().equals("Maksukuitti 20.02.2025.pdf")));
-    assertTrue(attachments.stream().anyMatch(a -> a.getName().equals("Betalningkvittot 20.02.2025.pdf")));
+    assertTrue(attachments.stream().anyMatch(a -> a.getName().equals("Betalningkvitto 20.02.2025.pdf")));
     assertTrue(attachments.stream().allMatch(a -> attachment.getContentType().equals("application/pdf")));
   }
 

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
@@ -116,19 +116,19 @@ public class PublicEnrollmentEmailServiceTest {
       "examLanguageSV",
       "finska",
       "examLevelFI",
-      "erinomainen",
+      "erinomainen taito",
       "examLevelSV",
-      "utmärkt",
+      "utmärkta språkkunskaper",
       "examDate",
       "12.03.2025",
       "skillsFI",
       "suullinen taito",
       "skillsSV",
-      "suullinen taito",
+      "förmåga att använda finska i tal",
       "partialExamsFI",
       "puhuminen, puheen ymmärtäminen",
       "partialExamsSV",
-      "puhuminen, puheen ymmärtäminen"
+      "muntlig färdighet, hörförståelse"
     );
 
     when(environment.getRequiredProperty("app.email.sending-enabled", Boolean.class)).thenReturn(true);
@@ -144,7 +144,7 @@ public class PublicEnrollmentEmailServiceTest {
     assertEquals(EmailType.ENROLLMENT_CONFIRMATION, email.getEmailType());
     assertEquals("Foo Bar", email.getRecipientName());
     assertEquals("foo.bar@vkt.test", email.getRecipientAddress());
-    assertTrue(email.getSubject().contains("Vahvistus tutkintoon ilmoittautumisesta"));
+    assertTrue(email.getSubject().contains("Vahvistus ilmoittautumisesta Valtionhallinnon kielitutkintoon"));
     assertEquals("<html>enrollment</html>", email.getBody());
     assertNull(email.getSentAt());
     assertNull(email.getError());
@@ -191,19 +191,19 @@ public class PublicEnrollmentEmailServiceTest {
       "examLanguageSV",
       "svenska",
       "examLevelFI",
-      "erinomainen",
+      "erinomainen taito",
       "examLevelSV",
-      "utmärkt",
+      "utmärkta språkkunskaper",
       "examDate",
       "12.03.2025",
       "skillsFI",
       "kirjallinen taito, ymmärtämisen taito",
       "skillsSV",
-      "kirjallinen taito, ymmärtämisen taito",
+      "förmåga att använda svenska i skrift, förmåga att förstå svenska",
       "partialExamsFI",
       "kirjoittaminen, tekstin ymmärtäminen, puheen ymmärtäminen",
       "partialExamsSV",
-      "kirjoittaminen, tekstin ymmärtäminen, puheen ymmärtäminen"
+      "skriftlig färdighet, textförståelse, hörförståelse"
     );
 
     when(templateRenderer.renderEnrollmentToQueueConfirmationEmailBody(expectedTemplateParams))
@@ -218,7 +218,7 @@ public class PublicEnrollmentEmailServiceTest {
     assertEquals(EmailType.ENROLLMENT_TO_QUEUE_CONFIRMATION, email.getEmailType());
     assertEquals("Foo Bar", email.getRecipientName());
     assertEquals("foo.bar@vkt.test", email.getRecipientAddress());
-    assertTrue(email.getSubject().contains("Vahvistus ilmoittautumisesta tutkinnon jonotuspaikalle"));
+    assertTrue(email.getSubject().contains("Vahvistus ilmoittautumisesta jonotuspaikalle"));
     assertEquals("<html>enrollment-to-queue</html>", email.getBody());
     assertNull(email.getSentAt());
     assertNull(email.getError());

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
@@ -73,7 +73,6 @@ public class PublicEnrollmentEmailServiceTest {
           .builder()
           .date("20.02.2025")
           .paymentDate("19.02.2025")
-          .payer("Foo Bar")
           .exam("Suomi, erinomainen taito, 27.03.2025")
           .participant("Bar, Foo")
           .totalAmount("500 €")

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PublicEnrollmentEmailServiceTest.java
@@ -71,14 +71,16 @@ public class PublicEnrollmentEmailServiceTest {
       .thenReturn(
         ReceiptData
           .builder()
-          .dateOfReceipt("20.02.2025")
-          .payerName("Payer")
+          .date("20.02.2025")
           .paymentDate("19.02.2025")
-          .totalAmount("500")
-          .item(ReceiptItem.builder().name("A").value("B").additionalInfos(List.of()).build())
+          .payer("Foo Bar")
+          .exam("Suomi, erinomainen taito, 27.03.2025")
+          .participant("Bar, Foo")
+          .totalAmount("500 €")
+          .items(List.of(ReceiptItem.builder().name("A").amount("500 €").build()))
           .build()
       );
-    when(receiptRenderer.getReceiptPdfBytes(any())).thenReturn(new byte[] { 'a', 'b', 'c' });
+    when(receiptRenderer.getReceiptPdfBytes(any(), any())).thenReturn(new byte[] { 'a', 'b', 'c' });
 
     publicEnrollmentEmailService =
       new PublicEnrollmentEmailService(emailService, environment, receiptRenderer, templateRenderer);

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererIntegrationTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererIntegrationTest.java
@@ -26,7 +26,6 @@ class ReceiptRendererIntegrationTest {
         .builder()
         .date("25.12.2022")
         .paymentDate("24.12.2022")
-        .payer("Raimo Rahamies")
         .exam("Suomi, erinomainen taito, 28.1.2023")
         .participant("Ainolainen, Aino")
         .totalAmount("25 €")
@@ -42,7 +41,6 @@ class ReceiptRendererIntegrationTest {
     assertTrue(html.contains("<html "));
     assertTrue(html.contains("25.12.2022"));
     assertTrue(html.contains("Maksupäivä: 24.12.2022"));
-    assertTrue(html.contains("Maksajan nimi: Raimo Rahamies"));
     assertTrue(html.contains("Tutkinto: Suomi, erinomainen taito, 28.1.2023"));
     assertTrue(html.contains("Osallistuja: Ainolainen, Aino"));
     assertTrue(html.contains("Kirjallinen taito"));
@@ -59,7 +57,6 @@ class ReceiptRendererIntegrationTest {
         .builder()
         .date("25.12.2022")
         .paymentDate("24.12.2022")
-        .payer("Raimo Rahamies")
         .exam("Suomi, erinomainen taito, 28.1.2023")
         .participant("Ainolainen, Aino")
         .totalAmount("25 €")

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererIntegrationTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererIntegrationTest.java
@@ -26,6 +26,7 @@ class ReceiptRendererIntegrationTest {
         .builder()
         .date("25.12.2022")
         .paymentDate("24.12.2022")
+        .paymentReference("RF-123")
         .exam("Suomi, erinomainen taito, 28.1.2023")
         .participant("Ainolainen, Aino")
         .totalAmount("25 €")
@@ -41,6 +42,7 @@ class ReceiptRendererIntegrationTest {
     assertTrue(html.contains("<html "));
     assertTrue(html.contains("25.12.2022"));
     assertTrue(html.contains("Maksupäivä: 24.12.2022"));
+    assertTrue(html.contains("Maksun viite: RF-123"));
     assertTrue(html.contains("Tutkinto: Suomi, erinomainen taito, 28.1.2023"));
     assertTrue(html.contains("Osallistuja: Ainolainen, Aino"));
     assertTrue(html.contains("Kirjallinen taito"));
@@ -57,6 +59,7 @@ class ReceiptRendererIntegrationTest {
         .builder()
         .date("25.12.2022")
         .paymentDate("24.12.2022")
+        .paymentReference("RF-123")
         .exam("Suomi, erinomainen taito, 28.1.2023")
         .participant("Ainolainen, Aino")
         .totalAmount("25 €")

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererIntegrationTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererIntegrationTest.java
@@ -55,7 +55,6 @@ class ReceiptRendererIntegrationTest {
   @Test
   public void testGetReceiptPdfBytes() throws IOException, InterruptedException {
     final byte[] pdfBytes = receiptRenderer.getReceiptPdfBytes(
-      Language.FI,
       ReceiptData
         .builder()
         .date("25.12.2022")
@@ -70,7 +69,8 @@ class ReceiptRendererIntegrationTest {
             ReceiptItem.builder().name("Suullinen taito").amount("15 €").build()
           )
         )
-        .build()
+        .build(),
+      Language.FI
     );
     assertNotNull(pdfBytes);
     assertTrue(pdfBytes.length > 0);

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererIntegrationTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererIntegrationTest.java
@@ -3,6 +3,7 @@ package fi.oph.vkt.service.receipt;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import fi.oph.vkt.util.localisation.Language;
 import jakarta.annotation.Resource;
 import java.io.IOException;
 import java.util.List;
@@ -18,45 +19,56 @@ class ReceiptRendererIntegrationTest {
   private ReceiptRenderer receiptRenderer;
 
   @Test
-  public void testHtml() {
+  public void testGetReceiptHtml() {
     final String html = receiptRenderer.getReceiptHtml(
+      Language.FI,
       ReceiptData
         .builder()
-        .dateOfReceipt("24.12.2013")
-        .payerName("Raimo Rahamies")
-        .paymentDate("24.12.1987")
-        .totalAmount("454 €")
-        .item(
-          ReceiptItem
-            .builder()
-            .name("Valtionhallinnon kielitutkinnot (VKT) tutkintomaksu")
-            .value("454 €")
-            .additionalInfos(List.of("Suomi, erinomainen, 28.1.2023", "Osallistuja: Ainolainen, Aino"))
-            .build()
+        .date("25.12.2022")
+        .paymentDate("24.12.2022")
+        .payer("Raimo Rahamies")
+        .exam("Suomi, erinomainen taito, 28.1.2023")
+        .participant("Ainolainen, Aino")
+        .totalAmount("25 €")
+        .items(
+          List.of(
+            ReceiptItem.builder().name("Kirjallinen taito").amount("10 €").build(),
+            ReceiptItem.builder().name("Suullinen taito").amount("15 €").build()
+          )
         )
         .build()
     );
     assertNotNull(html);
     assertTrue(html.contains("<html "));
-    assertTrue(html.contains("Maksupäivä: 24.12.1987"));
+    assertTrue(html.contains("25.12.2022"));
+    assertTrue(html.contains("Maksupäivä: 24.12.2022"));
+    assertTrue(html.contains("Maksajan nimi: Raimo Rahamies"));
+    assertTrue(html.contains("Tutkinto: Suomi, erinomainen taito, 28.1.2023"));
+    assertTrue(html.contains("Osallistuja: Ainolainen, Aino"));
+    assertTrue(html.contains("Kirjallinen taito"));
+    assertTrue(html.contains("Suullinen taito"));
+    assertTrue(html.contains("10 €"));
+    assertTrue(html.contains("15 €"));
+    assertTrue(html.contains("25 €"));
   }
 
   @Test
-  public void testPdf() throws IOException, InterruptedException {
+  public void testGetReceiptPdfBytes() throws IOException, InterruptedException {
     final byte[] pdfBytes = receiptRenderer.getReceiptPdfBytes(
+      Language.FI,
       ReceiptData
         .builder()
-        .dateOfReceipt("24.12.2013")
-        .payerName("Raimo Rahamies")
-        .paymentDate("24.12.1987")
-        .totalAmount("454 €")
-        .item(
-          ReceiptItem
-            .builder()
-            .name("Valtionhallinnon kielitutkinnot (VKT) tutkintomaksu")
-            .value("454 €")
-            .additionalInfos(List.of("Suomi, erinomainen, 28.1.2023", "Osallistuja: Ainolainen, Aino"))
-            .build()
+        .date("25.12.2022")
+        .paymentDate("24.12.2022")
+        .payer("Raimo Rahamies")
+        .exam("Suomi, erinomainen taito, 28.1.2023")
+        .participant("Ainolainen, Aino")
+        .totalAmount("25 €")
+        .items(
+          List.of(
+            ReceiptItem.builder().name("Kirjallinen taito").amount("10 €").build(),
+            ReceiptItem.builder().name("Suullinen taito").amount("15 €").build()
+          )
         )
         .build()
     );

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererTest.java
@@ -68,7 +68,6 @@ class ReceiptRendererTest {
 
     final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId(), Language.FI);
     assertNotNull(receiptData);
-    assertEquals("Bar, Foo", receiptData.payer());
     assertEquals("Ruotsi, erinomainen taito, 07.10.2024", receiptData.exam());
     assertEquals("Bar, Foo", receiptData.participant());
     assertEquals("227 €", receiptData.totalAmount());

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import fi.oph.vkt.Factory;
 import fi.oph.vkt.model.Enrollment;
 import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Payment;
 import fi.oph.vkt.model.Person;
 import fi.oph.vkt.model.type.ExamLanguage;
 import fi.oph.vkt.model.type.ExamLevel;
@@ -53,22 +54,31 @@ class ReceiptRendererTest {
     person.setLastName("Bar");
 
     final Enrollment enrollment = Factory.enrollment(examEvent, person);
+    enrollment.setTextualSkill(true);
+    enrollment.setOralSkill(false);
+    enrollment.setUnderstandingSkill(true);
+
+    final Payment payment = Factory.payment(enrollment);
+    payment.setAmount(22700);
 
     entityManager.persist(examEvent);
     entityManager.persist(person);
     entityManager.persist(enrollment);
+    entityManager.persist(payment);
 
     final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId(), Language.FI);
     assertNotNull(receiptData);
-    assertEquals("Bar, Foo", receiptData.payerName());
-    assertEquals("454 €", receiptData.totalAmount());
+    assertEquals("Bar, Foo", receiptData.payer());
+    assertEquals("Ruotsi, erinomainen taito, 07.10.2024", receiptData.exam());
+    assertEquals("Bar, Foo", receiptData.participant());
+    assertEquals("227 €", receiptData.totalAmount());
 
-    final ReceiptItem receiptItem = receiptData.item();
-    assertEquals("Valtionhallinnon kielitutkinnot (VKT), tutkintomaksu", receiptItem.name());
-    assertEquals("454 €", receiptItem.value());
+    final ReceiptItem item1 = receiptData.items().get(0);
+    assertEquals("Kirjallinen taito", item1.name());
+    assertEquals("227 €", item1.amount());
 
-    assertEquals(2, receiptItem.additionalInfos().size());
-    assertEquals("Ruotsi, erinomainen, 07.10.2024", receiptItem.additionalInfos().get(0));
-    assertEquals("Osallistuja: Bar, Foo", receiptData.item().additionalInfos().get(1));
+    final ReceiptItem item2 = receiptData.items().get(1);
+    assertEquals("Ymmärtämisen taito", item2.name());
+    assertEquals("0 €", item2.amount());
   }
 }

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/receipt/ReceiptRendererTest.java
@@ -60,6 +60,7 @@ class ReceiptRendererTest {
 
     final Payment payment = Factory.payment(enrollment);
     payment.setAmount(22700);
+    payment.setReference("RF-123");
 
     entityManager.persist(examEvent);
     entityManager.persist(person);
@@ -68,6 +69,7 @@ class ReceiptRendererTest {
 
     final ReceiptData receiptData = receiptRenderer.getReceiptData(enrollment.getId(), Language.FI);
     assertNotNull(receiptData);
+    assertEquals("RF-123", receiptData.paymentReference());
     assertEquals("Ruotsi, erinomainen taito, 07.10.2024", receiptData.exam());
     assertEquals("Bar, Foo", receiptData.participant());
     assertEquals("227 €", receiptData.totalAmount());

--- a/backend/vkt/src/test/java/fi/oph/vkt/util/EnrollmentUtilTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/util/EnrollmentUtilTest.java
@@ -1,44 +1,47 @@
 package fi.oph.vkt.util;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import fi.oph.vkt.Factory;
 import fi.oph.vkt.model.Enrollment;
 import fi.oph.vkt.model.ExamEvent;
 import fi.oph.vkt.model.Person;
-import fi.oph.vkt.model.type.ExamLevel;
-import jakarta.annotation.Resource;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-@DataJpaTest
-class EnrollmentUtilTest {
-
-  @Resource
-  private TestEntityManager entityManager;
+public class EnrollmentUtilTest {
 
   @Test
-  public void testIsUnderstandingSkillFree() {
+  public void testGetTextualSkillFee() {
     final ExamEvent examEvent = Factory.examEvent();
-    examEvent.setLevel(ExamLevel.EXCELLENT);
-    entityManager.persist(examEvent);
+    final Person person = Factory.person();
+    final Enrollment enrollment = Factory.enrollment(examEvent, person);
 
-    assertTrue(EnrollmentUtil.isUnderstandingSkillFree(createEnrollment(examEvent, true, false)));
-    assertTrue(EnrollmentUtil.isUnderstandingSkillFree(createEnrollment(examEvent, false, true)));
-    assertTrue(EnrollmentUtil.isUnderstandingSkillFree(createEnrollment(examEvent, true, true)));
+    enrollment.setTextualSkill(false);
+    assertEquals(0, EnrollmentUtil.getTextualSkillFee(enrollment));
+
+    enrollment.setTextualSkill(true);
+    assertEquals(22700, EnrollmentUtil.getTextualSkillFee(enrollment));
   }
 
-  private Enrollment createEnrollment(final ExamEvent examEvent, final boolean textualSkill, final boolean oralSkill) {
+  @Test
+  public void testGetOralSkillFee() {
+    final ExamEvent examEvent = Factory.examEvent();
     final Person person = Factory.person();
-    entityManager.persist(person);
-
     final Enrollment enrollment = Factory.enrollment(examEvent, person);
-    enrollment.setTextualSkill(textualSkill);
-    enrollment.setOralSkill(oralSkill);
-    enrollment.setUnderstandingSkill(true);
-    entityManager.persist(enrollment);
 
-    return enrollment;
+    enrollment.setOralSkill(false);
+    assertEquals(0, EnrollmentUtil.getOralSkillFee(enrollment));
+
+    enrollment.setOralSkill(true);
+    assertEquals(22700, EnrollmentUtil.getOralSkillFee(enrollment));
+  }
+
+  @Test
+  public void testGetUnderstandingSkillFee() {
+    final ExamEvent examEvent = Factory.examEvent();
+    final Person person = Factory.person();
+    final Enrollment enrollment = Factory.enrollment(examEvent, person);
+
+    assertEquals(0, EnrollmentUtil.getUnderstandingSkillFee(enrollment));
   }
 }

--- a/backend/vkt/src/test/java/fi/oph/vkt/util/EnrollmentUtilTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/util/EnrollmentUtilTest.java
@@ -1,35 +1,44 @@
 package fi.oph.vkt.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import fi.oph.vkt.Factory;
 import fi.oph.vkt.model.Enrollment;
-import lombok.NonNull;
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Person;
+import fi.oph.vkt.model.type.ExamLevel;
+import jakarta.annotation.Resource;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
+@DataJpaTest
 class EnrollmentUtilTest {
 
+  @Resource
+  private TestEntityManager entityManager;
+
   @Test
-  public void testCalculateExaminationPaymentSum() {
-    assertEquals(0, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(false, false, false)));
-    assertEquals(227, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(true, false, false)));
-    assertEquals(454, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(true, true, false)));
-    assertEquals(454, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(true, false, true)));
-    assertEquals(227, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(false, true, false)));
-    assertEquals(227, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(false, false, true)));
-    assertEquals(454, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(false, true, true)));
-    assertEquals(454, EnrollmentUtil.calculateExaminationPaymentSum(createEnrollment(true, true, true)));
+  public void testIsUnderstandingSkillFree() {
+    final ExamEvent examEvent = Factory.examEvent();
+    examEvent.setLevel(ExamLevel.EXCELLENT);
+    entityManager.persist(examEvent);
+
+    assertTrue(EnrollmentUtil.isUnderstandingSkillFree(createEnrollment(examEvent, true, false)));
+    assertTrue(EnrollmentUtil.isUnderstandingSkillFree(createEnrollment(examEvent, false, true)));
+    assertTrue(EnrollmentUtil.isUnderstandingSkillFree(createEnrollment(examEvent, true, true)));
   }
 
-  @NonNull
-  private static Enrollment createEnrollment(
-    final boolean oralSkill,
-    final boolean textualSkill,
-    final boolean understandingSkill
-  ) {
-    final Enrollment enrollment = new Enrollment();
-    enrollment.setOralSkill(oralSkill);
+  private Enrollment createEnrollment(final ExamEvent examEvent, final boolean textualSkill, final boolean oralSkill) {
+    final Person person = Factory.person();
+    entityManager.persist(person);
+
+    final Enrollment enrollment = Factory.enrollment(examEvent, person);
     enrollment.setTextualSkill(textualSkill);
-    enrollment.setUnderstandingSkill(understandingSkill);
+    enrollment.setOralSkill(oralSkill);
+    enrollment.setUnderstandingSkill(true);
+    entityManager.persist(enrollment);
+
     return enrollment;
   }
 }

--- a/backend/vkt/src/test/java/fi/oph/vkt/util/TemplateRendererTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/util/TemplateRendererTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.annotation.Resource;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -62,34 +61,5 @@ class TemplateRendererTest {
     assertTrue(emailContent.contains("kirjallinen taito, suullinen taito"));
     assertTrue(emailContent.contains("kirjoittaminen, tekstin ymmärtäminen, puhuminen"));
     assertTrue(emailContent.contains("finska"));
-  }
-
-  @Test
-  public void testRenderReceipt() {
-    final Map<String, Object> params = Map.of(
-      "dateOfReceipt",
-      "24.12.2022",
-      "payerName",
-      "Väinöläinen, Väinö",
-      "paymentDate",
-      "24.12.1987",
-      "totalAmount",
-      "454 €",
-      "item",
-      Map.of(
-        "name",
-        "Valtionhallinnon kielitutkinnot (VKT) tutkintomaksu",
-        "value",
-        "454 €",
-        "additionalInfos",
-        List.of("Suomi, erinomainen, 28.1.2023", "Osallistuja: Ainolainen, Aino")
-      )
-    );
-
-    final String renderedContent = templateRenderer.renderReceipt(params);
-
-    assertNotNull(renderedContent);
-    assertTrue(renderedContent.contains("<html "));
-    assertTrue(renderedContent.contains("Suomi, erinomainen, 28.1.2023"));
   }
 }

--- a/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
+++ b/frontend/packages/vkt/src/components/clerkEnrollment/overview/ClerkEnrollmentDetailsFields.tsx
@@ -75,7 +75,7 @@ const PaymentDetails = ({ payment }: { payment: ClerkPayment }) => {
       </Text>
       <Text>
         {t('payment.details.date')}:{' '}
-        <b>{DateUtils.formatOptionalDate(payment.modifiedAt)}</b>
+        <b>{DateUtils.formatOptionalDateTime(payment.modifiedAt)}</b>
       </Text>
       <Text>
         {t('payment.details.amount')}:{' '}


### PR DESCRIPTION
## Yhteenveto

Muokattu suomenkielistä kuittipohjaa siten, että siitä käy ilmi mistä riveistä tutkintomaksu koostuu. Kuittipohjasta tehty myös kopio jossa ruotsinkieliset käännökset. Myös viestipohjia muokattu OPH:lta tulleiden kommenttien perusteella.

Tää on käytännössä kai tällaisenaan valmis mutta vois weeklyssä vielä esitellä tätä ja katsoa tuleeko tähän kommentteja.
