### PR TITLE
YKI(Frontend): OPHYKIKEH-182 tutkintotilaisuuksien järjestys etusivulla

### DIFF
--- a/frontend/packages/yki/dev/rest/examSessions/allExamSessions.json
+++ b/frontend/packages/yki/dev/rest/examSessions/allExamSessions.json
@@ -277,6 +277,61 @@
       "post_admission": null
     },
     {
+      "level_code": "PERUS",
+      "max_participants": 20,
+      "language_code": "swe",
+      "participants": 20,
+      "contact": [
+        {
+          "name": "Contact Person",
+          "email": "contact.person@testi.invalid",
+          "phone_number": "+3584678124"
+        }
+      ],
+      "pa_participants": 0,
+      "office_oid": "1.2.246.562.10.29461948951",
+      "published_at": "2019-01-15T11:20:41.776Z",
+      "session_date": "2019-04-06",
+      "organizer_oid": "1.2.246.562.10.28646781493",
+      "id": 111,
+      "registration_start_date": "2019-02-01",
+      "location": [
+        {
+          "lang": "fi",
+          "extra_information": "uusia lisätietoja",
+          "name": "Amiedu",
+          "other_location_info": "auditorio A3",
+          "street_address": "Jokukatu 4",
+          "post_office": "Tampere",
+          "zip": "00100"
+        },
+        {
+          "lang": "sv",
+          "extra_information": "ny extra info",
+          "name": "Omenia",
+          "other_location_info": "auditorium A3",
+          "street_address": "Jokukatu 4",
+          "post_office": "Tammerfors",
+          "zip": "00100"
+        },
+        {
+          "lang": "en",
+          "extra_information": "new additional info",
+          "name": "Omenia",
+          "other_location_info": "auditorium A3",
+          "street_address": "Jokukatu 4",
+          "post_office": "Tampere",
+          "zip": "00100"
+        }
+      ],
+      "exam_fee": "123.00",
+      "registration_end_date": "2039-02-28",
+      "open": true,
+      "queue_full": true,
+      "queue": 50,
+      "post_admission": null
+    },
+    {
       "level_code": "KESKI",
       "max_participants": 25,
       "language_code": "fin",

--- a/frontend/packages/yki/src/components/reassessment/PublicEvaluationPeriodListingRow.tsx
+++ b/frontend/packages/yki/src/components/reassessment/PublicEvaluationPeriodListingRow.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
 import { EvaluationPeriod } from 'interfaces/evaluationPeriod';
 import { storeEvaluationPeriod } from 'redux/reducers/evaluationOrder';
-import { ExamUtils } from 'utils/exam';
+import { ExamSessionUtils } from 'utils/examSession';
 
 const PublicEvaluationPeriodListingCellsForPhone = ({
   evaluationPeriod,
@@ -33,7 +33,7 @@ const PublicEvaluationPeriodListingCellsForPhone = ({
     <TableCell>
       <div className="rows grow gapped-xs">
         <Typography variant="h2" component="p">
-          {ExamUtils.languageAndLevelText(evaluationPeriod)}
+          {ExamSessionUtils.languageAndLevelText(evaluationPeriod)}
         </Typography>
         <Text>
           <b>{translateCommon('examDate')}</b>
@@ -85,7 +85,9 @@ const PublicEvaluationPeriodListingCellsForDesktop = ({
 
   return (
     <>
-      <TableCell>{ExamUtils.languageAndLevelText(evaluationPeriod)}</TableCell>
+      <TableCell>
+        {ExamSessionUtils.languageAndLevelText(evaluationPeriod)}
+      </TableCell>
       <TableCell>
         {DateUtils.formatOptionalDate(evaluationPeriod.exam_date, 'l')}
       </TableCell>

--- a/frontend/packages/yki/src/components/reassessment/evaluationOrder/PublicEvaluationOrderForm.tsx
+++ b/frontend/packages/yki/src/components/reassessment/evaluationOrder/PublicEvaluationOrderForm.tsx
@@ -38,7 +38,7 @@ import {
   submitEvaluationOrder,
 } from 'redux/reducers/evaluationOrder';
 import { evaluationOrderSelector } from 'redux/selectors/evaluationOrder';
-import { ExamUtils } from 'utils/exam';
+import { ExamSessionUtils } from 'utils/examSession';
 
 const RenderEvaluationDetails = () => {
   const translateCommon = useCommonTranslation();
@@ -53,7 +53,7 @@ const RenderEvaluationDetails = () => {
       <Text>{t('info')}</Text>
       <Text>
         {translateCommon('examination')}:{' '}
-        <b>{ExamUtils.languageAndLevelText(evaluationPeriod)}</b>
+        <b>{ExamSessionUtils.languageAndLevelText(evaluationPeriod)}</b>
         <br />
         {translateCommon('examDate')}:{' '}
         <b>{DateUtils.formatOptionalDate(evaluationPeriod.exam_date)}</b>

--- a/frontend/packages/yki/src/components/registration/PublicRegistrationExamSessionDetails.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicRegistrationExamSessionDetails.tsx
@@ -7,7 +7,7 @@ import {
   usePublicTranslation,
 } from 'configs/i18n';
 import { ExamSession } from 'interfaces/examSessions';
-import { ExamUtils } from 'utils/exam';
+import { ExamSessionUtils } from 'utils/examSession';
 
 export const PublicRegistrationExamSessionDetails = ({
   examSession,
@@ -26,11 +26,14 @@ export const PublicRegistrationExamSessionDetails = ({
   }
 
   const { start, end, participants, quota } =
-    ExamUtils.getCurrentOrFutureAdmissionPeriod(examSession);
+    ExamSessionUtils.getCurrentOrFutureAdmissionPeriod(examSession);
   const openings = Math.max(quota - participants, 0);
 
-  const header = ExamUtils.languageAndLevelText(examSession);
-  const location = ExamUtils.getLocationInfo(examSession, getCurrentLang());
+  const header = ExamSessionUtils.languageAndLevelText(examSession);
+  const location = ExamSessionUtils.getLocationInfo(
+    examSession,
+    getCurrentLang()
+  );
 
   return (
     <div className="rows">

--- a/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingRow.tsx
+++ b/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingRow.tsx
@@ -118,7 +118,7 @@ const PublicExamSessionListingCellsForDesktop = ({
   examSession: ExamSession;
   locationInfo: ExamSessionLocation;
   availablePlacesText: string;
-  registerActionAvailable?: boolean;
+  registerActionAvailable: boolean;
 }) => {
   return (
     <>
@@ -158,7 +158,7 @@ const PublicExamSessionListingCellsForPhone = ({
   examSession: ExamSession;
   locationInfo: ExamSessionLocation;
   availablePlacesText: string;
-  registerActionAvailable?: boolean;
+  registerActionAvailable: boolean;
 }) => {
   const translateCommon = useCommonTranslation();
 
@@ -267,7 +267,7 @@ export const PublicExamSessionListingRow = ({
         <PublicExamSessionListingCellsForPhone
           examSession={examSession}
           availablePlacesText={availablePlacesText}
-          registerActionAvailable={registerActionAvailable}
+          registerActionAvailable={!!registerActionAvailable}
           locationInfo={locationInfo}
         />
       </TableRow>
@@ -278,7 +278,7 @@ export const PublicExamSessionListingRow = ({
         <PublicExamSessionListingCellsForDesktop
           examSession={examSession}
           availablePlacesText={availablePlacesText}
-          registerActionAvailable={registerActionAvailable}
+          registerActionAvailable={!!registerActionAvailable}
           locationInfo={locationInfo}
         />
       </TableRow>

--- a/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingRow.tsx
+++ b/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingRow.tsx
@@ -15,7 +15,8 @@ import { AppRoutes, RegistrationKind } from 'enums/app';
 import { ExamSession, ExamSessionLocation } from 'interfaces/examSessions';
 import { storeExamSession } from 'redux/reducers/examSession';
 import { resetPublicRegistration } from 'redux/reducers/registration';
-import { ExamUtils } from 'utils/exam';
+import { DateTimeUtils } from 'utils/dateTime';
+import { ExamSessionUtils } from 'utils/examSession';
 
 const RegisterToExamButton = ({
   examSession,
@@ -29,7 +30,7 @@ const RegisterToExamButton = ({
   const { isPhone } = useWindowProperties();
 
   const { participants, quota, open, kind } =
-    ExamUtils.getCurrentOrFutureAdmissionPeriod(examSession);
+    ExamSessionUtils.getCurrentOrFutureAdmissionPeriod(examSession);
   const placesAvailable = participants < quota;
   const queueAvailable =
     open && kind === RegistrationKind.Admission && !examSession.queue_full;
@@ -64,7 +65,7 @@ const RegistrationUnavailableText = ({
   });
   const now = dayjs();
   const { start, end } =
-    ExamUtils.getCurrentOrFutureAdmissionPeriod(examSession);
+    ExamSessionUtils.getCurrentOrFutureAdmissionPeriod(examSession);
   if (now.isBefore(start)) {
     return (
       <>
@@ -87,15 +88,15 @@ const renderAdmissionPeriod = ({
   start: Dayjs;
   end: Dayjs;
 }) => {
-  return `${ExamUtils.renderDateTime(start)} — ${ExamUtils.renderDateTime(
-    end
-  )}`;
+  return `${DateTimeUtils.renderDateTime(
+    start
+  )} — ${DateTimeUtils.renderDateTime(end)}`;
 };
 
 const AdmissionPeriodText = ({ examSession }: { examSession: ExamSession }) => {
   const translateCommon = useCommonTranslation();
   const relevantPeriod =
-    ExamUtils.getCurrentOrFutureAdmissionPeriod(examSession);
+    ExamSessionUtils.getCurrentOrFutureAdmissionPeriod(examSession);
   if (relevantPeriod.kind === RegistrationKind.Admission) {
     return <>{renderAdmissionPeriod(relevantPeriod)}</>;
   } else {
@@ -121,7 +122,9 @@ const PublicExamSessionListingCellsForDesktop = ({
 }) => {
   return (
     <>
-      <TableCell>{ExamUtils.languageAndLevelText(examSession)}</TableCell>
+      <TableCell>
+        {ExamSessionUtils.languageAndLevelText(examSession)}
+      </TableCell>
       <TableCell>
         {DateUtils.formatOptionalDate(examSession.session_date, 'l')}
       </TableCell>
@@ -163,7 +166,7 @@ const PublicExamSessionListingCellsForPhone = ({
     <TableCell>
       <div className="rows grow gapped-xs">
         <Typography variant="h2" component="p">
-          {ExamUtils.languageAndLevelText(examSession)}
+          {ExamSessionUtils.languageAndLevelText(examSession)}
         </Typography>
         <Text>
           <b>{translateCommon('examDate')}</b>
@@ -215,11 +218,20 @@ export const PublicExamSessionListingRow = ({
   const now = dayjs();
   const { isPhone } = useWindowProperties();
 
-  const locationInfo = ExamUtils.getLocationInfo(examSession, getCurrentLang());
-  const registrationPeriodOpen = ExamUtils.isRegistrationOpen(examSession, now);
-  const postAdmissionOpen = ExamUtils.isPostAdmissionOpen(examSession, now);
+  const locationInfo = ExamSessionUtils.getLocationInfo(
+    examSession,
+    getCurrentLang()
+  );
+  const registrationPeriodOpen = ExamSessionUtils.isRegistrationOpen(
+    examSession,
+    now
+  );
+  const postAdmissionOpen = ExamSessionUtils.isPostAdmissionOpen(
+    examSession,
+    now
+  );
   const relevantPeriod =
-    ExamUtils.getCurrentOrFutureAdmissionPeriod(examSession);
+    ExamSessionUtils.getCurrentOrFutureAdmissionPeriod(examSession);
   const getAvailablePlacesText = () => {
     if (
       relevantPeriod.kind === RegistrationKind.Admission &&

--- a/frontend/packages/yki/src/components/registration/steps/register/SubmitRegistrationDetails.tsx
+++ b/frontend/packages/yki/src/components/registration/steps/register/SubmitRegistrationDetails.tsx
@@ -14,7 +14,7 @@ import { loadNationalities } from 'redux/reducers/nationalities';
 import { examSessionSelector } from 'redux/selectors/examSession';
 import { nationalitiesSelector } from 'redux/selectors/nationalities';
 import { registrationSelector } from 'redux/selectors/registration';
-import { ExamUtils } from 'utils/exam';
+import { ExamSessionUtils } from 'utils/examSession';
 
 const FillRegistrationDetails = () => {
   const dispatch = useAppDispatch();
@@ -89,7 +89,7 @@ const Success = () => {
       <H2>{t('title')}</H2>
       <Text>
         {t('confirmation')}:{' '}
-        {ExamUtils.languageAndLevelText(examSession as ExamSession)}
+        {ExamSessionUtils.languageAndLevelText(examSession as ExamSession)}
       </Text>
       <Text>
         {t('paymentLinkEmail.text1')}

--- a/frontend/packages/yki/src/pages/EvaluationOrderStatusPage.tsx
+++ b/frontend/packages/yki/src/pages/EvaluationOrderStatusPage.tsx
@@ -15,7 +15,7 @@ import {
   resetEvaluationOrderState,
 } from 'redux/reducers/evaluationOrder';
 import { evaluationOrderSelector } from 'redux/selectors/evaluationOrder';
-import { ExamUtils } from 'utils/exam';
+import { ExamSessionUtils } from 'utils/examSession';
 
 const EvaluationDetails = ({
   evaluationDetails,
@@ -28,7 +28,7 @@ const EvaluationDetails = ({
     <div>
       <Text>
         {translateCommon('examination')}:{' '}
-        <b>{ExamUtils.languageAndLevelText(evaluationDetails)}</b>
+        <b>{ExamSessionUtils.languageAndLevelText(evaluationDetails)}</b>
       </Text>
       <Text>
         {translateCommon('examDate')}:{' '}

--- a/frontend/packages/yki/src/pages/InitRegistrationPage.tsx
+++ b/frontend/packages/yki/src/pages/InitRegistrationPage.tsx
@@ -20,7 +20,7 @@ import { resetPublicIdentificationState } from 'redux/reducers/publicIdentificat
 import { setActiveStep } from 'redux/reducers/registration';
 import { examSessionSelector } from 'redux/selectors/examSession';
 import { registrationSelector } from 'redux/selectors/registration';
-import { ExamUtils } from 'utils/exam';
+import { ExamSessionUtils } from 'utils/examSession';
 
 const ContentSelector = () => {
   const examSession = useAppSelector(examSessionSelector).examSession;
@@ -28,7 +28,7 @@ const ContentSelector = () => {
     return null;
   }
   const { open, participants, quota } =
-    ExamUtils.getCurrentOrFutureAdmissionPeriod(examSession);
+    ExamSessionUtils.getCurrentOrFutureAdmissionPeriod(examSession);
   if (!open || participants >= quota) {
     return <RegistrationNotAvailable />;
   } else {
@@ -72,7 +72,7 @@ const RegistrationNotAvailable = () => {
   const { isPhone } = useWindowProperties();
 
   const { kind, open, start } =
-    ExamUtils.getCurrentOrFutureAdmissionPeriod(examSession);
+    ExamSessionUtils.getCurrentOrFutureAdmissionPeriod(examSession);
   const now = dayjs();
   const queueAvailable =
     open && kind === RegistrationKind.Admission && !examSession.queue_full;

--- a/frontend/packages/yki/src/redux/reducers/examSessions.ts
+++ b/frontend/packages/yki/src/redux/reducers/examSessions.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { APIResponseStatus } from 'shared/enums';
 
 import { ExamSessionFilters, ExamSessions } from 'interfaces/examSessions';
+import { ExamSessionUtils } from 'utils/examSession';
 
 interface ExamSessionsState extends ExamSessions {
   status: APIResponseStatus;
@@ -33,11 +34,15 @@ const examSessionsSlice = createSlice({
       state.status = APIResponseStatus.Error;
     },
     storeExamSessions(state, action: PayloadAction<ExamSessions>) {
-      state.status = APIResponseStatus.Success;
-      state.exam_sessions = action.payload.exam_sessions;
-      const uniqueMunicipalities = new Set(
-        action.payload.exam_sessions.map((es) => es.location[0].post_office)
+      const examSessions = action.payload.exam_sessions.sort((es1, es2) =>
+        ExamSessionUtils.compareExamSessions(es1, es2)
       );
+      const uniqueMunicipalities = new Set(
+        examSessions.map((es) => es.location[0].post_office)
+      );
+
+      state.status = APIResponseStatus.Success;
+      state.exam_sessions = examSessions;
       state.municipalities = Array.from(uniqueMunicipalities);
     },
     setPublicExamSessionFilters(

--- a/frontend/packages/yki/src/tests/jest/utils/examSession.test.ts
+++ b/frontend/packages/yki/src/tests/jest/utils/examSession.test.ts
@@ -5,26 +5,24 @@ import { ExamSessionLocation } from 'interfaces/examSessions';
 import { ExamSessionUtils } from 'utils/examSession';
 
 describe('ExamSessionUtils', () => {
-  const baseLocation = [
-    {
-      name: 'Jälkiedu',
-      post_office: 'Tampere',
-      zip: '00100',
-      street_address: 'Jokukatu 4',
-      other_location_info: 'auditorio A2',
-      extra_information: '',
-      lang: 'fi',
-    },
-  ];
-
   const baseExamSession = {
-    id: 0,
+    id: 1,
     session_date: dayjs('2099-31-12'),
     language_code: ExamLanguage.ENG,
     level_code: ExamLevel.KESKI,
     max_participants: 13,
     published_at: '',
-    location: baseLocation as Array<ExamSessionLocation>,
+    location: [
+      {
+        name: 'Jälkiedu',
+        post_office: 'Tampere',
+        zip: '00100',
+        street_address: 'Jokukatu 4',
+        other_location_info: 'auditorio A2',
+        extra_information: '',
+        lang: 'fi',
+      },
+    ] as Array<ExamSessionLocation>,
     exam_fee: 100.0,
     open: true,
     queue: 0,
@@ -208,5 +206,42 @@ describe('ExamSessionUtils', () => {
     ).toEqual(-1);
   });
 
-  // TODO: add some post admission related tests
+  it('should treat exam sessions with post admission similarly to ones without', () => {
+    const postAdmissionSession = {
+      ...baseExamSession,
+      registration_end_date: dayjs('2021-01-01'),
+      post_admission_active: true,
+      post_admission_start_date: dayjs('2021-02-02'),
+      post_admission_end_date: dayjs('2090-03-03'),
+      post_admission_quota: 5,
+      pa_participants: 3,
+    };
+
+    expect(
+      ExamSessionUtils.compareExamSessions(
+        postAdmissionSession,
+        baseExamSession
+      )
+    ).toEqual(0);
+
+    expect(
+      ExamSessionUtils.compareExamSessions(
+        {
+          ...postAdmissionSession,
+          pa_participants: postAdmissionSession.post_admission_quota,
+        },
+        baseExamSession
+      )
+    ).toEqual(1);
+
+    expect(
+      ExamSessionUtils.compareExamSessions(
+        {
+          ...postAdmissionSession,
+          post_admission_end_date: dayjs('2021-03-03'),
+        },
+        baseExamSession
+      )
+    ).toEqual(1);
+  });
 });

--- a/frontend/packages/yki/src/tests/jest/utils/examSession.test.ts
+++ b/frontend/packages/yki/src/tests/jest/utils/examSession.test.ts
@@ -1,0 +1,198 @@
+import dayjs from 'dayjs';
+
+import { ExamLanguage, ExamLevel } from 'enums/app';
+import { ExamSessionLocation } from 'interfaces/examSessions';
+import { ExamSessionUtils } from 'utils/examSession';
+
+describe('ExamSessionUtils', () => {
+  const baseLocation = [
+    {
+      name: 'Jälkiedu',
+      post_office: 'Tampere',
+      zip: '00100',
+      street_address: 'Jokukatu 4',
+      other_location_info: 'auditorio A2',
+      extra_information: '',
+      lang: 'fi',
+    },
+  ];
+
+  const baseExamSession = {
+    id: 0,
+    session_date: dayjs('2099-31-12'),
+    language_code: ExamLanguage.ENG,
+    level_code: ExamLevel.KESKI,
+    max_participants: 13,
+    published_at: '',
+    location: baseLocation as Array<ExamSessionLocation>,
+    exam_fee: 100.0,
+    open: true,
+    queue: 0,
+    queue_full: false,
+    participants: 7,
+    pa_participants: 0,
+    post_admission_quota: 0,
+    post_admission_active: false,
+    registration_start_date: dayjs('2020-01-01'),
+    registration_end_date: dayjs('2090-06-15'),
+  };
+
+  describe('compareExamSessions', () => {
+    it('should ignore irrelevant changes between exam sessions', () => {
+      expect(
+        ExamSessionUtils.compareExamSessions(baseExamSession, baseExamSession)
+      ).toEqual(0);
+
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          { ...baseExamSession, registration_start_date: dayjs('2021-01-01') },
+          baseExamSession
+        )
+      ).toEqual(0);
+
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          { ...baseExamSession, registration_end_date: dayjs('2089-06-15') },
+          baseExamSession
+        )
+      ).toEqual(0);
+    });
+
+    it('should prioritise exam sessions based on language code', () => {
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          { ...baseExamSession, language_code: ExamLanguage.DEU },
+          baseExamSession
+        )
+      ).toEqual(-1);
+
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          { ...baseExamSession, language_code: ExamLanguage.FIN },
+          baseExamSession
+        )
+      ).toEqual(1);
+    });
+
+    it('should prioritise exam sessions with room', () => {
+      expect(
+        ExamSessionUtils.compareExamSessions(baseExamSession, {
+          ...baseExamSession,
+          participants: baseExamSession.max_participants,
+        })
+      ).toEqual(-1);
+
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          {
+            ...baseExamSession,
+            participants: baseExamSession.max_participants,
+          },
+          baseExamSession
+        )
+      ).toEqual(1);
+    });
+
+    it('should prioritise exam sessions without full queue', () => {
+      expect(
+        ExamSessionUtils.compareExamSessions(baseExamSession, {
+          ...baseExamSession,
+          queue_full: true,
+        })
+      ).toEqual(-1);
+
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          {
+            ...baseExamSession,
+            queue_full: true,
+          },
+          baseExamSession
+        )
+      ).toEqual(1);
+    });
+
+    it('should prioritise exam sessions with earlier session date', () => {
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          {
+            ...baseExamSession,
+            session_date: dayjs('2098-12-31'),
+          },
+          baseExamSession
+        )
+      ).toEqual(-1);
+
+      expect(
+        ExamSessionUtils.compareExamSessions(baseExamSession, {
+          ...baseExamSession,
+          session_date: dayjs('2098-12-31'),
+        })
+      ).toEqual(1);
+    });
+
+    it('should prioritise exam sessions without ended registration period', () => {
+      expect(
+        ExamSessionUtils.compareExamSessions(baseExamSession, {
+          ...baseExamSession,
+          registration_end_date: dayjs('2021-01-01'),
+        })
+      ).toEqual(-1);
+
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          {
+            ...baseExamSession,
+            registration_end_date: dayjs('2021-01-01'),
+          },
+          baseExamSession
+        )
+      ).toEqual(1);
+    });
+
+    it('should prioritise comparators', () => {
+      // language code > fullness
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          {
+            ...baseExamSession,
+            language_code: ExamLanguage.DEU,
+            participants: baseExamSession.max_participants,
+          },
+          baseExamSession
+        )
+      ).toEqual(-1);
+
+      // fullness > earlier session date
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          {
+            ...baseExamSession,
+            participants: baseExamSession.max_participants,
+            session_date: dayjs('2098-12-31'),
+          },
+          baseExamSession
+        )
+      ).toEqual(1);
+    });
+
+    // earlier session date > ended registration
+    // participants set as max_participants for both to avoid es1 to be considered full and es2 not
+    expect(
+      ExamSessionUtils.compareExamSessions(
+        {
+          ...baseExamSession,
+          participants: baseExamSession.max_participants,
+          session_date: dayjs('2098-12-31'),
+          registration_end_date: dayjs('2021-01-01'),
+        },
+        {
+          ...baseExamSession,
+          participants: baseExamSession.max_participants,
+        }
+      )
+    ).toEqual(-1);
+  });
+
+  // TODO: add some post admission related tests
+});

--- a/frontend/packages/yki/src/tests/jest/utils/examSession.test.ts
+++ b/frontend/packages/yki/src/tests/jest/utils/examSession.test.ts
@@ -206,7 +206,7 @@ describe('ExamSessionUtils', () => {
     ).toEqual(-1);
   });
 
-  it('should treat exam sessions with post admission similarly to ones without', () => {
+  it('should value availability of regular and post admission equally', () => {
     const postAdmissionSession = {
       ...baseExamSession,
       registration_end_date: dayjs('2021-01-01'),

--- a/frontend/packages/yki/src/tests/jest/utils/examSession.test.ts
+++ b/frontend/packages/yki/src/tests/jest/utils/examSession.test.ts
@@ -151,7 +151,7 @@ describe('ExamSessionUtils', () => {
     });
 
     it('should prioritise comparators', () => {
-      // language code > fullness
+      // language code > room
       expect(
         ExamSessionUtils.compareExamSessions(
           {
@@ -163,12 +163,26 @@ describe('ExamSessionUtils', () => {
         )
       ).toEqual(-1);
 
-      // fullness > earlier session date
+      // room > queue fullness
       expect(
         ExamSessionUtils.compareExamSessions(
           {
             ...baseExamSession,
             participants: baseExamSession.max_participants,
+          },
+          {
+            ...baseExamSession,
+            queue_full: true,
+          }
+        )
+      ).toEqual(1);
+
+      // queue fullness > earlier session date
+      expect(
+        ExamSessionUtils.compareExamSessions(
+          {
+            ...baseExamSession,
+            queue_full: true,
             session_date: dayjs('2098-12-31'),
           },
           baseExamSession

--- a/frontend/packages/yki/src/utils/dateTime.ts
+++ b/frontend/packages/yki/src/utils/dateTime.ts
@@ -1,0 +1,15 @@
+import { Dayjs } from 'dayjs';
+import { DateUtils } from 'shared/utils';
+
+import { translateOutsideComponent } from 'configs/i18n';
+
+export class DateTimeUtils {
+  static renderDateTime(dateTime?: Dayjs) {
+    const t = translateOutsideComponent();
+
+    return DateUtils.formatOptionalDateTime(
+      dateTime,
+      t('yki.common.dates.dateTimeFormat')
+    );
+  }
+}

--- a/frontend/packages/yki/src/utils/examSession.ts
+++ b/frontend/packages/yki/src/utils/examSession.ts
@@ -6,6 +6,114 @@ import { ExamLanguage, ExamLevel, RegistrationKind } from 'enums/app';
 import { ExamSession, ExamSessionLocation } from 'interfaces/examSessions';
 
 export class ExamSessionUtils {
+  private static getRegistrationAvailablePlaces(examSession: ExamSession) {
+    return examSession.max_participants - examSession.participants;
+  }
+
+  private static isPostAdmissionAvailable(examSession: ExamSession) {
+    return (
+      examSession.post_admission_end_date &&
+      examSession.post_admission_start_date &&
+      examSession.post_admission_active &&
+      examSession.post_admission_quota
+    );
+  }
+
+  private static getPostAdmissionAvailablePlaces(examSession: ExamSession) {
+    if (ExamSessionUtils.isPostAdmissionAvailable(examSession)) {
+      return examSession.post_admission_quota - examSession.pa_participants;
+    }
+
+    return 0;
+  }
+
+  static getAvailablePlaces(examSession: ExamSession) {
+    return !ExamSessionUtils.hasRegistrationEnded(examSession, dayjs())
+      ? ExamSessionUtils.getRegistrationAvailablePlaces(examSession)
+      : ExamSessionUtils.getPostAdmissionAvailablePlaces(examSession);
+  }
+
+  static hasRoom(examSession: ExamSession) {
+    return ExamSessionUtils.getAvailablePlaces(examSession) > 0;
+  }
+
+  private static compareExamSessionsByLang(es1: ExamSession, es2: ExamSession) {
+    // TODO: write proper language comparator / re-order ExamLanguage enums
+    if (es1.language_code < es2.language_code) {
+      return -1;
+    } else if (es1.language_code > es2.language_code) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  private static compareExamSessionsByRoom(es1: ExamSession, es2: ExamSession) {
+    const hasRoom1 = ExamSessionUtils.hasRoom(es1);
+    const hasRoom2 = ExamSessionUtils.hasRoom(es2);
+
+    if (hasRoom1 && !hasRoom2) {
+      return -1;
+    } else if (!hasRoom1 && hasRoom2) {
+      return 1;
+    }
+
+    if (!es1.queue_full && es2.queue_full) {
+      return -1;
+    } else if (es1.queue_full && !es2.queue_full) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  private static compareExamSessionsByDate(es1: ExamSession, es2: ExamSession) {
+    if (es1.session_date.isBefore(es2.session_date)) {
+      return -1;
+    } else if (es1.session_date.isAfter(es2.session_date)) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  private static compareExamSessionsByRegistrationEnding(
+    es1: ExamSession,
+    es2: ExamSession
+  ) {
+    const now = dayjs();
+    const registrationEnded1 = ExamSessionUtils.hasRegistrationEnded(es1, now);
+    const registrationEnded2 = ExamSessionUtils.hasRegistrationEnded(es2, now);
+
+    if (!registrationEnded1 && registrationEnded2) {
+      return -1;
+    } else if (registrationEnded1 && !registrationEnded2) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  static compareExamSessions(es1: ExamSession, es2: ExamSession) {
+    // Prioritised ordering of comparators
+    const comparatorFns = [
+      ExamSessionUtils.compareExamSessionsByLang,
+      ExamSessionUtils.compareExamSessionsByRoom,
+      ExamSessionUtils.compareExamSessionsByDate,
+      ExamSessionUtils.compareExamSessionsByRegistrationEnding,
+    ];
+
+    for (let i = 0; i < comparatorFns.length; i++) {
+      const order = comparatorFns[i](es1, es2);
+
+      if (order !== 0) {
+        return order;
+      }
+    }
+
+    return 0;
+  }
+
   static languageAndLevelText({
     language_code,
     level_code,
@@ -31,16 +139,30 @@ export class ExamSessionUtils {
     return locationData as ExamSessionLocation;
   }
 
-  static isRegistrationOpen(examSession: ExamSession, now: Dayjs) {
-    const { registration_start_date, registration_end_date } = examSession;
+  static hasRegistrationStarted(examSession: ExamSession, now: Dayjs) {
+    const { registration_start_date } = examSession;
 
     // TODO Consider timezones! Registration opening / closing times are supposed to be
     // wrt. Finnish times, but user can be on a different timezone.
     const registrationOpensAt = registration_start_date.hour(10);
+
+    return registrationOpensAt.isBefore(now);
+  }
+
+  static hasRegistrationEnded(examSession: ExamSession, now: Dayjs) {
+    const { registration_end_date } = examSession;
+
+    // TODO Consider timezones! Registration opening / closing times are supposed to be
+    // wrt. Finnish times, but user can be on a different timezone.
     const registrationClosesAt = registration_end_date.hour(16);
 
+    return registrationClosesAt.isAfter(now);
+  }
+
+  static isRegistrationOpen(examSession: ExamSession, now: Dayjs) {
     return (
-      registrationOpensAt.isBefore(now) && registrationClosesAt.isAfter(now)
+      ExamSessionUtils.hasRegistrationStarted(examSession, now) &&
+      ExamSessionUtils.hasRegistrationEnded(examSession, now)
     );
   }
 
@@ -71,11 +193,11 @@ export class ExamSessionUtils {
     const now = dayjs();
     const registrationOpensAt = examSession.registration_start_date?.hour(10);
     const registrationClosesAt = examSession.registration_end_date?.hour(16);
-    const postAdmissionAvailable =
-      examSession.post_admission_active &&
-      examSession.post_admission_start_date &&
-      examSession.post_admission_end_date;
-    if (now.isBefore(registrationClosesAt) || !postAdmissionAvailable) {
+
+    if (
+      now.isBefore(registrationClosesAt) ||
+      !ExamSessionUtils.isPostAdmissionAvailable(examSession)
+    ) {
       return {
         kind: RegistrationKind.Admission,
         start: registrationOpensAt,

--- a/frontend/packages/yki/src/utils/examSession.ts
+++ b/frontend/packages/yki/src/utils/examSession.ts
@@ -1,12 +1,11 @@
 import dayjs, { Dayjs } from 'dayjs';
 import { AppLanguage } from 'shared/enums';
-import { DateUtils } from 'shared/utils';
 
 import { translateOutsideComponent } from 'configs/i18n';
 import { ExamLanguage, ExamLevel, RegistrationKind } from 'enums/app';
 import { ExamSession, ExamSessionLocation } from 'interfaces/examSessions';
 
-export class ExamUtils {
+export class ExamSessionUtils {
   static languageAndLevelText({
     language_code,
     level_code,
@@ -30,15 +29,6 @@ export class ExamUtils {
     );
 
     return locationData as ExamSessionLocation;
-  }
-
-  static renderDateTime(dateTime?: Dayjs) {
-    const t = translateOutsideComponent();
-
-    return DateUtils.formatOptionalDateTime(
-      dateTime,
-      t('yki.common.dates.dateTimeFormat')
-    );
   }
 
   static isRegistrationOpen(examSession: ExamSession, now: Dayjs) {

--- a/frontend/packages/yki/src/utils/examSession.ts
+++ b/frontend/packages/yki/src/utils/examSession.ts
@@ -156,13 +156,13 @@ export class ExamSessionUtils {
     // wrt. Finnish times, but user can be on a different timezone.
     const registrationClosesAt = registration_end_date.hour(16);
 
-    return registrationClosesAt.isAfter(now);
+    return registrationClosesAt.isBefore(now);
   }
 
   static isRegistrationOpen(examSession: ExamSession, now: Dayjs) {
     return (
       ExamSessionUtils.hasRegistrationStarted(examSession, now) &&
-      ExamSessionUtils.hasRegistrationEnded(examSession, now)
+      !ExamSessionUtils.hasRegistrationEnded(examSession, now)
     );
   }
 

--- a/frontend/packages/yki/src/utils/examSession.ts
+++ b/frontend/packages/yki/src/utils/examSession.ts
@@ -14,8 +14,7 @@ export class ExamSessionUtils {
     return (
       examSession.post_admission_active &&
       examSession.post_admission_start_date &&
-      examSession.post_admission_end_date &&
-      examSession.post_admission_quota
+      examSession.post_admission_end_date
     );
   }
 
@@ -92,8 +91,16 @@ export class ExamSessionUtils {
     es2: ExamSession
   ) {
     const now = dayjs();
-    const registrationEnded1 = ExamSessionUtils.hasRegistrationEnded(es1, now);
-    const registrationEnded2 = ExamSessionUtils.hasRegistrationEnded(es2, now);
+
+    const registrationEnded1 =
+      ExamSessionUtils.hasRegistrationEnded(es1, now) &&
+      (!ExamSessionUtils.isPostAdmissionAvailable(es1) ||
+        ExamSessionUtils.hasPostAdmissionEnded(es1, now));
+
+    const registrationEnded2 =
+      ExamSessionUtils.hasRegistrationEnded(es2, now) &&
+      (!ExamSessionUtils.isPostAdmissionAvailable(es2) ||
+        ExamSessionUtils.hasPostAdmissionEnded(es2, now));
 
     if (!registrationEnded1 && registrationEnded2) {
       return -1;

--- a/frontend/packages/yki/src/utils/examSession.ts
+++ b/frontend/packages/yki/src/utils/examSession.ts
@@ -61,6 +61,13 @@ export class ExamSessionUtils {
       return 1;
     }
 
+    return 0;
+  }
+
+  private static compareExamSessionsByQueueFullness(
+    es1: ExamSession,
+    es2: ExamSession
+  ) {
     if (!es1.queue_full && es2.queue_full) {
       return -1;
     } else if (es1.queue_full && !es2.queue_full) {
@@ -102,6 +109,7 @@ export class ExamSessionUtils {
     const comparatorFns = [
       ExamSessionUtils.compareExamSessionsByLang,
       ExamSessionUtils.compareExamSessionsByRoom,
+      ExamSessionUtils.compareExamSessionsByQueueFullness,
       ExamSessionUtils.compareExamSessionsByDate,
       ExamSessionUtils.compareExamSessionsByRegistrationEnding,
     ];


### PR DESCRIPTION
## Yhteenveto

Toteutettu tilaisuuksien järjestäminen ilmoittautumisen etusivulla vanhan UI:n tavoin pl. se, että tässä uudessa UI:ssa tilaisuudet järjestetään priorisoiden ensin kielen mukaisesti. Kielen mukaan järjestys tapahtuu parhaillaan vissiin ExamLanguage enumin arvojen järjestyksen mukaisesti. Voidaan muuttaa tuota varmaan myöhemminkin jos sopii järjestyksestä OPH:n kanssa ensin?

Vanhassa UI:ssa tilaisuuksien järjestämisen logiikka löytyy `registration` reducerin funktion `sortSessions` alta.

Testejä en tähän ainakaan alkanut toistaiseksi kirjoittaa, kun noita on yleisestikin työn alla paraikaa.
