### PR TITLE
VKT(Backend): OPHVKTKEH-197 ylimääräisten henkilötietojen ja varausten poisto

### DIFF
--- a/backend/akr/src/main/java/fi/oph/akr/config/Constants.java
+++ b/backend/akr/src/main/java/fi/oph/akr/config/Constants.java
@@ -7,6 +7,7 @@ public class Constants {
   public static final String SERVICENAME = "akr";
   public static final String APP_ROLE = "APP_AKT";
 
+  // For now, no containers are run in untuva during nighttime
   // Daily at 9:00
   public static final String EVICT_PUBLIC_TRANSLATORS_CACHE_CRON = "0 0 9 * * *";
   // Daily at 9:30

--- a/backend/otr/src/main/java/fi/oph/otr/config/Constants.java
+++ b/backend/otr/src/main/java/fi/oph/otr/config/Constants.java
@@ -7,6 +7,7 @@ public class Constants {
   public static final String SERVICENAME = "otr";
   public static final String APP_ROLE = "APP_OIKEUSTULKKIREKISTERI_OIKEUSTULKKI_CRUD";
 
+  // For now, no containers are run in untuva during nighttime
   // Daily at 10:00
   public static final String CHECK_EXPIRING_QUALIFICATIONS_CRON = "0 0 10 * * *";
 }

--- a/backend/vkt/db/1_tables.sql
+++ b/backend/vkt/db/1_tables.sql
@@ -288,7 +288,8 @@ CREATE TABLE public.person (
     first_name text NOT NULL,
     oid character varying(255),
     other_identifier character varying(1024),
-    date_of_birth date
+    date_of_birth date,
+    latest_identified_at timestamp with time zone NOT NULL
 );
 
 

--- a/backend/vkt/db/3_liquibase.sql
+++ b/backend/vkt/db/3_liquibase.sql
@@ -86,6 +86,7 @@ COPY public.databasechangelog (id, author, filename, dateexecuted, orderexecuted
 2023-05-30-modify_payment-table_amount	mikhuttu	migrations.xml	2023-05-30 13:31:02.784706	21	EXECUTED	8:a1e8d1377da2bc6360f9971c8b052cb4	modifyDataType columnName=amount, tableName=payment		\N	4.9.1	\N	\N	5453462712
 2023-06-01-enrollment-payment-link-hash	jrkkp	migrations.xml	2023-06-01 13:53:01.472105	22	EXECUTED	8:0fc928a86fa41527372d8e8af21e813b	addColumn tableName=enrollment		\N	4.9.1	\N	\N	5627581378
 2023-06-02-rename-enrollment-status-EXPECTING_PAYMENT	mikhuttu	migrations.xml	2023-06-02 08:38:57.704377	23	EXECUTED	8:a35dc4c9e0d0d241f4293f0b2ba16224	insert tableName=enrollment_status; sql; sql		\N	4.9.1	\N	\N	5695137627
+2023-06-16-person-latest-identified-at	mikhuttu	migrations.xml	2023-06-16 09:46:36.462511	24	EXECUTED	8:51d5c16082a3fd83108e9c40e7ae78e6	addColumn tableName=person; sql; addNotNullConstraint columnName=latest_identified_at, tableName=person		\N	4.20.0	\N	\N	6908796433
 \.
 
 

--- a/backend/vkt/db/4_init.sql
+++ b/backend/vkt/db/4_init.sql
@@ -171,11 +171,12 @@ VALUES (
 );
 
 -- Insert persons
-INSERT INTO person(identity_number, last_name, first_name)
+INSERT INTO person(identity_number, last_name, first_name, latest_identified_at)
 SELECT
   'id' || i::text,
   last_names[mod(i, array_length(last_names, 1)) + 1],
-  first_names[mod(i, array_length(first_names, 1)) + 1]
+  first_names[mod(i, array_length(first_names, 1)) + 1],
+  NOW()
 FROM generate_series(1, 22) i,
    (SELECT ('{Anneli, Ella, Hanna, Iiris, Liisa, Maria, Ninni, Viivi, Sointu, Jaakko, Lasse, Kyösti, ' ||
             'Markku, Kristian, Mikael, Nooa, Otto, Olli}')::text[] AS first_names) AS first_name_table,

--- a/backend/vkt/src/main/java/fi/oph/vkt/config/Constants.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/config/Constants.java
@@ -7,6 +7,7 @@ public class Constants {
   public static final String SERVICENAME = "vkt";
   public static final String APP_ROLE = "APP_VKT";
 
+  // For now, no containers are run in untuva during nighttime
   // Daily at 9:00
   public static final String DELETE_CANCELED_UNFINISHED_ENROLLMENTS_CRON = "0 0 9 * * *";
   // Daily at 9:30

--- a/backend/vkt/src/main/java/fi/oph/vkt/config/Constants.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/config/Constants.java
@@ -9,4 +9,8 @@ public class Constants {
 
   // Daily at 9:00
   public static final String DELETE_CANCELED_UNFINISHED_ENROLLMENTS_CRON = "0 0 9 * * *";
+  // Daily at 9:30
+  public static final String DELETE_EXPIRED_RESERVATIONS_CRON = "0 30 9 * * *";
+  // Daily at 10:00
+  public static final String DELETE_OBSOLETE_PERSONS_CRON = "0 0 10 * * *";
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/model/Person.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/model/Person.java
@@ -9,6 +9,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -45,6 +46,9 @@ public class Person extends BaseEntity {
 
   @Column(name = "date_of_birth")
   private LocalDate dateOfBirth;
+
+  @Column(name = "latest_identified_at", nullable = false)
+  private LocalDateTime latestIdentifiedAt;
 
   @OneToMany(mappedBy = "person")
   private List<Enrollment> enrollments = new ArrayList<>();

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/PersonRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/PersonRepository.java
@@ -15,11 +15,9 @@ public interface PersonRepository extends BaseRepository<Person> {
   @Query(
     "SELECT p" +
     " FROM Person p" +
-    " LEFT JOIN p.enrollments e" +
-    " LEFT JOIN p.reservations r" +
     " WHERE p.latestIdentifiedAt < ?1" +
-    " GROUP BY p" +
-    " HAVING COUNT(e) = 0 AND COUNT(r) = 0"
+    " AND NOT EXISTS (SELECT 1 FROM Enrollment e WHERE e.person = p)" +
+    " AND NOT EXISTS (SELECT 1 FROM Reservation r WHERE r.person = p)"
   )
   List<Person> findObsoletePersons(final LocalDateTime latestIdentifiedBefore);
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/PersonRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/PersonRepository.java
@@ -15,9 +15,11 @@ public interface PersonRepository extends BaseRepository<Person> {
   @Query(
     "SELECT p" +
     " FROM Person p" +
-    " WHERE COUNT(p.enrollments) = 0" +
-    " AND count(p.reservations) = 0" +
-    " AND p.latestIdentifiedAt < ?1"
+    " LEFT JOIN p.enrollments e" +
+    " LEFT JOIN p.reservations r" +
+    " WHERE p.latestIdentifiedAt < ?1" +
+    " GROUP BY p" +
+    " HAVING COUNT(e) = 0 AND COUNT(r) = 0"
   )
   List<Person> findObsoletePersons(final LocalDateTime latestIdentifiedBefore);
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/repository/PersonRepository.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/repository/PersonRepository.java
@@ -1,11 +1,23 @@
 package fi.oph.vkt.repository;
 
 import fi.oph.vkt.model.Person;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PersonRepository extends BaseRepository<Person> {
   Optional<Person> findByIdentityNumber(final String identityNumber);
   Optional<Person> findByOtherIdentifier(final String otherIdentifier);
+
+  @Query(
+    "SELECT p" +
+    " FROM Person p" +
+    " WHERE COUNT(p.enrollments) = 0" +
+    " AND count(p.reservations) = 0" +
+    " AND p.latestIdentifiedAt < ?1"
+  )
+  List<Person> findObsoletePersons(final LocalDateTime latestIdentifiedBefore);
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/scheduled/DeleteExpiredReservations.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/scheduled/DeleteExpiredReservations.java
@@ -25,7 +25,7 @@ public class DeleteExpiredReservations {
   private final ClerkReservationService clerkReservationService;
 
   @Scheduled(cron = Constants.DELETE_EXPIRED_RESERVATIONS_CRON)
-  @SchedulerLock(name = "deleteObsoleteReservations", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
+  @SchedulerLock(name = "deleteExpiredReservations", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
   public void action() {
     SchedulingUtil.runWithScheduledUser(() -> {
       LOG.info("deleteExpiredReservations");

--- a/backend/vkt/src/main/java/fi/oph/vkt/scheduled/DeleteExpiredReservations.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/scheduled/DeleteExpiredReservations.java
@@ -1,0 +1,40 @@
+package fi.oph.vkt.scheduled;
+
+import fi.oph.vkt.config.Constants;
+import fi.oph.vkt.service.ClerkReservationService;
+import fi.oph.vkt.util.SchedulingUtil;
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteExpiredReservations {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DeleteExpiredReservations.class);
+
+  private static final String LOCK_AT_LEAST = "PT1S";
+
+  private static final String LOCK_AT_MOST = "PT1H";
+
+  @Resource
+  private final ClerkReservationService clerkReservationService;
+
+  @Scheduled(cron = Constants.DELETE_EXPIRED_RESERVATIONS_CRON)
+  @SchedulerLock(
+    name = "deleteObsoleteReservations",
+    lockAtLeastFor = LOCK_AT_LEAST,
+    lockAtMostFor = LOCK_AT_MOST
+  )
+  public void action() {
+    SchedulingUtil.runWithScheduledUser(() -> {
+      LOG.info("deleteExpiredReservations");
+
+      clerkReservationService.deleteExpiredReservations();
+    });
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/scheduled/DeleteObsoletePersons.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/scheduled/DeleteObsoletePersons.java
@@ -1,7 +1,7 @@
 package fi.oph.vkt.scheduled;
 
 import fi.oph.vkt.config.Constants;
-import fi.oph.vkt.service.ClerkReservationService;
+import fi.oph.vkt.service.ClerkPersonService;
 import fi.oph.vkt.util.SchedulingUtil;
 import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
@@ -13,24 +13,24 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class DeleteExpiredReservations {
+public class DeleteObsoletePersons {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DeleteExpiredReservations.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DeleteObsoletePersons.class);
 
   private static final String LOCK_AT_LEAST = "PT1S";
 
   private static final String LOCK_AT_MOST = "PT1H";
 
   @Resource
-  private final ClerkReservationService clerkReservationService;
+  private final ClerkPersonService clerkPersonService;
 
-  @Scheduled(cron = Constants.DELETE_EXPIRED_RESERVATIONS_CRON)
-  @SchedulerLock(name = "deleteObsoleteReservations", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
+  @Scheduled(cron = Constants.DELETE_OBSOLETE_PERSONS_CRON)
+  @SchedulerLock(name = "deleteObsoletePersons", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
   public void action() {
     SchedulingUtil.runWithScheduledUser(() -> {
-      LOG.info("deleteExpiredReservations");
+      LOG.info("deleteObsoletePersons");
 
-      clerkReservationService.deleteExpiredReservations();
+      clerkPersonService.deleteObsoletePersons();
     });
   }
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkPersonService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkPersonService.java
@@ -17,6 +17,7 @@ public class ClerkPersonService {
 
   @Transactional(isolation = Isolation.SERIALIZABLE)
   public void deleteObsoletePersons() {
+    // A suitable time for us to expect anyone enrolling to queue to either finish enrolling or quit
     final Duration ttl = Duration.of(24, ChronoUnit.HOURS);
 
     personRepository

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkPersonService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkPersonService.java
@@ -1,0 +1,26 @@
+package fi.oph.vkt.service;
+
+import fi.oph.vkt.repository.PersonRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ClerkPersonService {
+
+  private final PersonRepository personRepository;
+
+  @Transactional(isolation = Isolation.SERIALIZABLE)
+  public void deleteObsoletePersons() {
+    final Duration ttl = Duration.of(24, ChronoUnit.HOURS);
+
+    personRepository
+      .findObsoletePersons(LocalDateTime.now().minus(ttl))
+      .forEach(person -> personRepository.deleteById(person.getId()));
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkReservationService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkReservationService.java
@@ -17,7 +17,7 @@ public class ClerkReservationService {
 
   @Transactional(isolation = Isolation.SERIALIZABLE)
   public void deleteExpiredReservations() {
-    // Pretty much arbitrary ttl after expiry time of the reservation
+    // Pretty much arbitrary ttl after expiry time of a reservation
     final Duration ttl = Duration.of(1, ChronoUnit.HOURS);
 
     reservationRepository

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkReservationService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkReservationService.java
@@ -24,8 +24,6 @@ public class ClerkReservationService {
       .findAll()
       .stream()
       .filter(r -> r.getExpiresAt().plus(ttl).isBefore(LocalDateTime.now()))
-      .forEach(reservation -> {
-        reservationRepository.deleteById(reservation.getId());
-      });
+      .forEach(reservation -> reservationRepository.deleteById(reservation.getId()));
   }
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkReservationService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/ClerkReservationService.java
@@ -1,0 +1,31 @@
+package fi.oph.vkt.service;
+
+import fi.oph.vkt.repository.ReservationRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ClerkReservationService {
+
+  private final ReservationRepository reservationRepository;
+
+  @Transactional(isolation = Isolation.SERIALIZABLE)
+  public void deleteExpiredReservations() {
+    // Pretty much arbitrary ttl after expiry time of the reservation
+    final Duration ttl = Duration.of(1, ChronoUnit.HOURS);
+
+    reservationRepository
+      .findAll()
+      .stream()
+      .filter(r -> r.getExpiresAt().plus(ttl).isBefore(LocalDateTime.now()))
+      .forEach(reservation -> {
+        reservationRepository.deleteById(reservation.getId());
+      });
+  }
+}

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicAuthService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicAuthService.java
@@ -7,6 +7,7 @@ import fi.oph.vkt.service.auth.CasTicketValidationService;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -31,32 +32,13 @@ public class PublicAuthService {
     return casLoginUrl + "?service=" + casServiceUrl;
   }
 
-  private Person createPerson(
-    final String identityNumber,
-    final String firstName,
-    final String lastName,
-    final String OID,
-    final String otherIdentifier,
-    final LocalDate dateOfBirth
-  ) {
-    final Person person = new Person();
-    person.setIdentityNumber(identityNumber);
-    person.setLastName(lastName);
-    person.setFirstName(firstName);
-    person.setOid(OID);
-    person.setOtherIdentifier(otherIdentifier);
-    person.setDateOfBirth(dateOfBirth);
-
-    return personRepository.saveAndFlush(person);
-  }
-
   @Transactional
   public Person createPersonFromTicket(final String ticket, final long examEventId, final EnrollmentType type) {
     final Map<String, String> personDetails = casTicketValidationService.validate(ticket, examEventId, type);
 
     final String identityNumber = personDetails.get("identityNumber");
-    final String firstName = personDetails.get("firstName");
     final String lastName = personDetails.get("lastName");
+    final String firstName = personDetails.get("firstName");
     final String OID = personDetails.get("oid");
     final String otherIdentifier = personDetails.get("otherIdentifier");
     final String dateOfBirthRaw = personDetails.get("dateOfBirth");
@@ -64,12 +46,20 @@ public class PublicAuthService {
       ? null
       : LocalDate.parse(dateOfBirthRaw);
 
-    final Optional<Person> optionalPerson = identityNumber != null && !identityNumber.isEmpty()
+    final Optional<Person> optionalExistingPerson = identityNumber != null && !identityNumber.isEmpty()
       ? personRepository.findByIdentityNumber(identityNumber)
       : personRepository.findByOtherIdentifier(otherIdentifier);
 
-    return optionalPerson.orElseGet(() ->
-      createPerson(identityNumber, firstName, lastName, OID, otherIdentifier, dateOfBirth)
-    );
+    final Person person = optionalExistingPerson.orElse(new Person());
+
+    person.setIdentityNumber(identityNumber);
+    person.setLastName(lastName);
+    person.setFirstName(firstName);
+    person.setOid(OID);
+    person.setOtherIdentifier(otherIdentifier);
+    person.setDateOfBirth(dateOfBirth);
+    person.setLatestIdentifiedAt(LocalDateTime.now());
+
+    return personRepository.saveAndFlush(person);
   }
 }

--- a/backend/vkt/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/backend/vkt/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -613,10 +613,14 @@
 
     <changeSet id="2023-06-16-person-latest-identified-at" author="mikhuttu">
         <addColumn tableName="person">
-            <column name="latest_identified_at" type="TIMESTAMP WITH TIME ZONE">
-                <constraints nullable="false"/>
-            </column>
+            <column name="latest_identified_at" type="TIMESTAMP WITH TIME ZONE" />
         </addColumn>
+
+        <sql>
+            UPDATE person SET latest_identified_at = NOW()
+        </sql>
+
+        <addNotNullConstraint tableName="person" columnName="latest_identified_at" />
     </changeSet>
 
 </databaseChangeLog>

--- a/backend/vkt/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/backend/vkt/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -610,4 +610,13 @@
             DELETE FROM enrollment_status WHERE name = 'EXPECTING_PAYMENT'
         </sql>
     </changeSet>
+
+    <changeSet id="2023-06-16-person-latest-identified-at" author="mikhuttu">
+        <addColumn tableName="person">
+            <column name="latest_identified_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/backend/vkt/src/test/java/fi/oph/vkt/Factory.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/Factory.java
@@ -39,6 +39,7 @@ public class Factory {
     person.setOid(UUID.randomUUID().toString());
     person.setLastName("Tester");
     person.setFirstName("Foo Bar");
+    person.setLatestIdentifiedAt(LocalDateTime.now());
 
     return person;
   }

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/ClerkPersonServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/ClerkPersonServiceTest.java
@@ -1,0 +1,73 @@
+package fi.oph.vkt.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import fi.oph.vkt.Factory;
+import fi.oph.vkt.model.Enrollment;
+import fi.oph.vkt.model.ExamEvent;
+import fi.oph.vkt.model.Person;
+import fi.oph.vkt.model.Reservation;
+import fi.oph.vkt.repository.PersonRepository;
+import jakarta.annotation.Resource;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+public class ClerkPersonServiceTest {
+
+  @Resource
+  private PersonRepository personRepository;
+
+  @Resource
+  private TestEntityManager entityManager;
+
+  private ClerkPersonService clerkPersonService;
+
+  @BeforeEach
+  public void setup() {
+    clerkPersonService = new ClerkPersonService(personRepository);
+  }
+
+  @Test
+  public void testDeleteObsoletePersons() {
+    final ExamEvent examEvent = Factory.examEvent();
+    final LocalDateTime ttlPassed = LocalDateTime.now().minusDays(1).minusMinutes(1);
+
+    final Person person1 = Factory.person();
+    person1.setLatestIdentifiedAt(ttlPassed);
+    final Enrollment enrollment1 = Factory.enrollment(examEvent, person1);
+
+    final Person person2 = Factory.person();
+    person2.setLatestIdentifiedAt(ttlPassed);
+    final Reservation reservation2 = Factory.reservation(examEvent, person2);
+
+    final Person person3 = Factory.person();
+    person3.setLatestIdentifiedAt(ttlPassed.plusMinutes(5));
+
+    final Person person4 = Factory.person();
+    person4.setLatestIdentifiedAt(ttlPassed);
+
+    entityManager.persist(examEvent);
+    entityManager.persist(person1);
+    entityManager.persist(enrollment1);
+    entityManager.persist(person2);
+    entityManager.persist(reservation2);
+    entityManager.persist(person3);
+    entityManager.persist(person4);
+
+    clerkPersonService.deleteObsoletePersons();
+
+    final List<Person> persons = personRepository.findAll();
+
+    assertEquals(
+      Set.of(person1.getId(), person2.getId(), person3.getId()),
+      persons.stream().map(Person::getId).collect(Collectors.toSet())
+    );
+  }
+}


### PR DESCRIPTION
## Yhteenveto

- Umpeutuneet varaukset poistetaan päivittäin
- Ylimääräiset henkilötiedot (ei ilmoittautumisia, ei varauksia, ei ole tunnistautunut 24 tuntiin) poistetaan päivittäin

Lisäsin `person` tauluun lisäkenttänä tiedon tuosta, milloin ko. henkilö on tunnistautunut viimeksi. Päivitin myös PublicAuthServicen logiikkaa siten, että jos suomi.fi:n kautta tuleekin myöhemmin muuttuneet henkilötiedot samalle henkilölle, päivitetään kantaan ko. henkilön kohdalle uudet. Kyllä toi varmaan olis kuitenkin hyvä toimia noin? Toki ikävää jos aiemmin tehdyn ilmoittautumisen osalta ko. henkilön nimi sinne vaikka päivittyy nimenvaihdoksen seurauksena.

Voisin viedä tän myöhemmin vaikka untuvalle pyörittelyä varten jos toiminnallisuus ok.
