### PR TITLE
VKT(Frontend): OPHVKTKEH-208 publicEnrollment redux state refactoring

### DIFF
--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -43,7 +43,7 @@
           "registrationCloses": "Ilmoittautuminen sulkeutuu"
         },
         "expirationTimer": {
-          "cancelReservation": "Peruuta ilmoittautuminen",
+          "cancelEnrollment": "Peruuta ilmoittautuminen",
           "continueEnrollment": "Jatka ilmoittautumista",
           "reservationExpired": "Paikkavaraus tutkintoon umpeutunut",
           "reservationExpiredContinue": "Jatka etusivulle",

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
@@ -14,7 +14,7 @@ import { APIEndpoints } from 'enums/api';
 import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
 import {
   PublicEnrollment,
-  PublicReservationDetails,
+  PublicReservation,
 } from 'interfaces/publicEnrollment';
 import { PublicExamEvent } from 'interfaces/publicExamEvent';
 import {
@@ -28,7 +28,7 @@ export const PublicEnrollmentControlButtons = ({
   activeStep,
   examEvent,
   enrollment,
-  reservationDetails,
+  reservation,
   isLoading,
   isStepValid,
   setShowValidation,
@@ -38,7 +38,7 @@ export const PublicEnrollmentControlButtons = ({
   activeStep: PublicEnrollmentFormStep;
   examEvent: PublicExamEvent;
   enrollment: PublicEnrollment;
-  reservationDetails: PublicReservationDetails;
+  reservation?: PublicReservation;
   isLoading: boolean;
   isStepValid: boolean;
   setShowValidation: (showValidation: boolean) => void;
@@ -55,10 +55,9 @@ export const PublicEnrollmentControlButtons = ({
   const navigate = useNavigate();
 
   const { showDialog } = useDialog();
-  const reservationId = reservationDetails.reservation?.id;
+  const reservationId = reservation?.id;
   const examEventId = examEvent.id;
-  const isEnrollmentToQueue =
-    !reservationDetails.reservation && !isPaymentLinkPreviewView;
+  const isEnrollmentToQueue = !reservation && !isPaymentLinkPreviewView;
 
   const handleCancelBtnClick = () => {
     if (isPaymentLinkPreviewView) {
@@ -91,7 +90,7 @@ export const PublicEnrollmentControlButtons = ({
 
   useEffect(() => {
     if (submitStatus === APIResponseStatus.Success) {
-      if (reservationDetails.reservation) {
+      if (reservation) {
         // Safari needs time to re-render loading indicator
         setTimeout(() => {
           window.location.href = `${APIEndpoints.Payment}/create/${enrollment.id}/redirect`;
@@ -108,7 +107,7 @@ export const PublicEnrollmentControlButtons = ({
     dispatch,
     examEventId,
     enrollment.id,
-    reservationDetails.reservation,
+    reservation,
   ]);
 
   const handleBackBtnClick = () => {
@@ -138,9 +137,9 @@ export const PublicEnrollmentControlButtons = ({
       } else {
         dispatch(
           loadPublicEnrollmentSave({
-            examEventId,
             enrollment,
-            reservationDetails,
+            examEventId,
+            reservationId,
           })
         );
       }

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
@@ -16,6 +16,7 @@ import {
   PublicEnrollment,
   PublicReservationDetails,
 } from 'interfaces/publicEnrollment';
+import { PublicExamEvent } from 'interfaces/publicExamEvent';
 import {
   cancelPublicEnrollment,
   cancelPublicEnrollmentAndRemoveReservation,
@@ -25,6 +26,7 @@ import { RouteUtils } from 'utils/routes';
 
 export const PublicEnrollmentControlButtons = ({
   activeStep,
+  examEvent,
   enrollment,
   reservationDetails,
   isLoading,
@@ -34,6 +36,7 @@ export const PublicEnrollmentControlButtons = ({
   isPaymentLinkPreviewView,
 }: {
   activeStep: PublicEnrollmentFormStep;
+  examEvent: PublicExamEvent;
   enrollment: PublicEnrollment;
   reservationDetails: PublicReservationDetails;
   isLoading: boolean;
@@ -53,7 +56,7 @@ export const PublicEnrollmentControlButtons = ({
 
   const { showDialog } = useDialog();
   const reservationId = reservationDetails.reservation?.id;
-  const examEventId = reservationDetails.examEvent.id;
+  const examEventId = examEvent.id;
   const isEnrollmentToQueue =
     !reservationDetails.reservation && !isPaymentLinkPreviewView;
 
@@ -135,6 +138,7 @@ export const PublicEnrollmentControlButtons = ({
       } else {
         dispatch(
           loadPublicEnrollmentSave({
+            examEventId,
             enrollment,
             reservationDetails,
           })

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentDesktopGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentDesktopGrid.tsx
@@ -96,8 +96,7 @@ export const PublicEnrollmentDesktopGrid = ({
                 <PublicEnrollmentPaymentSum enrollment={enrollment} />
               )}
               {activeStep > PublicEnrollmentFormStep.Authenticate &&
-                !isPreviewPassed &&
-                reservation && (
+                !isPreviewPassed && (
                   <PublicEnrollmentControlButtons
                     submitStatus={enrollmentSubmitStatus}
                     activeStep={activeStep}

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -51,7 +51,7 @@ export const PublicEnrollmentGrid = ({
     enrollment,
     reservationDetails,
     reservationDetailsStatus,
-    selectedExamEvent,
+    examEvent,
   } = useAppSelector(publicEnrollmentSelector);
 
   // i18n
@@ -68,7 +68,7 @@ export const PublicEnrollmentGrid = ({
     if (
       reservationDetailsStatus === APIResponseStatus.NotStarted &&
       !reservationDetails &&
-      !selectedExamEvent &&
+      !examEvent &&
       params.examEventId
     ) {
       if (activeStep === PublicEnrollmentFormStep.Authenticate) {
@@ -82,7 +82,7 @@ export const PublicEnrollmentGrid = ({
     reservationDetailsStatus,
     enrollment,
     reservationDetails,
-    selectedExamEvent,
+    examEvent,
     params.examEventId,
     activeStep,
   ]);
@@ -113,7 +113,7 @@ export const PublicEnrollmentGrid = ({
     []
   );
 
-  if (!selectedExamEvent) {
+  if (!examEvent) {
     return (
       <Grid className="public-enrollment__grid" item>
         <LoadingProgressIndicator
@@ -137,7 +137,7 @@ export const PublicEnrollmentGrid = ({
 
   const isEnrollmentToQueue =
     (activeStep === PublicEnrollmentFormStep.Authenticate &&
-      !ExamEventUtils.hasOpenings(selectedExamEvent)) ||
+      !ExamEventUtils.hasOpenings(examEvent)) ||
     (activeStep > PublicEnrollmentFormStep.Authenticate && !hasReservation);
 
   const isShiftedFromQueue =
@@ -211,12 +211,12 @@ export const PublicEnrollmentGrid = ({
                 isEnrollmentToQueue={isEnrollmentToQueue}
               />
               <PublicEnrollmentExamEventDetails
-                examEvent={selectedExamEvent}
+                examEvent={examEvent}
                 showOpenings={!isPreviewPassed && !isShiftedFromQueue}
                 isEnrollmentToQueue={isEnrollmentToQueue}
               />
               <PublicEnrollmentStepContents
-                selectedExamEvent={selectedExamEvent}
+                examEvent={examEvent}
                 activeStep={activeStep}
                 enrollment={enrollment}
                 isLoading={isLoading}
@@ -237,6 +237,7 @@ export const PublicEnrollmentGrid = ({
               <div className="rows">
                 <PublicEnrollmentControlButtons
                   submitStatus={enrollmentSubmitStatus}
+                  examEvent={examEvent}
                   activeStep={activeStep}
                   enrollment={enrollment}
                   reservationDetails={reservationDetails}
@@ -287,12 +288,12 @@ export const PublicEnrollmentGrid = ({
                 isEnrollmentToQueue={isEnrollmentToQueue}
               />
               <PublicEnrollmentExamEventDetails
-                examEvent={selectedExamEvent}
+                examEvent={examEvent}
                 showOpenings={!isPreviewPassed && !isShiftedFromQueue}
                 isEnrollmentToQueue={isEnrollmentToQueue}
               />
               <PublicEnrollmentStepContents
-                selectedExamEvent={selectedExamEvent}
+                examEvent={examEvent}
                 activeStep={activeStep}
                 enrollment={enrollment}
                 isLoading={isLoading}
@@ -307,6 +308,7 @@ export const PublicEnrollmentGrid = ({
                 reservationDetails && (
                   <PublicEnrollmentControlButtons
                     submitStatus={enrollmentSubmitStatus}
+                    examEvent={examEvent}
                     activeStep={activeStep}
                     enrollment={enrollment}
                     reservationDetails={reservationDetails}

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -110,7 +110,10 @@ export const PublicEnrollmentGrid = ({
     []
   );
 
-  if (!examEvent) {
+  if (
+    enrollmentInitialisationStatus !== APIResponseStatus.Success ||
+    !examEvent
+  ) {
     return (
       <Grid className="public-enrollment__grid" item>
         <LoadingProgressIndicator

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -24,7 +24,7 @@ import { AppRoutes, EnrollmentStatus } from 'enums/app';
 import { PublicEnrollmentFormStep } from 'enums/publicEnrollment';
 import { useNavigationProtection } from 'hooks/useNavigationProtection';
 import {
-  loadPublicEnrollment,
+  loadEnrollmentInitialisation,
   loadPublicExamEvent,
   resetPublicEnrollment,
 } from 'redux/reducers/publicEnrollment';
@@ -50,7 +50,7 @@ export const PublicEnrollmentGrid = ({
     cancelStatus,
     enrollment,
     reservation,
-    reservationDetailsStatus,
+    enrollmentInitialisationStatus,
     examEvent,
   } = useAppSelector(publicEnrollmentSelector);
 
@@ -66,19 +66,19 @@ export const PublicEnrollmentGrid = ({
 
   useEffect(() => {
     if (
-      reservationDetailsStatus === APIResponseStatus.NotStarted &&
+      enrollmentInitialisationStatus === APIResponseStatus.NotStarted &&
       !examEvent &&
       params.examEventId
     ) {
       if (activeStep === PublicEnrollmentFormStep.Authenticate) {
         dispatch(loadPublicExamEvent(+params.examEventId));
       } else {
-        dispatch(loadPublicEnrollment(+params.examEventId));
+        dispatch(loadEnrollmentInitialisation(+params.examEventId));
       }
     }
   }, [
     dispatch,
-    reservationDetailsStatus,
+    enrollmentInitialisationStatus,
     examEvent,
     params.examEventId,
     activeStep,

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -49,7 +49,7 @@ export const PublicEnrollmentGrid = ({
     enrollmentSubmitStatus,
     cancelStatus,
     enrollment,
-    reservationDetails,
+    reservation,
     reservationDetailsStatus,
     examEvent,
   } = useAppSelector(publicEnrollmentSelector);
@@ -67,7 +67,6 @@ export const PublicEnrollmentGrid = ({
   useEffect(() => {
     if (
       reservationDetailsStatus === APIResponseStatus.NotStarted &&
-      !reservationDetails &&
       !examEvent &&
       params.examEventId
     ) {
@@ -80,8 +79,6 @@ export const PublicEnrollmentGrid = ({
   }, [
     dispatch,
     reservationDetailsStatus,
-    enrollment,
-    reservationDetails,
     examEvent,
     params.examEventId,
     activeStep,
@@ -133,7 +130,7 @@ export const PublicEnrollmentGrid = ({
 
   const isPreviewStepActive = activeStep === PublicEnrollmentFormStep.Preview;
   const isPreviewPassed = activeStep > PublicEnrollmentFormStep.Preview;
-  const hasReservation = !!reservationDetails?.reservation;
+  const hasReservation = !!reservation;
 
   const isEnrollmentToQueue =
     (activeStep === PublicEnrollmentFormStep.Authenticate &&
@@ -163,9 +160,9 @@ export const PublicEnrollmentGrid = ({
             setState={memoizedSetAppBarState}
           >
             <div className="rows">
-              {reservationDetails?.reservation && !isPreviewPassed && (
+              {reservation && !isPreviewPassed && (
                 <PublicEnrollmentTimer
-                  reservation={reservationDetails.reservation}
+                  reservation={reservation}
                   isLoading={isLoading}
                 />
               )}
@@ -227,8 +224,7 @@ export const PublicEnrollmentGrid = ({
           </LoadingProgressIndicator>
         </Paper>
         {activeStep > PublicEnrollmentFormStep.Authenticate &&
-          !isPreviewPassed &&
-          reservationDetails && (
+          !isPreviewPassed && (
             <StackableMobileAppBar
               order={2}
               state={appBarState}
@@ -240,7 +236,7 @@ export const PublicEnrollmentGrid = ({
                   examEvent={examEvent}
                   activeStep={activeStep}
                   enrollment={enrollment}
-                  reservationDetails={reservationDetails}
+                  reservation={reservation}
                   isLoading={isLoading}
                   isStepValid={isStepValid}
                   setShowValidation={setShowValidation}
@@ -277,9 +273,9 @@ export const PublicEnrollmentGrid = ({
                   includePaymentStep={hasReservation}
                 />
               )}
-              {reservationDetails?.reservation && !isPreviewPassed && (
+              {reservation && !isPreviewPassed && (
                 <PublicEnrollmentTimer
-                  reservation={reservationDetails.reservation}
+                  reservation={reservation}
                   isLoading={isLoading}
                 />
               )}
@@ -304,14 +300,13 @@ export const PublicEnrollmentGrid = ({
                 <PublicEnrollmentPaymentSum enrollment={enrollment} />
               )}
               {activeStep > PublicEnrollmentFormStep.Authenticate &&
-                !isPreviewPassed &&
-                reservationDetails && (
+                !isPreviewPassed && (
                   <PublicEnrollmentControlButtons
                     submitStatus={enrollmentSubmitStatus}
                     examEvent={examEvent}
                     activeStep={activeStep}
                     enrollment={enrollment}
-                    reservationDetails={reservationDetails}
+                    reservation={reservation}
                     isLoading={isLoading}
                     isStepValid={isStepValid}
                     setShowValidation={setShowValidation}

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentPhoneGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentPhoneGrid.tsx
@@ -179,8 +179,7 @@ export const PublicEnrollmentPhoneGrid = ({
           </LoadingProgressIndicator>
         </Paper>
         {activeStep > PublicEnrollmentFormStep.Authenticate &&
-          !isPreviewPassed &&
-          reservation && (
+          !isPreviewPassed && (
             <StackableMobileAppBar
               order={2}
               state={appBarState}

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentStepContents.tsx
@@ -14,18 +14,18 @@ export const PublicEnrollmentStepContents = ({
   isLoading,
   setIsStepValid,
   showValidation,
-  selectedExamEvent,
+  examEvent,
 }: {
   activeStep: PublicEnrollmentFormStep;
   enrollment: PublicEnrollment;
   isLoading: boolean;
   setIsStepValid: (isValid: boolean) => void;
   showValidation: boolean;
-  selectedExamEvent: PublicExamEvent;
+  examEvent: PublicExamEvent;
 }) => {
   switch (activeStep) {
     case PublicEnrollmentFormStep.Authenticate:
-      return <Authenticate selectedExamEvent={selectedExamEvent} />;
+      return <Authenticate examEvent={examEvent} />;
     case PublicEnrollmentFormStep.FillContactDetails:
       return (
         <FillContactDetails

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentTimer.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentTimer.tsx
@@ -13,7 +13,7 @@ import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { PublicReservation } from 'interfaces/publicEnrollment';
 import {
   cancelPublicEnrollmentAndRemoveReservation,
-  renewPublicEnrollmentReservation,
+  renewReservation,
 } from 'redux/reducers/publicEnrollment';
 import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
 
@@ -67,12 +67,12 @@ export const PublicEnrollmentTimer = ({
     };
   }, [reservation, expirationTime]);
 
-  const renewReservation = () => {
-    dispatch(renewPublicEnrollmentReservation(reservation.id));
+  const handleRenewReservation = () => {
+    dispatch(renewReservation(reservation.id));
     setTimerWarningClosed(true);
   };
 
-  const cancelReservation = () => {
+  const handleCancelEnrollment = () => {
     dispatch(cancelPublicEnrollmentAndRemoveReservation(reservation.id));
   };
 
@@ -123,20 +123,20 @@ export const PublicEnrollmentTimer = ({
               isLoading={cancelLoading}
             >
               <CustomButton
-                data-testid="public-enrollment__cancel-reservation-modal-button"
+                data-testid="public-enrollment__cancel-enrollment-modal-button"
                 variant={Variant.Text}
                 color={Color.Secondary}
-                onClick={cancelReservation}
+                onClick={handleCancelEnrollment}
                 disabled={cancelLoading || isLoading}
               >
-                {t('cancelReservation')}
+                {t('cancelEnrollment')}
               </CustomButton>
             </LoadingProgressIndicator>
             <CustomButton
               data-testid="public-enrollment__renew-reservation-modal-button"
               variant={Variant.Contained}
               color={Color.Secondary}
-              onClick={renewReservation}
+              onClick={handleRenewReservation}
               disabled={cancelLoading || isLoading}
             >
               {t('continueEnrollment')}
@@ -164,7 +164,7 @@ export const PublicEnrollmentTimer = ({
                 data-testid="public-enrollment__reservation-expired-ok-button"
                 variant={Variant.Text}
                 color={Color.Secondary}
-                onClick={cancelReservation}
+                onClick={handleCancelEnrollment}
                 disabled={cancelLoading || isLoading}
               >
                 {t('reservationExpiredContinue')}

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/Authenticate.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/Authenticate.tsx
@@ -7,11 +7,7 @@ import { APIEndpoints } from 'enums/api';
 import { PublicExamEvent } from 'interfaces/publicExamEvent';
 import { ExamEventUtils } from 'utils/examEvent';
 
-export const Authenticate = ({
-  selectedExamEvent,
-}: {
-  selectedExamEvent: PublicExamEvent;
-}) => {
+export const Authenticate = ({ examEvent }: { examEvent: PublicExamEvent }) => {
   const [isRedirecting, setIsRedirecting] = useState(false);
   const { t } = usePublicTranslation({
     keyPrefix: 'vkt.component.publicEnrollment.steps.authenticate',
@@ -23,10 +19,10 @@ export const Authenticate = ({
 
     window.location.href = APIEndpoints.PublicAuthLogin.replace(
       ':examEventId',
-      selectedExamEvent.id.toString()
+      examEvent.id.toString()
     ).replace(
       ':type',
-      ExamEventUtils.hasOpenings(selectedExamEvent) ? 'reservation' : 'queue'
+      ExamEventUtils.hasOpenings(examEvent) ? 'reservation' : 'queue'
     );
   };
 

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/PersonDetails.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/PersonDetails.tsx
@@ -11,8 +11,7 @@ export const PersonDetails = () => {
     keyPrefix: 'vkt.component.publicEnrollment.steps.personDetails',
   });
 
-  const { reservationDetails } = useAppSelector(publicEnrollmentSelector);
-  const person = reservationDetails?.person;
+  const { person } = useAppSelector(publicEnrollmentSelector);
 
   if (!person) {
     return null;

--- a/frontend/packages/vkt/src/components/publicExamEvent/listing/row/PublicExamEventCells.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/listing/row/PublicExamEventCells.tsx
@@ -12,7 +12,7 @@ import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes, ExamLevel } from 'enums/app';
 import { PublicExamEvent } from 'interfaces/publicExamEvent';
-import { setPublicEnrollmentSelectedExam } from 'redux/reducers/publicEnrollment';
+import { setPublicExamEvent } from 'redux/reducers/publicEnrollment';
 import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
 import { ExamEventUtils } from 'utils/examEvent';
 
@@ -77,9 +77,8 @@ export const PublicExamEventPhoneCells = ({
   });
   const translateCommon = useCommonTranslation();
 
-  const { reservationDetailsStatus, selectedExamEvent } = useAppSelector(
-    publicEnrollmentSelector
-  );
+  const { reservationDetailsStatus, examEvent: selectedExamEvent } =
+    useAppSelector(publicEnrollmentSelector);
   const isInitialisationInProgress =
     reservationDetailsStatus === APIResponseStatus.InProgress;
 
@@ -87,7 +86,7 @@ export const PublicExamEventPhoneCells = ({
   const navigate = useNavigate();
 
   const handleOnClick = () => {
-    dispatch(setPublicEnrollmentSelectedExam(examEvent));
+    dispatch(setPublicExamEvent(examEvent));
     navigate(
       AppRoutes.PublicAuth.replace(':examEventId', examEvent.id.toString())
     );
@@ -146,9 +145,8 @@ export const PublicExamEventDesktopCells = ({
   });
   const translateCommon = useCommonTranslation();
 
-  const { reservationDetailsStatus, selectedExamEvent } = useAppSelector(
-    publicEnrollmentSelector
-  );
+  const { reservationDetailsStatus, examEvent: selectedExamEvent } =
+    useAppSelector(publicEnrollmentSelector);
   const isInitialisationInProgress =
     reservationDetailsStatus === APIResponseStatus.InProgress;
 
@@ -156,7 +154,7 @@ export const PublicExamEventDesktopCells = ({
   const navigate = useNavigate();
 
   const handleOnClick = () => {
-    dispatch(setPublicEnrollmentSelectedExam(examEvent));
+    dispatch(setPublicExamEvent(examEvent));
     navigate(
       AppRoutes.PublicAuth.replace(':examEventId', examEvent.id.toString())
     );

--- a/frontend/packages/vkt/src/components/publicExamEvent/listing/row/PublicExamEventCells.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/listing/row/PublicExamEventCells.tsx
@@ -12,7 +12,7 @@ import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes, ExamLevel } from 'enums/app';
 import { PublicExamEvent } from 'interfaces/publicExamEvent';
-import { setPublicExamEvent } from 'redux/reducers/publicEnrollment';
+import { storePublicExamEvent } from 'redux/reducers/publicEnrollment';
 import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
 import { ExamEventUtils } from 'utils/examEvent';
 
@@ -77,16 +77,16 @@ export const PublicExamEventPhoneCells = ({
   });
   const translateCommon = useCommonTranslation();
 
-  const { reservationDetailsStatus, examEvent: selectedExamEvent } =
+  const { enrollmentInitialisationStatus, examEvent: selectedExamEvent } =
     useAppSelector(publicEnrollmentSelector);
   const isInitialisationInProgress =
-    reservationDetailsStatus === APIResponseStatus.InProgress;
+    enrollmentInitialisationStatus === APIResponseStatus.InProgress;
 
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
   const handleOnClick = () => {
-    dispatch(setPublicExamEvent(examEvent));
+    dispatch(storePublicExamEvent(examEvent));
     navigate(
       AppRoutes.PublicAuth.replace(':examEventId', examEvent.id.toString())
     );
@@ -145,16 +145,16 @@ export const PublicExamEventDesktopCells = ({
   });
   const translateCommon = useCommonTranslation();
 
-  const { reservationDetailsStatus, examEvent: selectedExamEvent } =
+  const { enrollmentInitialisationStatus, examEvent: selectedExamEvent } =
     useAppSelector(publicEnrollmentSelector);
   const isInitialisationInProgress =
-    reservationDetailsStatus === APIResponseStatus.InProgress;
+    enrollmentInitialisationStatus === APIResponseStatus.InProgress;
 
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
   const handleOnClick = () => {
-    dispatch(setPublicExamEvent(examEvent));
+    dispatch(storePublicExamEvent(examEvent));
     navigate(
       AppRoutes.PublicAuth.replace(':examEventId', examEvent.id.toString())
     );

--- a/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
@@ -5,10 +5,7 @@ import {
   CertificateShippingData,
   PartialExamsAndSkills,
 } from 'interfaces/common/enrollment';
-import {
-  PublicExamEvent,
-  PublicExamEventResponse,
-} from 'interfaces/publicExamEvent';
+import { PublicExamEventResponse } from 'interfaces/publicExamEvent';
 import { PublicPerson, PublicPersonResponse } from 'interfaces/publicPerson';
 import { WithId } from 'interfaces/with';
 
@@ -21,9 +18,7 @@ export interface PublicReservation extends WithId {
 
 export interface PublicReservationDetails {
   person: PublicPerson;
-  examEvent: PublicExamEvent;
   reservation?: PublicReservation; // undefined if enrolling to queue
-  enrollment?: PublicEnrollment;
 }
 
 export interface PublicReservationResponse
@@ -34,13 +29,10 @@ export interface PublicReservationResponse
 }
 
 export interface PublicReservationDetailsResponse
-  extends Omit<
-    PublicReservationDetails,
-    'examEvent' | 'reservation' | 'person'
-  > {
+  extends Omit<PublicReservationDetails, 'person' | 'reservation'> {
   examEvent: PublicExamEventResponse;
-  reservation?: PublicReservationResponse;
   person: PublicPersonResponse;
+  reservation?: PublicReservationResponse;
   enrollment?: PublicEnrollment;
 }
 

--- a/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
@@ -6,7 +6,7 @@ import {
   PartialExamsAndSkills,
 } from 'interfaces/common/enrollment';
 import { PublicExamEventResponse } from 'interfaces/publicExamEvent';
-import { PublicPerson, PublicPersonResponse } from 'interfaces/publicPerson';
+import { PublicPersonResponse } from 'interfaces/publicPerson';
 import { WithId } from 'interfaces/with';
 
 export interface PublicReservation extends WithId {
@@ -16,11 +16,6 @@ export interface PublicReservation extends WithId {
   isRenewable: boolean;
 }
 
-export interface PublicReservationDetails {
-  person: PublicPerson;
-  reservation?: PublicReservation; // undefined if enrolling to queue
-}
-
 export interface PublicReservationResponse
   extends Omit<PublicReservation, 'expiresAt' | 'renewedAt' | 'createdAt'> {
   expiresAt: string;
@@ -28,8 +23,7 @@ export interface PublicReservationResponse
   createdAt: string;
 }
 
-export interface PublicReservationDetailsResponse
-  extends Omit<PublicReservationDetails, 'person' | 'reservation'> {
+export interface PublicReservationDetailsResponse {
   examEvent: PublicExamEventResponse;
   person: PublicPersonResponse;
   reservation?: PublicReservationResponse;

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -9,7 +9,7 @@ import { PublicExamEvent } from 'interfaces/publicExamEvent';
 import { PublicPerson } from 'interfaces/publicPerson';
 
 interface PublicEnrollmentState {
-  reservationDetailsStatus: APIResponseStatus; // TODO: rename
+  enrollmentInitialisationStatus: APIResponseStatus;
   renewReservationStatus: APIResponseStatus;
   enrollmentSubmitStatus: APIResponseStatus;
   cancelStatus: APIResponseStatus;
@@ -20,7 +20,7 @@ interface PublicEnrollmentState {
 }
 
 const initialState: PublicEnrollmentState = {
-  reservationDetailsStatus: APIResponseStatus.NotStarted,
+  enrollmentInitialisationStatus: APIResponseStatus.NotStarted,
   renewReservationStatus: APIResponseStatus.NotStarted,
   enrollmentSubmitStatus: APIResponseStatus.NotStarted,
   cancelStatus: APIResponseStatus.NotStarted,
@@ -43,32 +43,34 @@ const initialState: PublicEnrollmentState = {
     previousEnrollment: '',
     privacyStatementConfirmation: false,
   },
+  examEvent: undefined,
+  person: undefined,
+  reservation: undefined,
 };
 
 const publicEnrollmentSlice = createSlice({
   name: 'publicEnrollment',
   initialState,
   reducers: {
-    loadPublicEnrollment(state, _action: PayloadAction<number>) {
-      state.reservationDetailsStatus = APIResponseStatus.InProgress;
-    },
+    // TODO: the following three actions are used for fetching exam event details for Authenticate step and should use a separate status
     loadPublicExamEvent(state, _action: PayloadAction<number>) {
-      state.reservationDetailsStatus = APIResponseStatus.InProgress;
-    },
-    initialisePublicEnrollment(state, _action: PayloadAction<PublicExamEvent>) {
-      state.reservationDetailsStatus = APIResponseStatus.InProgress;
-    },
-    rejectPublicEnrollmentInitialisation(state) {
-      state.reservationDetailsStatus = APIResponseStatus.Error;
+      state.enrollmentInitialisationStatus = APIResponseStatus.InProgress;
     },
     rejectPublicExamEvent(state) {
-      state.reservationDetailsStatus = APIResponseStatus.Error;
+      state.enrollmentInitialisationStatus = APIResponseStatus.Error;
       state.examEvent = initialState.examEvent;
     },
-    setPublicExamEvent(state, action: PayloadAction<PublicExamEvent>) {
+    storePublicExamEvent(state, action: PayloadAction<PublicExamEvent>) {
+      state.enrollmentInitialisationStatus = APIResponseStatus.Success;
       state.examEvent = action.payload;
     },
-    storeReservationDetails(
+    loadEnrollmentInitialisation(state, _action: PayloadAction<number>) {
+      state.enrollmentInitialisationStatus = APIResponseStatus.InProgress;
+    },
+    rejectEnrollmentInitialisation(state) {
+      state.enrollmentInitialisationStatus = APIResponseStatus.Error;
+    },
+    storeEnrollmentInitialisation(
       state,
       action: PayloadAction<{
         examEvent: PublicExamEvent;
@@ -77,26 +79,19 @@ const publicEnrollmentSlice = createSlice({
         enrollment?: PublicEnrollment;
       }>
     ) {
-      state.reservationDetailsStatus = APIResponseStatus.Success;
+      state.enrollmentInitialisationStatus = APIResponseStatus.Success;
       state.enrollment = action.payload.enrollment ?? state.enrollment;
       state.examEvent = action.payload.examEvent;
       state.person = action.payload.person;
       state.reservation = action.payload.reservation;
     },
-    storePublicExamEvent(state, action: PayloadAction<PublicExamEvent>) {
-      state.reservationDetailsStatus = APIResponseStatus.Success;
-      state.examEvent = action.payload;
-    },
-    renewPublicEnrollmentReservation(state, _action: PayloadAction<number>) {
+    renewReservation(state, _action: PayloadAction<number>) {
       state.renewReservationStatus = APIResponseStatus.InProgress;
     },
-    rejectPublicReservationRenew(state) {
+    rejectReservationRenew(state) {
       state.renewReservationStatus = APIResponseStatus.Error;
     },
-    updatePublicEnrollmentReservation(
-      state,
-      action: PayloadAction<PublicReservation>
-    ) {
+    storeReservationRenew(state, action: PayloadAction<PublicReservation>) {
       state.renewReservationStatus = APIResponseStatus.Success;
       state.reservation = action.payload;
     },
@@ -113,7 +108,8 @@ const publicEnrollmentSlice = createSlice({
       state.cancelStatus = APIResponseStatus.Success;
     },
     resetPublicEnrollment(state) {
-      state.reservationDetailsStatus = initialState.reservationDetailsStatus;
+      state.enrollmentInitialisationStatus =
+        initialState.enrollmentInitialisationStatus;
       state.renewReservationStatus = initialState.renewReservationStatus;
       state.enrollmentSubmitStatus = initialState.enrollmentSubmitStatus;
       state.cancelStatus = initialState.cancelStatus;
@@ -150,23 +146,21 @@ const publicEnrollmentSlice = createSlice({
 
 export const publicEnrollmentReducer = publicEnrollmentSlice.reducer;
 export const {
-  loadPublicEnrollment,
   loadPublicExamEvent,
-  initialisePublicEnrollment,
-  rejectPublicEnrollmentInitialisation,
   rejectPublicExamEvent,
-  setPublicExamEvent,
-  storeReservationDetails,
   storePublicExamEvent,
+  loadEnrollmentInitialisation,
+  rejectEnrollmentInitialisation,
+  storeEnrollmentInitialisation,
+  renewReservation,
+  rejectReservationRenew,
+  storeReservationRenew,
   cancelPublicEnrollment,
   cancelPublicEnrollmentAndRemoveReservation,
   storePublicEnrollmentCancellation,
   resetPublicEnrollment,
   updatePublicEnrollment,
-  updatePublicEnrollmentReservation,
   loadPublicEnrollmentSave,
   rejectPublicEnrollmentSave,
-  rejectPublicReservationRenew,
   storePublicEnrollmentSave,
-  renewPublicEnrollmentReservation,
 } = publicEnrollmentSlice.actions;

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -14,7 +14,7 @@ interface PublicEnrollmentState {
   renewReservationStatus: APIResponseStatus;
   enrollmentSubmitStatus: APIResponseStatus;
   cancelStatus: APIResponseStatus;
-  selectedExamEvent?: PublicExamEvent;
+  examEvent?: PublicExamEvent;
   enrollment: PublicEnrollment;
 }
 
@@ -62,26 +62,27 @@ const publicEnrollmentSlice = createSlice({
     },
     rejectPublicExamEvent(state) {
       state.reservationDetailsStatus = APIResponseStatus.Error;
-      state.selectedExamEvent = initialState.selectedExamEvent;
+      state.examEvent = initialState.examEvent;
     },
-    setPublicEnrollmentSelectedExam(
-      state,
-      action: PayloadAction<PublicExamEvent>
-    ) {
-      state.selectedExamEvent = action.payload;
+    setPublicExamEvent(state, action: PayloadAction<PublicExamEvent>) {
+      state.examEvent = action.payload;
     },
-    storePublicEnrollmentInitialisation(
+    storeReservationDetails(
       state,
       action: PayloadAction<PublicReservationDetails>
     ) {
       state.reservationDetailsStatus = APIResponseStatus.Success;
       state.reservationDetails = action.payload;
-      state.selectedExamEvent = action.payload.examEvent;
-      state.enrollment = action.payload.enrollment ?? state.enrollment;
     },
     storePublicExamEvent(state, action: PayloadAction<PublicExamEvent>) {
       state.reservationDetailsStatus = APIResponseStatus.Success;
-      state.selectedExamEvent = action.payload;
+      state.examEvent = action.payload;
+    },
+    setPublicEnrollment(
+      state,
+      action: PayloadAction<PublicEnrollment | undefined>
+    ) {
+      state.enrollment = action.payload ?? state.enrollment;
     },
     renewPublicEnrollmentReservation(state, _action: PayloadAction<number>) {
       state.renewReservationStatus = APIResponseStatus.InProgress;
@@ -116,9 +117,9 @@ const publicEnrollmentSlice = createSlice({
       state.reservationDetails = initialState.reservationDetails;
       state.renewReservationStatus = initialState.renewReservationStatus;
       state.enrollmentSubmitStatus = initialState.enrollmentSubmitStatus;
-      state.enrollment = initialState.enrollment;
       state.cancelStatus = initialState.cancelStatus;
-      state.selectedExamEvent = initialState.selectedExamEvent;
+      state.examEvent = initialState.examEvent;
+      state.enrollment = initialState.enrollment;
     },
     updatePublicEnrollment(
       state,
@@ -129,6 +130,7 @@ const publicEnrollmentSlice = createSlice({
     loadPublicEnrollmentSave(
       state,
       _action: PayloadAction<{
+        examEventId: number;
         enrollment: PublicEnrollment;
         reservationDetails: PublicReservationDetails;
       }>
@@ -152,9 +154,10 @@ export const {
   initialisePublicEnrollment,
   rejectPublicEnrollmentInitialisation,
   rejectPublicExamEvent,
-  setPublicEnrollmentSelectedExam,
-  storePublicEnrollmentInitialisation,
+  setPublicExamEvent,
+  storeReservationDetails,
   storePublicExamEvent,
+  setPublicEnrollment,
   cancelPublicEnrollment,
   cancelPublicEnrollmentAndRemoveReservation,
   storePublicEnrollmentCancellation,

--- a/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
@@ -45,9 +45,10 @@ function* loadEnrollmentInitialisationSaga(action: PayloadAction<number>) {
       storeEnrollmentInitialisation({
         enrollment,
         examEvent: SerializationUtils.deserializePublicExamEvent(examEvent),
-        person: SerializationUtils.deserializePerson(person),
+        person: SerializationUtils.deserializePublicPerson(person),
         reservation:
-          reservation && SerializationUtils.deserializeReservation(reservation),
+          reservation &&
+          SerializationUtils.deserializePublicReservation(reservation),
       })
     );
   } catch (error) {
@@ -88,7 +89,7 @@ function* renewReservationSaga(action: PayloadAction<number>) {
       renewUrl
     );
 
-    const reservation = SerializationUtils.deserializeReservation(
+    const reservation = SerializationUtils.deserializePublicReservation(
       response.data
     );
 
@@ -126,7 +127,7 @@ function* loadPublicEnrollmentSaveSaga(
     reservationId?: number;
   }>
 ) {
-  const { examEventId, enrollment, reservationId } = action.payload;
+  const { enrollment, examEventId, reservationId } = action.payload;
 
   try {
     const {

--- a/frontend/packages/vkt/src/utils/serialization.ts
+++ b/frontend/packages/vkt/src/utils/serialization.ts
@@ -17,8 +17,6 @@ import {
 } from 'interfaces/clerkListExamEvent';
 import {
   PublicReservation,
-  PublicReservationDetails,
-  PublicReservationDetailsResponse,
   PublicReservationResponse,
 } from 'interfaces/publicEnrollment';
 import {
@@ -36,20 +34,6 @@ export class SerializationUtils {
       date: dayjs(publicExamEvent.date),
       registrationCloses: dayjs(publicExamEvent.registrationCloses),
     };
-  }
-
-  static deserializePublicReservationDetails(
-    reservationDetails: PublicReservationDetailsResponse
-  ): PublicReservationDetails {
-    const person = SerializationUtils.deserializePerson(
-      reservationDetails.person
-    );
-
-    const reservation =
-      reservationDetails.reservation &&
-      SerializationUtils.deserializeReservation(reservationDetails.reservation);
-
-    return { person, reservation };
   }
 
   static deserializeReservation(

--- a/frontend/packages/vkt/src/utils/serialization.ts
+++ b/frontend/packages/vkt/src/utils/serialization.ts
@@ -41,24 +41,15 @@ export class SerializationUtils {
   static deserializePublicReservationDetails(
     reservationDetails: PublicReservationDetailsResponse
   ): PublicReservationDetails {
-    const examEvent = SerializationUtils.deserializePublicExamEvent(
-      reservationDetails.examEvent
+    const person = SerializationUtils.deserializePerson(
+      reservationDetails.person
     );
 
     const reservation =
       reservationDetails.reservation &&
       SerializationUtils.deserializeReservation(reservationDetails.reservation);
 
-    const person = SerializationUtils.deserializePerson(
-      reservationDetails.person
-    );
-
-    return {
-      ...reservationDetails,
-      person,
-      examEvent,
-      reservation,
-    };
+    return { person, reservation };
   }
 
   static deserializeReservation(

--- a/frontend/packages/vkt/src/utils/serialization.ts
+++ b/frontend/packages/vkt/src/utils/serialization.ts
@@ -36,7 +36,7 @@ export class SerializationUtils {
     };
   }
 
-  static deserializeReservation(
+  static deserializePublicReservation(
     reservation: PublicReservationResponse
   ): PublicReservation {
     return {
@@ -47,7 +47,7 @@ export class SerializationUtils {
     };
   }
 
-  static deserializePerson(person: PublicPersonResponse): PublicPerson {
+  static deserializePublicPerson(person: PublicPersonResponse): PublicPerson {
     return {
       ...person,
       dateOfBirth: DateUtils.optionalStringToDate(person.dateOfBirth),


### PR DESCRIPTION
## Yhteenveto

Havaitsin että meillä talletettiin kahteen otteeseen publicEnrollment stateen tutkintotilaisuuden sekä varauksen ilmoittautumisen tiedot (sekä staten juureen että reservationDetails kentän alle). Poistin statesta lopulta tuon `reservationDetails` kentän ja siirsin sen alta puuttuvat `person` ja `reservation` kentät publicEnrollment staten juureen. Tehty samalla hieman kenttien uudelleennimeämisiä ja muuta koodin refaktorointia.

Vaatii hieman lisää testausta ja tän vois mergailla vielä tuoda uusiksi devin päälle kun stepperin korjaukset ensin mergattu deviin.
