### PR TITLE
VKT(Backend & Frontend) OPHVKTKEH-192: Tunnistaudu stepin refresh korjaus

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/api/PublicController.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/PublicController.java
@@ -96,9 +96,17 @@ public class PublicController {
   }
 
   /**
-   * Returns info about enrollment when refreshing a page during an enrollment step
+   * Returns info about exam when refreshing a page during authenticate step
    */
   @GetMapping(path = "/examEvent/{examEventId:\\d+}")
+  public PublicExamEventDTO getExamEventInfo(@PathVariable final long examEventId) {
+    return publicExamEventService.getExamEvent(examEventId);
+  }
+
+  /**
+   * Returns info about enrollment when refreshing a page during an enrollment step
+   */
+  @GetMapping(path = "/enrollment/{examEventId:\\d+}")
   public PublicEnrollmentInitialisationDTO getEnrollmentInfo(
     @PathVariable final long examEventId,
     final HttpSession session

--- a/backend/vkt/src/main/java/fi/oph/vkt/api/PublicController.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/PublicController.java
@@ -96,7 +96,7 @@ public class PublicController {
   }
 
   /**
-   * Returns info about exam when refreshing a page during authenticate step
+   * Returns info about exam event when refreshing a page during authenticate step
    */
   @GetMapping(path = "/examEvent/{examEventId:\\d+}")
   public PublicExamEventDTO getExamEventInfo(@PathVariable final long examEventId) {
@@ -106,7 +106,7 @@ public class PublicController {
   /**
    * Returns info about enrollment when refreshing a page during an enrollment step
    */
-  @GetMapping(path = "/enrollment/{examEventId:\\d+}")
+  @GetMapping(path = "/examEvent/{examEventId:\\d+}/enrollment")
   public PublicEnrollmentInitialisationDTO getEnrollmentInfo(
     @PathVariable final long examEventId,
     final HttpSession session

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicExamEventService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicExamEventService.java
@@ -7,14 +7,12 @@ import fi.oph.vkt.repository.ExamEventRepository;
 import fi.oph.vkt.repository.PublicExamEventProjection;
 import fi.oph.vkt.repository.ReservationRepository;
 import fi.oph.vkt.util.ExamEventUtil;
-
+import fi.oph.vkt.util.exception.NotFoundException;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import fi.oph.vkt.util.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicExamEventService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicExamEventService.java
@@ -1,6 +1,7 @@
 package fi.oph.vkt.service;
 
 import fi.oph.vkt.api.dto.PublicExamEventDTO;
+import fi.oph.vkt.model.ExamEvent;
 import fi.oph.vkt.model.type.ExamLevel;
 import fi.oph.vkt.repository.ExamEventRepository;
 import fi.oph.vkt.repository.PublicExamEventProjection;
@@ -20,6 +21,21 @@ public class PublicExamEventService {
 
   private final ExamEventRepository examEventRepository;
   private final ReservationRepository reservationRepository;
+
+  @Transactional(readOnly = true)
+  public PublicExamEventDTO getExamEvent(final long examEventId) {
+    final ExamEvent examEvent = examEventRepository.getReferenceById(examEventId);
+
+    return PublicExamEventDTO
+      .builder()
+      .id(examEvent.getId())
+      .language(examEvent.getLanguage())
+      .date(examEvent.getDate())
+      .registrationCloses(examEvent.getRegistrationCloses())
+      .openings(ExamEventUtil.getOpenings(examEvent))
+      .hasCongestion(ExamEventUtil.isCongested(examEvent))
+      .build();
+  }
 
   @Transactional(readOnly = true)
   public List<PublicExamEventDTO> listExamEvents(final ExamLevel level) {

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicExamEventService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicExamEventService.java
@@ -7,10 +7,14 @@ import fi.oph.vkt.repository.ExamEventRepository;
 import fi.oph.vkt.repository.PublicExamEventProjection;
 import fi.oph.vkt.repository.ReservationRepository;
 import fi.oph.vkt.util.ExamEventUtil;
+
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import fi.oph.vkt.util.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +29,10 @@ public class PublicExamEventService {
   @Transactional(readOnly = true)
   public PublicExamEventDTO getExamEvent(final long examEventId) {
     final ExamEvent examEvent = examEventRepository.getReferenceById(examEventId);
+
+    if (examEvent.getRegistrationCloses().isBefore(LocalDate.now())) {
+      throw new NotFoundException(String.format("Exam event (%d) enrollment is closed", examEvent.getId()));
+    }
 
     return PublicExamEventDTO
       .builder()

--- a/backend/vkt/src/main/java/fi/oph/vkt/util/ExamEventUtil.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/util/ExamEventUtil.java
@@ -1,6 +1,35 @@
 package fi.oph.vkt.util;
 
+import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Reservation;
+import fi.oph.vkt.model.type.EnrollmentStatus;
+import java.util.List;
+
 public class ExamEventUtil {
+
+  public static long getOpenings(final ExamEvent examEvent) {
+    final List<Enrollment> enrollments = examEvent.getEnrollments();
+    final long participants = enrollments
+      .stream()
+      .filter(e ->
+        e.getStatus() == EnrollmentStatus.PAID ||
+        e.getStatus() == EnrollmentStatus.SHIFTED_FROM_QUEUE ||
+        e.getStatus() == EnrollmentStatus.EXPECTING_PAYMENT_UNFINISHED_ENROLLMENT
+      )
+      .count();
+
+    final boolean hasQueue = enrollments.stream().anyMatch(e -> e.getStatus() == EnrollmentStatus.QUEUED);
+
+    return hasQueue ? 0L : examEvent.getMaxParticipants() - participants;
+  }
+
+  public static boolean isCongested(final ExamEvent examEvent) {
+    final long openings = getOpenings(examEvent);
+    final long reservations = examEvent.getReservations().stream().filter(Reservation::isActive).count();
+
+    return isCongested(openings, reservations);
+  }
 
   public static boolean isCongested(final long openings, final long reservations) {
     return openings > 0 && openings <= reservations;

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
@@ -11,7 +11,6 @@ import { useDialog } from 'shared/hooks';
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch } from 'configs/redux';
 import { APIEndpoints } from 'enums/api';
-import { AppRoutes } from 'enums/app';
 import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
 import {
   PublicEnrollment,
@@ -21,7 +20,6 @@ import {
   cancelPublicEnrollment,
   cancelPublicEnrollmentAndRemoveReservation,
   loadPublicEnrollmentSave,
-  resetPublicEnrollment,
 } from 'redux/reducers/publicEnrollment';
 import { resetSelectedPublicExamEvent } from 'redux/reducers/publicExamEvent';
 import { RouteUtils } from 'utils/routes';
@@ -81,12 +79,7 @@ export const PublicEnrollmentControlButtons = ({
             variant: Variant.Contained,
             action: () => {
               dispatch(confirmAction);
-              dispatch(resetPublicEnrollment());
               dispatch(resetSelectedPublicExamEvent());
-
-              if (!reservationId) {
-                navigate(AppRoutes.PublicHomePage);
-              }
             },
           },
         ],

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -81,6 +81,8 @@ export const PublicEnrollmentGrid = ({
   );
 
   const isLoading = [status].includes(APIResponseStatus.InProgress);
+  const isAuthenticateStepActive =
+    activeStep === PublicEnrollmentFormStep.Authenticate;
   const isPreviewStepActive = activeStep === PublicEnrollmentFormStep.Preview;
   const isDoneStepActive = activeStep >= PublicEnrollmentFormStep.Done;
   const hasReservation = !!reservationDetails?.reservation;
@@ -126,20 +128,22 @@ export const PublicEnrollmentGrid = ({
                 {isPaymentSumAvailable && (
                   <PublicEnrollmentPaymentSum enrollment={enrollment} />
                 )}
-                {!isDoneStepActive && reservationDetails && (
-                  <PublicEnrollmentControlButtons
-                    submitStatus={enrollmentSubmitStatus}
-                    activeStep={activeStep}
-                    enrollment={enrollment}
-                    reservationDetails={reservationDetails}
-                    isLoading={isLoading}
-                    isStepValid={isStepValid}
-                    setShowValidation={setShowValidation}
-                    isPaymentLinkPreviewView={
-                      isShiftedFromQueue && isPreviewStepActive
-                    }
-                  />
-                )}
+                {!isDoneStepActive &&
+                  !isAuthenticateStepActive &&
+                  reservationDetails && (
+                    <PublicEnrollmentControlButtons
+                      submitStatus={enrollmentSubmitStatus}
+                      activeStep={activeStep}
+                      enrollment={enrollment}
+                      reservationDetails={reservationDetails}
+                      isLoading={isLoading}
+                      isStepValid={isStepValid}
+                      setShowValidation={setShowValidation}
+                      isPaymentLinkPreviewView={
+                        isShiftedFromQueue && isPreviewStepActive
+                      }
+                    />
+                  )}
               </div>
             )}
           </LoadingProgressIndicator>

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -35,7 +35,6 @@ export const PublicEnrollmentGrid = ({
     status,
     enrollmentSubmitStatus,
     cancelStatus,
-    enrollToQueue,
     enrollment,
     reservationDetails,
     reservationDetailsStatus,
@@ -85,7 +84,6 @@ export const PublicEnrollmentGrid = ({
   const isPreviewStepActive = activeStep === PublicEnrollmentFormStep.Preview;
   const isDoneStepActive = activeStep >= PublicEnrollmentFormStep.Done;
   const hasReservation = !!reservationDetails?.reservation;
-  const isExpectedToHaveOpenings = !enrollToQueue;
 
   const isShiftedFromQueue =
     enrollment.status === EnrollmentStatus.SHIFTED_FROM_QUEUE;
@@ -124,7 +122,6 @@ export const PublicEnrollmentGrid = ({
                   isLoading={isLoading}
                   setIsStepValid={setIsStepValid}
                   showValidation={showValidation}
-                  isExpectedToHaveOpenings={isExpectedToHaveOpenings}
                 />
                 {isPaymentSumAvailable && (
                   <PublicEnrollmentPaymentSum enrollment={enrollment} />

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -69,7 +69,10 @@ export const PublicEnrollmentGrid = ({
   useEffect(() => {
     if (cancelStatus === APIResponseStatus.Success) {
       navigate(AppRoutes.PublicHomePage);
-      dispatch(resetPublicEnrollment());
+
+      // Navigation is not instant so we delay reset a bit
+      // to prevent instant re-render of this component
+      setTimeout(() => dispatch(resetPublicEnrollment()), 50);
     }
   }, [cancelStatus, navigate, dispatch]);
 

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -16,6 +16,7 @@ import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
 import { useNavigationProtection } from 'hooks/useNavigationProtection';
 import {
   loadPublicEnrollment,
+  loadPublicExamEvent,
   resetPublicEnrollment,
 } from 'redux/reducers/publicEnrollment';
 import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
@@ -50,7 +51,11 @@ export const PublicEnrollmentGrid = ({
       !selectedExamEvent &&
       params.examEventId
     ) {
-      dispatch(loadPublicEnrollment(+params.examEventId));
+      if (activeStep === PublicEnrollmentFormStep.Authenticate) {
+        dispatch(loadPublicExamEvent(+params.examEventId));
+      } else {
+        dispatch(loadPublicEnrollment(+params.examEventId));
+      }
     }
   }, [
     dispatch,
@@ -59,6 +64,7 @@ export const PublicEnrollmentGrid = ({
     reservationDetails,
     selectedExamEvent,
     params.examEventId,
+    activeStep,
   ]);
 
   useEffect(() => {

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
@@ -14,7 +14,6 @@ export const PublicEnrollmentStepContents = ({
   isLoading,
   setIsStepValid,
   showValidation,
-  isExpectedToHaveOpenings,
   selectedExamEvent,
 }: {
   activeStep: PublicEnrollmentFormStep;
@@ -22,7 +21,6 @@ export const PublicEnrollmentStepContents = ({
   isLoading: boolean;
   setIsStepValid: (isValid: boolean) => void;
   showValidation: boolean;
-  isExpectedToHaveOpenings: boolean;
   selectedExamEvent: PublicExamEvent;
 }) => {
   switch (activeStep) {
@@ -30,7 +28,6 @@ export const PublicEnrollmentStepContents = ({
       return (
         <Authenticate
           isLoading={isLoading}
-          isExpectedToHaveOpenings={isExpectedToHaveOpenings}
           selectedExamEvent={selectedExamEvent}
         />
       );

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentTimer.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentTimer.tsx
@@ -14,7 +14,6 @@ import { PublicReservation } from 'interfaces/publicEnrollment';
 import {
   cancelPublicEnrollmentAndRemoveReservation,
   renewPublicEnrollmentReservation,
-  resetPublicEnrollment,
 } from 'redux/reducers/publicEnrollment';
 import { resetSelectedPublicExamEvent } from 'redux/reducers/publicExamEvent';
 
@@ -72,7 +71,6 @@ export const PublicEnrollmentTimer = ({
 
   const cancelReservation = () => {
     dispatch(cancelPublicEnrollmentAndRemoveReservation(reservation.id));
-    dispatch(resetPublicEnrollment());
     dispatch(resetSelectedPublicExamEvent());
   };
 

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/Authenticate.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/Authenticate.tsx
@@ -5,14 +5,13 @@ import { Color, Variant } from 'shared/enums';
 import { usePublicTranslation } from 'configs/i18n';
 import { APIEndpoints } from 'enums/api';
 import { PublicExamEvent } from 'interfaces/publicExamEvent';
+import { ExamEventUtils } from 'utils/examEvent';
 
 export const Authenticate = ({
   isLoading,
-  isExpectedToHaveOpenings,
   selectedExamEvent,
 }: {
   isLoading: boolean;
-  isExpectedToHaveOpenings: boolean;
   selectedExamEvent: PublicExamEvent;
 }) => {
   const [isRedirecting, setIsRedirecting] = useState(false);
@@ -32,7 +31,9 @@ export const Authenticate = ({
               selectedExamEvent.id.toString()
             ).replace(
               ':type',
-              isExpectedToHaveOpenings ? 'reservation' : 'queue'
+              ExamEventUtils.isEnrollingToQueue(selectedExamEvent)
+                ? 'queue'
+                : 'reservation'
             )}
             variant={Variant.Contained}
             onClick={() => setIsRedirecting(true)}

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/Authenticate.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/Authenticate.tsx
@@ -31,9 +31,9 @@ export const Authenticate = ({
               selectedExamEvent.id.toString()
             ).replace(
               ':type',
-              ExamEventUtils.isEnrollingToQueue(selectedExamEvent)
-                ? 'queue'
-                : 'reservation'
+              ExamEventUtils.hasOpenings(selectedExamEvent)
+                ? 'reservation'
+                : 'queue'
             )}
             variant={Variant.Contained}
             onClick={() => setIsRedirecting(true)}

--- a/frontend/packages/vkt/src/components/publicExamEvent/listing/PublicExamEventListingRow.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/listing/PublicExamEventListingRow.tsx
@@ -25,13 +25,12 @@ export const PublicExamEventListingRow = ({
   const { selectedExamEvent } = useAppSelector(publicEnrollmentSelector);
 
   const isSelected = examEvent.id === selectedExamEvent?.id;
-  const enrollToQueue = examEvent.openings <= 0;
 
   const handleRowClick = () => {
     dispatch(
       isSelected
         ? unsetPublicEnrollmentSelectedExam()
-        : setPublicEnrollmentSelectedExam([examEvent, enrollToQueue])
+        : setPublicEnrollmentSelectedExam(examEvent)
     );
   };
 

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -52,11 +52,18 @@ const publicEnrollmentSlice = createSlice({
     loadPublicEnrollment(state, _action: PayloadAction<number>) {
       state.reservationDetailsStatus = APIResponseStatus.InProgress;
     },
+    loadPublicExamEvent(state, _action: PayloadAction<number>) {
+      state.reservationDetailsStatus = APIResponseStatus.InProgress;
+    },
     initialisePublicEnrollment(state, _action: PayloadAction<PublicExamEvent>) {
       state.reservationDetailsStatus = APIResponseStatus.InProgress;
     },
     rejectPublicEnrollmentInitialisation(state) {
       state.reservationDetailsStatus = APIResponseStatus.Error;
+    },
+    rejectPublicExamEvent(state) {
+      state.reservationDetailsStatus = APIResponseStatus.Error;
+      state.selectedExamEvent = initialState.selectedExamEvent;
     },
     setPublicEnrollmentSelectedExam(
       state,
@@ -78,6 +85,10 @@ const publicEnrollmentSlice = createSlice({
       state.reservationDetails = action.payload;
       state.selectedExamEvent = action.payload.examEvent;
       state.enrollment = action.payload.enrollment ?? state.enrollment;
+    },
+    storePublicExamEvent(state, action: PayloadAction<PublicExamEvent>) {
+      state.reservationDetailsStatus = APIResponseStatus.Success;
+      state.selectedExamEvent = action.payload;
     },
     renewPublicEnrollmentReservation(state, _action: PayloadAction<number>) {
       state.status = APIResponseStatus.InProgress;
@@ -144,11 +155,14 @@ const publicEnrollmentSlice = createSlice({
 export const publicEnrollmentReducer = publicEnrollmentSlice.reducer;
 export const {
   loadPublicEnrollment,
+  loadPublicExamEvent,
   initialisePublicEnrollment,
   rejectPublicEnrollmentInitialisation,
+  rejectPublicExamEvent,
   setPublicEnrollmentSelectedExam,
   unsetPublicEnrollmentSelectedExam,
   storePublicEnrollmentInitialisation,
+  storePublicExamEvent,
   cancelPublicEnrollment,
   cancelPublicEnrollmentAndRemoveReservation,
   storePublicEnrollmentCancellation,

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -7,7 +7,6 @@ import {
   PublicReservationDetails,
 } from 'interfaces/publicEnrollment';
 import { PublicExamEvent } from 'interfaces/publicExamEvent';
-import { ExamEventUtils } from 'utils/examEvent';
 
 interface PublicEnrollmentState {
   reservationDetailsStatus: APIResponseStatus;
@@ -16,7 +15,6 @@ interface PublicEnrollmentState {
   enrollmentSubmitStatus: APIResponseStatus;
   cancelStatus: APIResponseStatus;
   selectedExamEvent?: PublicExamEvent;
-  enrollToQueue?: boolean;
   enrollment: PublicEnrollment;
 }
 
@@ -71,11 +69,9 @@ const publicEnrollmentSlice = createSlice({
       action: PayloadAction<PublicExamEvent>
     ) {
       state.selectedExamEvent = action.payload;
-      state.enrollToQueue = ExamEventUtils.isEnrollingToQueue(action.payload);
     },
     unsetPublicEnrollmentSelectedExam(state) {
       state.selectedExamEvent = initialState.selectedExamEvent;
-      state.enrollToQueue = initialState.enrollToQueue;
     },
     storePublicEnrollmentInitialisation(
       state,
@@ -89,7 +85,6 @@ const publicEnrollmentSlice = createSlice({
     storePublicExamEvent(state, action: PayloadAction<PublicExamEvent>) {
       state.reservationDetailsStatus = APIResponseStatus.Success;
       state.selectedExamEvent = action.payload;
-      state.enrollToQueue = ExamEventUtils.isEnrollingToQueue(action.payload);
     },
     renewPublicEnrollmentReservation(state, _action: PayloadAction<number>) {
       state.status = APIResponseStatus.InProgress;

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -7,6 +7,7 @@ import {
   PublicReservationDetails,
 } from 'interfaces/publicEnrollment';
 import { PublicExamEvent } from 'interfaces/publicExamEvent';
+import { ExamEventUtils } from 'utils/examEvent';
 
 interface PublicEnrollmentState {
   reservationDetailsStatus: APIResponseStatus;
@@ -67,11 +68,10 @@ const publicEnrollmentSlice = createSlice({
     },
     setPublicEnrollmentSelectedExam(
       state,
-      action: PayloadAction<[PublicExamEvent, boolean]>
+      action: PayloadAction<PublicExamEvent>
     ) {
-      const [examEvent, enrollToQueue] = action.payload;
-      state.selectedExamEvent = examEvent;
-      state.enrollToQueue = enrollToQueue;
+      state.selectedExamEvent = action.payload;
+      state.enrollToQueue = ExamEventUtils.isEnrollingToQueue(action.payload);
     },
     unsetPublicEnrollmentSelectedExam(state) {
       state.selectedExamEvent = initialState.selectedExamEvent;
@@ -89,6 +89,7 @@ const publicEnrollmentSlice = createSlice({
     storePublicExamEvent(state, action: PayloadAction<PublicExamEvent>) {
       state.reservationDetailsStatus = APIResponseStatus.Success;
       state.selectedExamEvent = action.payload;
+      state.enrollToQueue = ExamEventUtils.isEnrollingToQueue(action.payload);
     },
     renewPublicEnrollmentReservation(state, _action: PayloadAction<number>) {
       state.status = APIResponseStatus.InProgress;

--- a/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
@@ -10,7 +10,10 @@ import {
   PublicReservationDetailsResponse,
   PublicReservationResponse,
 } from 'interfaces/publicEnrollment';
-import { PublicExamEvent } from 'interfaces/publicExamEvent';
+import {
+  PublicExamEvent,
+  PublicExamEventResponse,
+} from 'interfaces/publicExamEvent';
 import { setAPIError } from 'redux/reducers/APIError';
 import {
   cancelPublicEnrollment,
@@ -18,13 +21,16 @@ import {
   initialisePublicEnrollment,
   loadPublicEnrollment,
   loadPublicEnrollmentSave,
+  loadPublicExamEvent,
   rejectPublicEnrollmentInitialisation,
   rejectPublicEnrollmentSave,
+  rejectPublicExamEvent,
   rejectPublicReservationRenew,
   renewPublicEnrollmentReservation,
   storePublicEnrollmentCancellation,
   storePublicEnrollmentInitialisation,
   storePublicEnrollmentSave,
+  storePublicExamEvent,
   updatePublicEnrollmentReservation,
 } from 'redux/reducers/publicEnrollment';
 import { NotifierUtils } from 'utils/notifier';
@@ -33,7 +39,7 @@ import { SerializationUtils } from 'utils/serialization';
 function* loadPublicEnrollmentSaga(action: PayloadAction<number>) {
   try {
     const eventId = action.payload;
-    const loadUrl = `${APIEndpoints.PublicExamEvent}/${eventId}`;
+    const loadUrl = `${APIEndpoints.PublicEnrollment}/${eventId}`;
 
     const response: AxiosResponse<PublicReservationDetailsResponse> =
       yield call(axiosInstance.get, loadUrl);
@@ -46,6 +52,28 @@ function* loadPublicEnrollmentSaga(action: PayloadAction<number>) {
     const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
     yield put(setAPIError(errorMessage));
     yield put(rejectPublicEnrollmentInitialisation());
+  }
+}
+
+function* loadPublicExamEventSaga(action: PayloadAction<number>) {
+  try {
+    const eventId = action.payload;
+    const loadUrl = `${APIEndpoints.PublicExamEvent}/${eventId}`;
+
+    const response: AxiosResponse<PublicExamEventResponse> = yield call(
+      axiosInstance.get,
+      loadUrl
+    );
+
+    const examEvent = SerializationUtils.deserializePublicExamEvent(
+      response.data
+    );
+
+    yield put(storePublicExamEvent(examEvent));
+  } catch (error) {
+    const errorMessage = NotifierUtils.getAPIErrorMessage(error as AxiosError);
+    yield put(setAPIError(errorMessage));
+    yield put(rejectPublicExamEvent());
   }
 }
 
@@ -145,6 +173,7 @@ function* loadPublicEnrollmentSaveSaga(
 
 export function* watchPublicEnrollments() {
   yield takeLatest(loadPublicEnrollment, loadPublicEnrollmentSaga);
+  yield takeLatest(loadPublicExamEvent, loadPublicExamEventSaga);
   yield takeLatest(initialisePublicEnrollment, initialisePublicEnrollmentSaga);
   yield takeLatest(
     renewPublicEnrollmentReservation,

--- a/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
@@ -39,7 +39,7 @@ import { SerializationUtils } from 'utils/serialization';
 function* loadPublicEnrollmentSaga(action: PayloadAction<number>) {
   try {
     const eventId = action.payload;
-    const loadUrl = `${APIEndpoints.PublicEnrollment}/${eventId}`;
+    const loadUrl = `${APIEndpoints.PublicExamEvent}/${eventId}/enrollment`;
 
     const response: AxiosResponse<PublicReservationDetailsResponse> =
       yield call(axiosInstance.get, loadUrl);

--- a/frontend/packages/vkt/src/utils/examEvent.ts
+++ b/frontend/packages/vkt/src/utils/examEvent.ts
@@ -3,6 +3,7 @@ import { DateUtils } from 'shared/utils';
 
 import { ExamLanguage, ExamLevel } from 'enums/app';
 import { ClerkListExamEvent } from 'interfaces/clerkListExamEvent';
+import { PublicExamEvent } from 'interfaces/publicExamEvent';
 
 export class ExamEventUtils {
   static getUpcomingExamEvents(examEvents: Array<ClerkListExamEvent>) {
@@ -15,6 +16,10 @@ export class ExamEventUtils {
     return examEvents.filter((e) =>
       DateUtils.isDatePartBefore(e.date, dayjs())
     );
+  }
+
+  static isEnrollingToQueue(examEvent: PublicExamEvent) {
+    return examEvent.openings <= 0;
   }
 
   static languageAndLevelText(

--- a/frontend/packages/vkt/src/utils/examEvent.ts
+++ b/frontend/packages/vkt/src/utils/examEvent.ts
@@ -18,8 +18,8 @@ export class ExamEventUtils {
     );
   }
 
-  static isEnrollingToQueue(examEvent: PublicExamEvent) {
-    return examEvent.openings <= 0;
+  static hasOpenings(examEvent: PublicExamEvent) {
+    return examEvent.openings > 0;
   }
 
   static languageAndLevelText(


### PR DESCRIPTION
## Yhteenveto

Tunnistaudu stepissa refresh ei toimi koska tässä kohtaa ei ole enrollmenttia tai reservationia luotu. Muutin niin, että hakee omasta API endpointista pelkät tutkinnon tiedot.