### PR TITLE
VKT:SHARED(Frontend): OPHVKTKEH-203 tyyli ym. parannuksia ilmoflowhon

### DIFF
--- a/frontend/packages/akr/package.json
+++ b/frontend/packages/akr/package.json
@@ -22,6 +22,6 @@
     "akr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.8"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.15"
   }
 }

--- a/frontend/packages/otr/package.json
+++ b/frontend/packages/otr/package.json
@@ -25,6 +25,6 @@
     "otr:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.8"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.15"
   }
 }

--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.9.15] - 2023-07-05
+
+### Added
+
+- Removed obsolete padding-left css from `table__head-box`
+
 ## [1.9.14] - 2023-07-03
 
 ### Added

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/components/Table/Table.scss
+++ b/frontend/packages/shared/src/components/Table/Table.scss
@@ -8,7 +8,6 @@
     align-items: center;
     display: flex;
     justify-content: space-between;
-    padding-left: 1.3rem;
 
     @include mixins.phone {
       @include mixins.phone-divider-border-bottom;

--- a/frontend/packages/vkt/package.json
+++ b/frontend/packages/vkt/package.json
@@ -25,6 +25,6 @@
     "vkt:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.14"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.15"
   }
 }

--- a/frontend/packages/vkt/public/i18n/fi-FI/common.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/common.json
@@ -101,9 +101,12 @@
         }
       },
       "languageFilter": {
-        "ALL": "Kaikki kielet",
-        "FI": "Suomi",
-        "SV": "Ruotsi"
+        "label": "Näytä seuraavien kielten tutkinnot",
+        "options": {
+          "ALL": "Kaikki kielet",
+          "FI": "Suomi",
+          "SV": "Ruotsi"
+        }
       },
       "loadingContent": "Sisältöä ladataan",
       "loadingDone": "Lataus valmis",

--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -90,8 +90,7 @@
         },
         "steps": {
           "authenticate": {
-            "buttonText": "TUNNISTAUDU SUOMI.FI:N KAUTTA",
-            "title": "Tunnistaudu ilmoittautumista varten"
+            "auth": "Tunnistaudu suomi.fi:n kautta"
           },
           "done": {
             "description1": "Ilmoittautuminen tutkinnon jonotuspaikalle onnistui! Sinulle lähetetään vahvistus osoitteeseen",

--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -92,6 +92,9 @@
           "authenticate": {
             "auth": "Tunnistaudu suomi.fi:n kautta"
           },
+          "certificateShipping": {
+            "title": "Tutkintotodistuksen toimitus"
+          },
           "done": {
             "description1": "Ilmoittautuminen tutkinnon jonotuspaikalle onnistui! Sinulle lähetetään vahvistus osoitteeseen",
             "description2": "TODO: Tähän tieto, mitä tapahtuu. Ehkä voisi kertoa myös hinnan, jos se tulee automaattisesti tuolta aiemmista valinnoista, jotta käyttäjä osaa varautua siihenkin."
@@ -121,9 +124,8 @@
             "noFullExam": "En, haluan suorittaa vain jonkin osatutkinnon"
           },
           "selectExam": {
-            "chooseExam": "Tutkinnon valinta",
-            "previousEnrollment": "Aikaisempiin tutkintoihin osallistuminen",
-            "certificateShipping": "Tutkintotodistuksen toimitus"
+            "description": "Tähdellä (*) merkityt osiot ovat pakollisia.",
+            "title": "Tutkinnon valinta"
           },
           "paymentFail": {
             "cancel": "Peruuta ilmoittautuminen",
@@ -162,9 +164,15 @@
             }
           },
           "previousEnrollment": {
-            "description": "Oletko osallistunut aiemmin valtionhallinnon kielitutkintoon? *",
-            "label": "Päivämäärä tai vapaa teksti *",
-            "whenPrevious": "Milloin olet viimeksi osallistunut? *"
+            "description": "Jos suoritat tutkinnon osissa, sinulla on kolme vuotta aikaa suorittaa koko tutkinto loppuun. Aika lasketaan ensimmäisen osatutkinnon suorituspäivästä alkaen.",
+            "radioButtons": {
+              "label": "Oletko osallistunut aiemmin valtionhallinnon kielitutkintoon? *"
+            },
+            "textField": {
+              "label": "Milloin olet viimeksi osallistunut? *",
+              "placeholder": "Kirjoita päivämäärä tai vapaa teksti"
+            },
+            "title": "Aikaisempiin tutkintoihin osallistuminen"
           }
         }
       },

--- a/frontend/packages/vkt/public/i18n/fi-FI/public.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/public.json
@@ -97,10 +97,18 @@
             "description2": "TODO: Tähän tieto, mitä tapahtuu. Ehkä voisi kertoa myös hinnan, jos se tulee automaattisesti tuolta aiemmista valinnoista, jotta käyttäjä osaa varautua siihenkin."
           },
           "fillContactDetails": {
-            "email": "Sähköpostiosoite",
-            "emailConfirmation": "Vahvista sähköpostiosoite",
+            "email": {
+              "label": "Sähköposti *",
+              "placeholder": "Esim. testi@testi.fi"
+            },
+            "emailConfirmation": {
+              "label": "Vahvista sähköposti *",
+              "placeholder": "Kirjoita sähköpostisi uudelleen"
+            },
             "mismatchingEmailsError": "Sähköpostiosoitekenttien sisällöt eivät vastaa toisiaan",
-            "phoneNumber": "Puhelinnumero",
+            "phoneNumber": {
+              "label": "Puhelinnumero *"
+            },
             "title": "Yhteystietosi"
           },
           "partialExamsSelection": {

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentDesktopGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentDesktopGrid.tsx
@@ -20,6 +20,7 @@ export const PublicEnrollmentDesktopGrid = ({
   activeStep,
   isStepValid,
   isShiftedFromQueue,
+  isExamEventDetailsAvailable,
   isPaymentSumAvailable,
   isPreviewStepActive,
   isPreviewPassed,
@@ -31,6 +32,7 @@ export const PublicEnrollmentDesktopGrid = ({
 }: {
   activeStep: PublicEnrollmentFormStep;
   isStepValid: boolean;
+  isExamEventDetailsAvailable: boolean;
   isPaymentSumAvailable: boolean;
   isPreviewStepActive: boolean;
   isShiftedFromQueue: boolean;
@@ -91,11 +93,13 @@ export const PublicEnrollmentDesktopGrid = ({
                 activeStep={activeStep}
                 isEnrollmentToQueue={isEnrollmentToQueue}
               />
-              <PublicEnrollmentExamEventDetails
-                examEvent={examEvent}
-                showOpenings={!isPreviewPassed && !isShiftedFromQueue}
-                isEnrollmentToQueue={isEnrollmentToQueue}
-              />
+              {isExamEventDetailsAvailable && (
+                <PublicEnrollmentExamEventDetails
+                  examEvent={examEvent}
+                  showOpenings={!isPreviewPassed && !isShiftedFromQueue}
+                  isEnrollmentToQueue={isEnrollmentToQueue}
+                />
+              )}
               <PublicEnrollmentStepContents
                 examEvent={examEvent}
                 activeStep={activeStep}

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentGrid.tsx
@@ -120,6 +120,8 @@ export const PublicEnrollmentGrid = ({
   const isPreviewStepActive = activeStep === PublicEnrollmentFormStep.Preview;
   const isPreviewPassed = activeStep > PublicEnrollmentFormStep.Preview;
 
+  const isExamEventDetailsAvailable =
+    activeStep !== PublicEnrollmentFormStep.FillContactDetails;
   const isPaymentSumAvailable =
     isPreviewStepActive && (!!reservation || isShiftedFromQueue);
 
@@ -134,6 +136,7 @@ export const PublicEnrollmentGrid = ({
         <PublicEnrollmentPhoneGrid
           isStepValid={isStepValid}
           isShiftedFromQueue={isShiftedFromQueue}
+          isExamEventDetailsAvailable={isExamEventDetailsAvailable}
           isPaymentSumAvailable={isPaymentSumAvailable}
           isPreviewStepActive={isPreviewStepActive}
           isPreviewPassed={isPreviewPassed}
@@ -148,6 +151,7 @@ export const PublicEnrollmentGrid = ({
         <PublicEnrollmentDesktopGrid
           isStepValid={isStepValid}
           isShiftedFromQueue={isShiftedFromQueue}
+          isExamEventDetailsAvailable={isExamEventDetailsAvailable}
           isPaymentSumAvailable={isPaymentSumAvailable}
           isPreviewStepActive={isPreviewStepActive}
           isPreviewPassed={isPreviewPassed}

--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentPhoneGrid.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentPhoneGrid.tsx
@@ -27,6 +27,7 @@ export const PublicEnrollmentPhoneGrid = ({
   activeStep,
   isStepValid,
   isShiftedFromQueue,
+  isExamEventDetailsAvailable,
   isPaymentSumAvailable,
   isPreviewStepActive,
   isPreviewPassed,
@@ -38,6 +39,7 @@ export const PublicEnrollmentPhoneGrid = ({
 }: {
   activeStep: PublicEnrollmentFormStep;
   isStepValid: boolean;
+  isExamEventDetailsAvailable: boolean;
   isPaymentSumAvailable: boolean;
   isPreviewStepActive: boolean;
   isShiftedFromQueue: boolean;
@@ -166,13 +168,15 @@ export const PublicEnrollmentPhoneGrid = ({
                   </div>
                 </div>
               )}
-              <div className="margin-top-lg">
-                <PublicEnrollmentExamEventDetails
-                  examEvent={examEvent}
-                  showOpenings={!isPreviewPassed && !isShiftedFromQueue}
-                  isEnrollmentToQueue={isEnrollmentToQueue}
-                />
-              </div>
+              {isExamEventDetailsAvailable && (
+                <div className="margin-top-lg">
+                  <PublicEnrollmentExamEventDetails
+                    examEvent={examEvent}
+                    showOpenings={!isPreviewPassed && !isShiftedFromQueue}
+                    isEnrollmentToQueue={isEnrollmentToQueue}
+                  />
+                </div>
+              )}
               <PublicEnrollmentStepContents
                 examEvent={examEvent}
                 activeStep={activeStep}

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/Authenticate.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/Authenticate.tsx
@@ -1,21 +1,25 @@
 import { useState } from 'react';
-import { CustomButton, H3, LoadingProgressIndicator } from 'shared/components';
+import { CustomButton, LoadingProgressIndicator } from 'shared/components';
 import { Color, Variant } from 'shared/enums';
 
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
 import { APIEndpoints } from 'enums/api';
 import { PublicExamEvent } from 'interfaces/publicExamEvent';
+import { cancelPublicEnrollment } from 'redux/reducers/publicEnrollment';
 import { ExamEventUtils } from 'utils/examEvent';
 
 export const Authenticate = ({ examEvent }: { examEvent: PublicExamEvent }) => {
-  const [isRedirecting, setIsRedirecting] = useState(false);
+  const [isAuthRedirecting, setIsAuthRedirecting] = useState(false);
   const { t } = usePublicTranslation({
     keyPrefix: 'vkt.component.publicEnrollment.steps.authenticate',
   });
   const translateCommon = useCommonTranslation();
 
-  const onClick = () => {
-    setIsRedirecting(true);
+  const dispatch = useAppDispatch();
+
+  const onAuthenticate = () => {
+    setIsAuthRedirecting(true);
 
     window.location.href = APIEndpoints.PublicAuthLogin.replace(
       ':examEventId',
@@ -26,26 +30,36 @@ export const Authenticate = ({ examEvent }: { examEvent: PublicExamEvent }) => {
     );
   };
 
+  const onCancel = () => {
+    dispatch(cancelPublicEnrollment());
+  };
+
   return (
-    <div className="margin-top-xxl gapped rows">
-      <H3>{t('title')}</H3>
-      <div className="columns">
-        <LoadingProgressIndicator
-          translateCommon={translateCommon}
-          isLoading={isRedirecting}
+    <div className="margin-top-xxl rows gapped">
+      <LoadingProgressIndicator
+        translateCommon={translateCommon}
+        isLoading={isAuthRedirecting}
+      >
+        <CustomButton
+          data-testid="public-enrollment__authenticate-button"
+          className="public-enrollment__grid__form-container__auth-button"
+          variant={Variant.Contained}
+          color={Color.Secondary}
+          onClick={onAuthenticate}
+          disabled={isAuthRedirecting}
         >
-          <CustomButton
-            className="public-enrollment__grid__form-container__auth-button"
-            variant={Variant.Contained}
-            onClick={onClick}
-            color={Color.Secondary}
-            data-testid="public-enrollment__authenticate-button"
-            disabled={isRedirecting}
-          >
-            {t('buttonText')}
-          </CustomButton>
-        </LoadingProgressIndicator>
-      </div>
+          {t('auth')}
+        </CustomButton>
+      </LoadingProgressIndicator>
+      <CustomButton
+        className="public-enrollment__grid__form-container__auth-button"
+        variant={Variant.Text}
+        color={Color.Secondary}
+        onClick={onCancel}
+        disabled={isAuthRedirecting}
+      >
+        {translateCommon('cancel')}
+      </CustomButton>
     </div>
   );
 };

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/FillContactDetails.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/FillContactDetails.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useEffect, useState } from 'react';
-import { CustomTextField, H2, Text } from 'shared/components';
+import { H2, LabeledTextField, Text } from 'shared/components';
 import { InputAutoComplete, TextFieldTypes } from 'shared/enums';
 import { TextField } from 'shared/interfaces';
 import { FieldErrors, getErrors, hasErrors } from 'shared/utils';
@@ -123,7 +123,7 @@ export const FillContactDetails = ({
     fieldName: keyof PublicEnrollmentContactDetails
   ) => ({
     id: `public-enrollment__contact-details__${fieldName}-field`,
-    label: t(fieldName),
+    label: t(`${fieldName}.label`),
     onBlur: handleBlur(fieldName),
     onChange: handleChange(fieldName),
     error: showCustomTextFieldError(fieldName),
@@ -133,20 +133,22 @@ export const FillContactDetails = ({
   });
 
   return (
-    <div className="margin-top-xxl rows gapped">
+    <div className="margin-top-sm rows gapped public-enrollment__grid__contact-details">
       <PersonDetails />
       <div className="margin-top-lg rows gapped">
         <H2>{t('title')}</H2>
         <Text>{translateCommon('requiredFieldsInfo')}</Text>
         <div className="grid-2-columns gapped">
-          <CustomTextField
+          <LabeledTextField
             {...getCustomTextFieldAttributes('email')}
+            placeholder={t('email.placeholder')}
             type={TextFieldTypes.Email}
             value={enrollment.email}
             autoComplete={InputAutoComplete.Email}
           />
-          <CustomTextField
+          <LabeledTextField
             {...getCustomTextFieldAttributes('emailConfirmation')}
+            placeholder={t('emailConfirmation.placeholder')}
             type={TextFieldTypes.Email}
             value={enrollment.emailConfirmation}
             onPaste={(e) => {
@@ -157,7 +159,7 @@ export const FillContactDetails = ({
           />
         </div>
       </div>
-      <CustomTextField
+      <LabeledTextField
         {...getCustomTextFieldAttributes('phoneNumber')}
         className="phone-number"
         value={enrollment.phoneNumber}

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/Preview.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/Preview.tsx
@@ -199,11 +199,13 @@ export const Preview = ({
 
   return (
     <div className="margin-top-xxl rows gapped-xxl">
-      <PersonDetails />
-      <ContactDetails
-        email={enrollment.email}
-        phoneNumber={enrollment.phoneNumber}
-      />
+      <div className="rows gapped-xxl public-enrollment__grid__contact-details">
+        <PersonDetails />
+        <ContactDetails
+          email={enrollment.email}
+          phoneNumber={enrollment.phoneNumber}
+        />
+      </div>
       <ExamEventDetails enrollment={enrollment} />
       <CertificateShippingDetails enrollment={enrollment} />
       <div className="rows gapped">

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/Preview.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/Preview.tsx
@@ -121,7 +121,7 @@ const CertificateShippingDetails = ({
   const digitalConsentEnabled = false;
 
   return (
-    <div className="rows gapped">
+    <div className="rows gapped-sm">
       <H2>{t('title')}</H2>
       {digitalConsentEnabled && (
         <div className="rows gapped-xxs">
@@ -208,7 +208,7 @@ export const Preview = ({
       </div>
       <ExamEventDetails enrollment={enrollment} />
       <CertificateShippingDetails enrollment={enrollment} />
-      <div className="rows gapped">
+      <div className="rows gapped-sm">
         <H2>{translateCommon('acceptTerms')}</H2>
         <div>
           <FormControlLabel

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/SelectExam.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/SelectExam.tsx
@@ -51,13 +51,12 @@ export const SelectExam = ({
   ]);
 
   return (
-    <div className="margin-top-xxl rows gapped-xl">
-      <div className="rows gapped">
-        <H2>{t('chooseExam')}</H2>
-        <div className="rows">
-          <Text>{translateCommon('examinationPayment.part1')}</Text>
-          <Text>{translateCommon('examinationPayment.part2')}</Text>
-        </div>
+    <div className="margin-top-xxl rows gapped">
+      <Text>{t('description')}</Text>
+      <H2>{t('title')}</H2>
+      <div className="rows">
+        <Text>{translateCommon('examinationPayment.part1')}</Text>
+        <Text>{translateCommon('examinationPayment.part2')}</Text>
       </div>
       <PartialExamsSelection
         enrollment={enrollment}
@@ -65,14 +64,12 @@ export const SelectExam = ({
         setValid={setPartialExamsSelection}
         showValidation={showValidation}
       />
-      <H2>{t('previousEnrollment')}</H2>
       <PreviousEnrollment
         enrollment={enrollment}
         editingDisabled={isLoading}
         setValid={setPreviousEnrollment}
         showValidation={showValidation}
       />
-      <H2>{t('certificateShipping')}</H2>
       <CertificateShipping
         enrollment={enrollment}
         editingDisabled={isLoading}

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/CertificateShipping.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/CertificateShipping.tsx
@@ -1,11 +1,11 @@
 import { Checkbox, Collapse, FormControlLabel } from '@mui/material';
 import { ChangeEvent, useEffect, useState } from 'react';
-import { CustomTextField, H3 } from 'shared/components';
+import { H2, H3, LabeledTextField } from 'shared/components';
 import { Color, InputAutoComplete, TextFieldTypes } from 'shared/enums';
 import { TextField } from 'shared/interfaces';
 import { getErrors, hasErrors } from 'shared/utils';
 
-import { useCommonTranslation } from 'configs/i18n';
+import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch } from 'configs/redux';
 import { CertificateShippingTextFields } from 'interfaces/common/enrollment';
 import { PublicEnrollment } from 'interfaces/publicEnrollment';
@@ -44,6 +44,9 @@ export const CertificateShipping = ({
   setValid: (isValid: boolean) => void;
   showValidation: boolean;
 }) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'vkt.component.publicEnrollment.steps.certificateShipping',
+  });
   const translateCommon = useCommonTranslation();
   const digitalConsentEnabled = false;
 
@@ -104,7 +107,7 @@ export const CertificateShipping = ({
   ) => ({
     id: `public-enrollment__certificate-shipping__${fieldName}-field`,
     type: TextFieldTypes.Text,
-    label: translateCommon(`enrollment.textFields.${fieldName}`),
+    label: `${translateCommon(`enrollment.textFields.${fieldName}`)} *`,
     onBlur: handleBlur(fieldName),
     onChange: handleChange(fieldName),
     error: showCustomTextFieldError(fieldName),
@@ -123,6 +126,7 @@ export const CertificateShipping = ({
 
   return (
     <div className="rows gapped">
+      <H2>{t('title')}</H2>
       {digitalConsentEnabled && (
         <FormControlLabel
           className="public-enrollment__grid__certificate-shipping__consent"
@@ -145,22 +149,22 @@ export const CertificateShipping = ({
           {translateCommon('enrollment.certificateShipping.addressTitle')}
         </H3>
         <div className="margin-top-lg grid-columns gapped">
-          <CustomTextField
+          <LabeledTextField
             {...getCustomTextFieldAttributes('street')}
             value={enrollment.street}
             autoComplete={InputAutoComplete.Street}
           />
-          <CustomTextField
+          <LabeledTextField
             {...getCustomTextFieldAttributes('postalCode')}
             value={enrollment.postalCode}
             autoComplete={InputAutoComplete.PostalCode}
           />
-          <CustomTextField
+          <LabeledTextField
             {...getCustomTextFieldAttributes('town')}
             value={enrollment.town}
             autoComplete={InputAutoComplete.Town}
           />
-          <CustomTextField
+          <LabeledTextField
             {...getCustomTextFieldAttributes('country')}
             value={enrollment.country}
             autoComplete={InputAutoComplete.Country}

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/PartialExamsSelection.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/PartialExamsSelection.tsx
@@ -158,12 +158,13 @@ export const PartialExamsSelection = ({
     !EnrollmentUtils.isValidOralSkillAndPartialExams(enrollment);
 
   return (
-    <div className="rows gapped">
+    <div className="rows">
       <FormControl component="fieldset">
         <FormLabel component="legend" className="heading-label">
           {t('doFullExam')}
         </FormLabel>
         <RadioGroup
+          className="rows gapped-xxs"
           name="full-exam-group"
           value={enrollment.hasPreviousEnrollment ? YesNo.Yes : YesNo.No}
           onChange={handleFullExamChange}
@@ -187,9 +188,7 @@ export const PartialExamsSelection = ({
               !allPartialExamsChecked &&
               (dirtyFullExam || somePartialExamsChecked)
             }
-            className={`margin-top-sm margin-left-sm ${
-              hasFullExamError && 'checkbox-error'
-            }`}
+            className={`margin-left-sm ${hasFullExamError && 'checkbox-error'}`}
           />
         </RadioGroup>
         {hasFullExamError && (
@@ -202,7 +201,7 @@ export const PartialExamsSelection = ({
         orientation="vertical"
         in={!allPartialExamsChecked && (dirtyFullExam || isSkillsSelected)}
       >
-        <div className="rows gapped-xxs">
+        <div className="margin-top-lg rows gapped-xxs">
           <H3>{t('skillsTitle')}</H3>
           <div className="rows margin-left-lg">
             <CheckboxField
@@ -233,7 +232,7 @@ export const PartialExamsSelection = ({
         orientation="vertical"
         in={!allPartialExamsChecked && isSkillsSelected}
       >
-        <H3>{t('partialExamsTitle')}</H3>
+        <H3 className="margin-top-lg">{t('partialExamsTitle')}</H3>
       </Collapse>
       <div>
         <Collapse
@@ -241,7 +240,7 @@ export const PartialExamsSelection = ({
           in={!allPartialExamsChecked && enrollment.textualSkill}
           className="public-enrollment__grid__partial-exam-selection"
         >
-          <div className="rows gapped-xxs">
+          <div className="margin-top-lg rows gapped-xxs">
             <H3>{t('textualSkill')}</H3>
             <CheckboxField
               enrollment={enrollment}
@@ -271,7 +270,7 @@ export const PartialExamsSelection = ({
           in={!allPartialExamsChecked && enrollment.oralSkill}
           className="public-enrollment__grid__partial-exam-selection"
         >
-          <div className="rows gapped-xxs">
+          <div className="margin-top-lg rows gapped-xxs">
             <H3>{t('oralSkill')}</H3>
             <CheckboxField
               enrollment={enrollment}

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/PartialExamsSelection.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/PartialExamsSelection.tsx
@@ -75,7 +75,7 @@ export const PartialExamsSelection = ({
   });
 
   const dispatch = useAppDispatch();
-  const [dirtyFullExam, setDirtyFullExam] = useState(false);
+  const [dirtyFullExam, setDirtyFullExam] = useState(!!enrollment.id);
 
   const isSkillsSelected = enrollment.textualSkill || enrollment.oralSkill;
 

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/PreviousEnrollment.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/selectExam/PreviousEnrollment.tsx
@@ -8,7 +8,7 @@ import {
   RadioGroup,
 } from '@mui/material';
 import { ChangeEvent, useEffect, useState } from 'react';
-import { CustomTextField } from 'shared/components';
+import { H2, LabeledTextField, Text } from 'shared/components';
 import { TextFieldTypes } from 'shared/enums';
 import { TextField } from 'shared/interfaces';
 import { getErrors, hasErrors } from 'shared/utils';
@@ -126,62 +126,71 @@ export const PreviousEnrollment = ({
   };
 
   return (
-    <div className="public-enrollment__grid__previous-enrollment rows gapped">
-      <FormControl component="fieldset">
-        <FormLabel component="legend" className="heading-label">
-          {t('description')}
-        </FormLabel>
-        <RadioGroup
-          name="has-previous-enrollment-group"
-          value={
-            enrollment.hasPreviousEnrollment
-              ? PreviouslyEnrolled.Yes
-              : PreviouslyEnrolled.No
-          }
-          onChange={handleRadioButtonChange}
-        >
-          <FormControlLabel
+    <>
+      <div className="margin-top-sm rows gapped">
+        <H2>{t('title')}</H2>
+        <Text>{t('description')}</Text>
+      </div>
+      <div className="public-enrollment__grid__previous-enrollment rows gapped">
+        <FormControl component="fieldset">
+          <FormLabel component="legend" className="heading-label">
+            {t('radioButtons.label')}
+          </FormLabel>
+          <RadioGroup
+            name="has-previous-enrollment-group"
+            value={
+              enrollment.hasPreviousEnrollment
+                ? PreviouslyEnrolled.Yes
+                : PreviouslyEnrolled.No
+            }
+            onChange={handleRadioButtonChange}
+          >
+            <FormControlLabel
+              disabled={editingDisabled}
+              value={PreviouslyEnrolled.Yes}
+              control={
+                <Radio aria-describedby="has-previous-enrollment-error" />
+              }
+              label={translateCommon('yes')}
+              checked={enrollment.hasPreviousEnrollment}
+              className={`margin-top-sm margin-left-sm ${
+                hasRadioButtonError && 'checkbox-error'
+              }`}
+            />
+            <FormControlLabel
+              disabled={editingDisabled}
+              value={PreviouslyEnrolled.No}
+              control={
+                <Radio aria-describedby="has-previous-enrollment-error" />
+              }
+              label={translateCommon('no')}
+              checked={enrollment.hasPreviousEnrollment === false}
+              className={`margin-left-sm ${
+                hasRadioButtonError && 'checkbox-error'
+              }`}
+            />
+          </RadioGroup>
+          {hasRadioButtonError && (
+            <FormHelperText id="has-previous-enrollment-error" error={true}>
+              {translateCommon('errors.customTextField.required')}
+            </FormHelperText>
+          )}
+        </FormControl>
+        <Collapse orientation="vertical" in={enrollment.hasPreviousEnrollment}>
+          <LabeledTextField
+            className="margin-top-sm public-enrollment__grid__previous-enrollment__textField"
+            id="public-enrollment__previous-enrollment__textField"
+            label={t('textField.label')}
+            placeholder={t('textField.placeholder')}
+            value={enrollment.previousEnrollment}
+            onBlur={handleTextFieldBlur}
+            onChange={handleTextFieldChange}
+            error={showCustomTextFieldError('previousEnrollment')}
+            helperText={errors['previousEnrollment']}
             disabled={editingDisabled}
-            value={PreviouslyEnrolled.Yes}
-            control={<Radio aria-describedby="has-previous-enrollment-error" />}
-            label={translateCommon('yes')}
-            checked={enrollment.hasPreviousEnrollment}
-            className={`margin-top-sm margin-left-sm ${
-              hasRadioButtonError && 'checkbox-error'
-            }`}
           />
-          <FormControlLabel
-            disabled={editingDisabled}
-            value={PreviouslyEnrolled.No}
-            control={<Radio aria-describedby="has-previous-enrollment-error" />}
-            label={translateCommon('no')}
-            checked={enrollment.hasPreviousEnrollment === false}
-            className={`margin-left-sm ${
-              hasRadioButtonError && 'checkbox-error'
-            }`}
-          />
-        </RadioGroup>
-        {hasRadioButtonError && (
-          <FormHelperText id="has-previous-enrollment-error" error={true}>
-            {translateCommon('errors.customTextField.required')}
-          </FormHelperText>
-        )}
-      </FormControl>
-      <Collapse orientation="vertical" in={enrollment.hasPreviousEnrollment}>
-        <FormLabel className="heading-label gapped-sm">
-          {t('whenPrevious')}
-        </FormLabel>
-        <CustomTextField
-          className="margin-top-sm public-enrollment__grid__previous-enrollment__input"
-          label={t('label')}
-          value={enrollment.previousEnrollment}
-          onBlur={handleTextFieldBlur}
-          onChange={handleTextFieldChange}
-          error={showCustomTextFieldError('previousEnrollment')}
-          helperText={errors['previousEnrollment']}
-          disabled={editingDisabled}
-        />
-      </Collapse>
-    </div>
+        </Collapse>
+      </div>
+    </>
   );
 };

--- a/frontend/packages/vkt/src/components/publicExamEvent/LanguageFilter.tsx
+++ b/frontend/packages/vkt/src/components/publicExamEvent/LanguageFilter.tsx
@@ -1,9 +1,12 @@
 import {
+  FormControl,
   FormControlLabel,
+  FormLabel,
   Radio,
   RadioGroup,
   SelectChangeEvent,
 } from '@mui/material';
+import { useWindowProperties } from 'shared/hooks';
 
 import { useCommonTranslation } from 'configs/i18n';
 import { ExamLanguage } from 'enums/app';
@@ -16,27 +19,33 @@ export const LanguageFilter = ({
   onChange: (event: SelectChangeEvent) => void;
 }) => {
   const translateCommon = useCommonTranslation();
+  const { isPhone } = useWindowProperties();
 
   return (
-    <RadioGroup
-      data-testid="exam-events__language-filter"
-      name="language-filter"
-      value={value}
-      onChange={onChange}
-    >
-      <div className="columns margin-top-sm">
-        {Object.entries(ExamLanguage).map(([key, language]) => {
-          return (
-            <FormControlLabel
-              key={key}
-              value={language}
-              checked={value === language}
-              label={translateCommon(`languageFilter.${key}`)}
-              control={<Radio />}
-            />
-          );
-        })}
-      </div>
-    </RadioGroup>
+    <FormControl className="margin-top-lg" component="fieldset">
+      <FormLabel component="legend" className="heading-label">
+        {translateCommon('languageFilter.label')}:
+      </FormLabel>
+      <RadioGroup
+        data-testid="exam-events__language-filter"
+        name="language-filter"
+        value={value}
+        onChange={onChange}
+      >
+        <div className={`${isPhone ? 'rows' : 'columns'} margin-left-sm`}>
+          {Object.entries(ExamLanguage).map(([key, language]) => {
+            return (
+              <FormControlLabel
+                key={key}
+                value={language}
+                checked={value === language}
+                label={translateCommon(`languageFilter.options.${key}`)}
+                control={<Radio />}
+              />
+            );
+          })}
+        </div>
+      </RadioGroup>
+    </FormControl>
   );
 };

--- a/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/interfaces/publicEnrollment.ts
@@ -24,10 +24,10 @@ export interface PublicReservationResponse
 }
 
 export interface PublicReservationDetailsResponse {
-  person: PublicPerson;
-  enrollment?: PublicEnrollment;
   examEvent: PublicExamEventResponse;
+  person: PublicPerson;
   reservation?: PublicReservationResponse;
+  enrollment?: PublicEnrollmentResponse;
 }
 
 export interface PublicEnrollmentContactDetails {
@@ -41,8 +41,21 @@ export interface PublicEnrollment
     PartialExamsAndSkills,
     CertificateShippingData {
   id?: number;
-  previousEnrollment?: string;
   hasPreviousEnrollment?: boolean;
+  previousEnrollment?: string;
   privacyStatementConfirmation: boolean;
   status?: EnrollmentStatus;
+}
+
+export interface PublicEnrollmentResponse
+  extends Omit<
+      PublicEnrollment,
+      | 'emailConfirmation'
+      | 'id'
+      | 'hasPreviousEnrollment'
+      | 'privacyStatementConfirmation'
+      | 'status'
+    >,
+    WithId {
+  status: EnrollmentStatus;
 }

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -97,16 +97,13 @@ const publicEnrollmentSlice = createSlice({
       state.reservation = action.payload;
     },
     cancelPublicEnrollment(state) {
-      state.cancelStatus = APIResponseStatus.InProgress;
+      state.cancelStatus = APIResponseStatus.Success;
     },
     cancelPublicEnrollmentAndRemoveReservation(
       state,
       _action: PayloadAction<number>
     ) {
       state.cancelStatus = APIResponseStatus.InProgress;
-    },
-    storePublicEnrollmentCancellation(state) {
-      state.cancelStatus = APIResponseStatus.Success;
     },
     resetPublicEnrollment() {
       return initialState;
@@ -159,7 +156,6 @@ export const {
   storeReservationRenew,
   cancelPublicEnrollment,
   cancelPublicEnrollmentAndRemoveReservation,
-  storePublicEnrollmentCancellation,
   resetPublicEnrollment,
   updatePublicEnrollment,
   loadPublicEnrollmentSave,

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -42,8 +42,11 @@ const initialState: PublicEnrollmentState = {
     postalCode: '',
     town: '',
     country: '',
+    id: undefined,
+    hasPreviousEnrollment: undefined,
     previousEnrollment: '',
     privacyStatementConfirmation: false,
+    status: undefined,
   },
   examEvent: undefined,
   person: undefined,
@@ -74,17 +77,17 @@ const publicEnrollmentSlice = createSlice({
     storeEnrollmentInitialisation(
       state,
       action: PayloadAction<{
-        enrollment?: PublicEnrollment;
         examEvent: PublicExamEvent;
         person: PublicPerson;
         reservation?: PublicReservation;
+        enrollment?: PublicEnrollment;
       }>
     ) {
       state.enrollmentInitialisationStatus = APIResponseStatus.Success;
-      state.enrollment = action.payload.enrollment ?? state.enrollment;
       state.examEvent = action.payload.examEvent;
       state.person = action.payload.person;
       state.reservation = action.payload.reservation;
+      state.enrollment = action.payload.enrollment ?? state.enrollment;
     },
     renewReservation(state, _action: PayloadAction<number>) {
       state.renewReservationStatus = APIResponseStatus.InProgress;

--- a/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
@@ -43,11 +43,13 @@ function* loadEnrollmentInitialisationSaga(action: PayloadAction<number>) {
     yield put(
       storeEnrollmentInitialisation({
         person,
-        enrollment,
         examEvent: SerializationUtils.deserializePublicExamEvent(examEvent),
         reservation:
           reservation &&
           SerializationUtils.deserializePublicReservation(reservation),
+        enrollment:
+          enrollment &&
+          SerializationUtils.deserializePublicEnrollment(enrollment),
       })
     );
   } catch (error) {
@@ -126,8 +128,11 @@ function* loadPublicEnrollmentSaveSaga(
 
   try {
     const {
-      emailConfirmation: _unusedField1,
-      privacyStatementConfirmation: _unusedField2,
+      emailConfirmation: _unused1,
+      id: _unused2,
+      hasPreviousEnrollment: _unused3,
+      privacyStatementConfirmation: _unused4,
+      status: _unused5,
       ...body
     } = enrollment;
 

--- a/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/sagas/publicEnrollment.ts
@@ -23,7 +23,6 @@ import {
   rejectReservationRenew,
   renewReservation,
   storeEnrollmentInitialisation,
-  storePublicEnrollmentCancellation,
   storePublicEnrollmentSave,
   storePublicExamEvent,
   storeReservationRenew,
@@ -101,10 +100,6 @@ function* renewReservationSaga(action: PayloadAction<number>) {
   }
 }
 
-function* cancelPublicEnrollmentSaga() {
-  yield put(storePublicEnrollmentCancellation());
-}
-
 function* cancelPublicEnrollmentAndRemoveReservationSaga(
   action: PayloadAction<number>
 ) {
@@ -116,7 +111,7 @@ function* cancelPublicEnrollmentAndRemoveReservationSaga(
   } catch (error) {
     // If deletion of reservation fails, it will expire in 30 mins
   } finally {
-    yield put(storePublicEnrollmentCancellation());
+    yield put(cancelPublicEnrollment());
   }
 }
 
@@ -160,7 +155,6 @@ export function* watchPublicEnrollments() {
   );
   yield takeLatest(loadPublicExamEvent, loadPublicExamEventSaga);
   yield takeLatest(renewReservation, renewReservationSaga);
-  yield takeLatest(cancelPublicEnrollment, cancelPublicEnrollmentSaga);
   yield takeLatest(
     cancelPublicEnrollmentAndRemoveReservation,
     cancelPublicEnrollmentAndRemoveReservationSaga

--- a/frontend/packages/vkt/src/styles/components/common/_heading-label.scss
+++ b/frontend/packages/vkt/src/styles/components/common/_heading-label.scss
@@ -1,0 +1,5 @@
+.heading-label {
+  color: $color-text-primary !important;
+  display: block;
+  font-weight: bold !important;
+}

--- a/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
+++ b/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
@@ -1,10 +1,4 @@
 .public-enrollment {
-  .heading-label {
-    color: $color-text-primary;
-    display: block;
-    font-weight: bold;
-  }
-
   & &__grid {
     &__form-container {
       padding: 3rem;

--- a/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
+++ b/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
@@ -46,8 +46,8 @@
         width: 100%;
       }
 
-      &__input {
-        width: 100%;
+      &__textField {
+        margin-bottom: 2rem;
       }
     }
 

--- a/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
+++ b/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
@@ -31,6 +31,14 @@
       }
     }
 
+    &__contact-details {
+      width: calc(80% - 1rem);
+
+      @include phone {
+        width: 100%;
+      }
+    }
+
     &__previous-enrollment {
       width: calc(50% - 1rem);
 

--- a/frontend/packages/vkt/src/styles/components/publicExamEvent/_public-exam-event-listing.scss
+++ b/frontend/packages/vkt/src/styles/components/publicExamEvent/_public-exam-event-listing.scss
@@ -1,5 +1,0 @@
-.public-exam-event-heading {
-  @include phone {
-    margin: 0 0 1rem;
-  }
-}

--- a/frontend/packages/vkt/src/styles/styles.scss
+++ b/frontend/packages/vkt/src/styles/styles.scss
@@ -5,6 +5,7 @@
 @import 'base/base';
 
 // Common
+@import 'components/common/heading-label';
 @import 'components/common/mobile-app-bar';
 
 // Components
@@ -16,7 +17,6 @@
 @import 'components/layouts/header';
 @import 'components/layouts/footer';
 @import 'components/publicEnrollment/public-enrollment';
-@import 'components/publicExamEvent/public-exam-event-listing';
 
 // Pages
 @import 'pages/accessibility-statement-page';

--- a/frontend/packages/vkt/src/utils/serialization.ts
+++ b/frontend/packages/vkt/src/utils/serialization.ts
@@ -16,6 +16,8 @@ import {
   ClerkListExamEventResponse,
 } from 'interfaces/clerkListExamEvent';
 import {
+  PublicEnrollment,
+  PublicEnrollmentResponse,
   PublicReservation,
   PublicReservationResponse,
 } from 'interfaces/publicEnrollment';
@@ -32,6 +34,17 @@ export class SerializationUtils {
       ...publicExamEvent,
       date: dayjs(publicExamEvent.date),
       registrationCloses: dayjs(publicExamEvent.registrationCloses),
+    };
+  }
+
+  static deserializePublicEnrollment(
+    enrollment: PublicEnrollmentResponse
+  ): PublicEnrollment {
+    return {
+      ...enrollment,
+      emailConfirmation: '',
+      hasPreviousEnrollment: !!enrollment.previousEnrollment,
+      privacyStatementConfirmation: false,
     };
   }
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2686,7 +2686,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.akr@workspace:packages/akr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.8"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.15"
   languageName: unknown
   linkType: soft
 
@@ -2694,7 +2694,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.otr@workspace:packages/otr"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.8"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.15"
   languageName: unknown
   linkType: soft
 
@@ -2786,7 +2786,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.14":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.15":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -2796,7 +2796,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.vkt@workspace:packages/vkt"
   dependencies:
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.14"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.15"
   languageName: unknown
   linkType: soft
 
@@ -11813,13 +11813,6 @@ __metadata:
   version: 1.9.11
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.9.11::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.9.11%2Ffe333aaf6ae6a499de64ba3ba5d38783ee60c0ab"
   checksum: 347ddc98397642431219105e3fd5dd9644429d09d37ee065df2a49905d45d153809a4564af0a3c0636b39346ebcc0eae3fe024e59632c4bf5ca740a7bdb75051
-  languageName: node
-  linkType: hard
-
-"shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.9.8":
-  version: 1.9.8
-  resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@npm:1.9.8::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Opetushallitus%2Fkieli-ja-kaantajatutkinnot.shared%2F1.9.8%2F129e68fa450d67736f802b2595b3687adf79fa9d"
-  checksum: e706967e8d55b39248bdb097d6c386a0a22dc5c0de5969c1b304fb102a3af8b9d3c46cb05cd75a33177b9e6a181553b9b8baac614625a9f73e772f550308f80b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Yhteenveto

Lisätty mm. label etusivun radio button groupille ja radio buttonit allekain mobiililla, havaittu tuon yhteydessä että sharedin `table__head-box` padding-left asetus oli ikävä ja sen poisto ei vaikuttanut sovellusten toimintaan vaikuttavan mitä testailin akr ja otr tuotantoversioitakin vasten.

Muutettu myös Täytä yhteystietosi -näkymää enemmän figma-leiskan kaltaiseksi sekä vaihdettu LabeledTextField komponentteja Valitse tutkinto -sivun käyttöön. Tuolla sivulla myös korjattu se, että `dirtyFullExam` sekä aiemman osallistumistiedon täyttö vaikuttaisivat toimivan halutulla tavalla tilanteessa, jossa ilmo keskeytetään vaikka maksuvaiheessa ja ilmoittaudutaan uudelleen. Tehty myös joitakin pienempiä css / margin parannuksia.

Vien untuvalle tämän version ajoon. Jos haluaa lokaalisti testailla niin kannattaa varmaan vaihtaa vkt ja shared alla pakkauksen versionumero joksikin muuksi, jotta saa yarn installilla pystyyn.

Toteutettu OPHVKTKEH-214 päälle.

## Check-lista

- [x] yarn.lock päivitetty
- [x] Käännösten Excel-tiedosto päivitetty
- [x] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
