### PR TITLE
OPHYKIKEH-248: Add footer links

### DIFF
--- a/frontend/packages/yki/public/i18n/en-GB/common.json
+++ b/frontend/packages/yki/public/i18n/en-GB/common.json
@@ -5,6 +5,7 @@
       "appNameAbbreviation": "YKI",
       "appTitle": "National Certificates of Language Proficiency (YKI) | Finnish National Agency for Education",
       "back": "Back",
+      "backToHomePage": "Back to front page",
       "cancel": "Cancel",
       "component": {
         "table": {

--- a/frontend/packages/yki/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/public/i18n/en-GB/public.json
@@ -70,7 +70,7 @@
             "title": "Feedback and development suggestions"
           },
           "privacy": {
-            "text": "Privacy policy statement",
+            "text": "Privacy policy statement (oph.fi)",
             "url": "https://www.oph.fi/en/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/yleiset-kielitutkinnot-yki/ilmoittautuminen-yki-testiin#anchor-information-on-the-processing-of-personal-data"
           },
           "ykiHomepage": {

--- a/frontend/packages/yki/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/public/i18n/en-GB/public.json
@@ -70,7 +70,8 @@
             "title": "Feedback and development suggestions"
           },
           "privacy": {
-            "text": "Privacy policy statement (in Finnish)"
+            "text": "Privacy policy statement",
+            "url": "https://www.oph.fi/en/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/yleiset-kielitutkinnot-yki/ilmoittautuminen-yki-testiin#anchor-information-on-the-processing-of-personal-data"
           },
           "ykiHomepage": {
             "text": "Website of the National Certificates of Language Proficiency (YKI) (oph.fi)"

--- a/frontend/packages/yki/public/i18n/fi-FI/accessibility.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/accessibility.json
@@ -1,0 +1,52 @@
+{
+  "yki": {
+    "accessibility": {
+      "content": {
+        "administrativeAgency": {
+          "description": "Saavutettavuuden valvonnan yksikkö",
+          "email": "saavutettavuus@avi.fi",
+          "link": {
+            "label": "Saavutettavuusvaatimukset.fi",
+            "url": "https://saavutettavuusvaatimukset.fi"
+          },
+          "phone": "0295 016 000",
+          "switchboard": "Vaihde",
+          "title": "Valvontaviranomaisen yhteystiedot"
+        },
+        "caveats": [
+        ],
+        "composition": {
+          "description": "",
+          "title": "Tämän saavutettavuusselosteen laatiminen"
+        },
+        "enforcement": {
+          "description": "",
+          "title": "Täytäntöönpanomenettely"
+        },
+        "feedback": {
+          "description1": "",
+          "description2": "",
+          "title": "Palaute ja yhteystiedot"
+        },
+        "furtherImprove": {
+          "description1": "",
+          "description2": "",
+          "title": "Teemme jatkuvasti työtä saavutettavuuden parantamiseksi"
+        },
+        "nonAccessible": {
+          "description1": "",
+          "description2": "",
+          "title": "Ei-saavutettava sisältö"
+        },
+        "status": {
+          "description": "",
+          "title": "Saavutettavuuden tila"
+        }
+      },
+      "heading": {
+        "description": "",
+        "title": "Saavutettavuusseloste"
+      }
+    }
+  }
+}

--- a/frontend/packages/yki/public/i18n/fi-FI/common.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/common.json
@@ -5,6 +5,7 @@
       "appNameAbbreviation": "YKI",
       "appTitle": "Yleiset kielitutkinnot | Opetushallitus",
       "back": "Takaisin",
+      "backToHomePage": "Takaisin etusivulle",
       "cancel": "Peruuta",
       "component": {
         "table": {

--- a/frontend/packages/yki/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/public.json
@@ -70,7 +70,7 @@
             "title": "Palaute ja kehitysideat"
           },
           "privacy": {
-            "text": "Tietosuojaseloste",
+            "text": "Tietosuojaseloste (oph.fi)",
             "url": "https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/yleiset-kielitutkinnot-yki/ilmoittautuminen-yki-testiin#anchor-tietoa-henkilotietojen-kasittelysta"
           },
           "ykiHomepage": {

--- a/frontend/packages/yki/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/public.json
@@ -70,7 +70,8 @@
             "title": "Palaute ja kehitysideat"
           },
           "privacy": {
-            "text": "Tietosuojaseloste"
+            "text": "Tietosuojaseloste",
+            "url": "https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/yleiset-kielitutkinnot-yki/ilmoittautuminen-yki-testiin#anchor-tietoa-henkilotietojen-kasittelysta"
           },
           "ykiHomepage": {
             "text": "Yleisten kielitutkintojen verkkosivu (oph.fi)"

--- a/frontend/packages/yki/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/public.json
@@ -62,6 +62,11 @@
           "street": "Hakaniemenranta 6",
           "zipCity": "PL 380, 00531 Helsinki"
         },
+        "headings": {
+          "statements": "Selosteet",
+          "info": "Lisätietoa YKIstä",
+          "contacts": "Yhteystiedot"
+        },
         "links": {
           "accessibility": {
             "text": "Saavutettavuusseloste"

--- a/frontend/packages/yki/public/i18n/sv-SE/common.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/common.json
@@ -4,6 +4,7 @@
       "actions": "Funktioner",
       "appNameAbbreviation": "YKI",
       "appTitle": "Allmänna språkexamina | Utbildningsstyrelsen",
+      "backToHomePage": "Tillbaka till framsidan",
       "contactEmail": "kielitutkinnot@oph.fi",
       "dates": {
         "dateTimeFormat": "l [kl.] HH:mm"

--- a/frontend/packages/yki/src/components/layouts/Footer.tsx
+++ b/frontend/packages/yki/src/components/layouts/Footer.tsx
@@ -29,17 +29,16 @@ export const Footer = () => {
         <div className="footer__info-row">
           <div className="footer__container footer__container__links">
             <CustomButtonLink
-              to={AppRoutes.NotFoundPage}
+              to={AppRoutes.AccessibilityStatementPage}
               variant={Variant.Text}
             >
               {t('links.accessibility.text')}
             </CustomButtonLink>
-            <CustomButtonLink
-              to={AppRoutes.NotFoundPage}
-              variant={Variant.Text}
-            >
-              {t('links.privacy.text')}
-            </CustomButtonLink>
+            <ExtLink
+              text={t('links.privacy.text')}
+              href={t('links.privacy.url')}
+              endIcon={<OpenInNewIcon />}
+            />
             <ExtLink
               text={t('links.ykiHomepage.text')}
               href={translateCommon('ykiHomepage.link')}

--- a/frontend/packages/yki/src/components/layouts/Footer.tsx
+++ b/frontend/packages/yki/src/components/layouts/Footer.tsx
@@ -21,7 +21,7 @@ export const Footer = () => {
       <Svg className="footer__wave" src={FooterWave} alt="" />
       <Paper className="footer" elevation={3}>
         <div className="footer__info-row">
-          <div className="footer__container footer__container__links">
+          <div className="footer__container footer__container__links rows gapped-xs">
             <h2>{t('headings.statements')}</h2>
             <Link to={AppRoutes.AccessibilityStatementPage}>
               <Text>{t('links.accessibility.text')}</Text>
@@ -35,7 +35,7 @@ export const Footer = () => {
               {t('links.privacy.text')} <OpenInNewIcon />
             </a>
           </div>
-          <div className="footer__container footer__container__info">
+          <div className="footer__container footer__container__info rows gapped-xs">
             <h2>{t('headings.info')}</h2>
             <a
               href={translateCommon('ykiHomepage.link')}
@@ -48,13 +48,11 @@ export const Footer = () => {
               <OpenInNewIcon />
             </a>
           </div>
-          <div className="footer__container footer__container__contact-details">
+          <div className="footer__container footer__container__contact-details rows gapped-xs">
             <h2>{t('headings.contacts')}</h2>
             <H3>{t('address.name')}</H3>
-            <br />
             <Text>{t('address.street')}</Text>
             <Text>{t('address.zipCity')}</Text>
-            <br />
             <div className="columns gapped-xxs">
               <Text className="inline-text">{t('address.phone.title')}</Text>
               <a
@@ -66,7 +64,7 @@ export const Footer = () => {
                 {t('address.phone.number')}
               </a>
             </div>
-            <div className="footer__container__links__contact">
+            <div className="footer__container__links__contact rows gapped-xs">
               <H3>{t('links.contact.title')}:</H3>
               <a
                 className="footer__container__links__contact__email"

--- a/frontend/packages/yki/src/components/layouts/Footer.tsx
+++ b/frontend/packages/yki/src/components/layouts/Footer.tsx
@@ -22,7 +22,8 @@ export const Footer = () => {
       <Paper className="footer" elevation={3}>
         <div className="footer__info-row">
           <div className="footer__container footer__container__links">
-            <Link to={AppRoutes.AccessibilityStatementPage} target="_blank">
+            <h2>{t('headings.statements')}</h2>
+            <Link to={AppRoutes.AccessibilityStatementPage}>
               <Text>{t('links.accessibility.text')}</Text>
             </Link>
             <ExtLink
@@ -30,6 +31,9 @@ export const Footer = () => {
               href={t('links.privacy.url')}
               endIcon={<OpenInNewIcon />}
             />
+          </div>
+          <div className="footer__container footer__container__info">
+            <h2>{t('headings.info')}</h2>
             <ExtLink
               text={t('links.ykiHomepage.text')}
               href={translateCommon('ykiHomepage.link')}
@@ -38,6 +42,7 @@ export const Footer = () => {
             />
           </div>
           <div className="footer__container footer__container__contact-details">
+            <h2>{t('headings.contacts')}</h2>
             <H3>{t('address.name')}</H3>
             <br />
             <Text>{t('address.street')}</Text>

--- a/frontend/packages/yki/src/components/layouts/Footer.tsx
+++ b/frontend/packages/yki/src/components/layouts/Footer.tsx
@@ -1,7 +1,7 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Divider, Paper } from '@mui/material';
 import { Link } from 'react-router-dom';
-import { ExtLink, H3, OPHLogoViewer, Svg, Text } from 'shared/components';
+import { H3, OPHLogoViewer, Svg, Text } from 'shared/components';
 import { Direction } from 'shared/enums';
 import { FooterWave } from 'shared/statics';
 
@@ -26,20 +26,27 @@ export const Footer = () => {
             <Link to={AppRoutes.AccessibilityStatementPage}>
               <Text>{t('links.accessibility.text')}</Text>
             </Link>
-            <ExtLink
-              text={t('links.privacy.text')}
+            <a
               href={t('links.privacy.url')}
-              endIcon={<OpenInNewIcon />}
-            />
+              className="columns gapped-xxs"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t('links.privacy.text')} <OpenInNewIcon />
+            </a>
           </div>
           <div className="footer__container footer__container__info">
             <h2>{t('headings.info')}</h2>
-            <ExtLink
-              text={t('links.ykiHomepage.text')}
+            <a
               href={translateCommon('ykiHomepage.link')}
-              endIcon={<OpenInNewIcon />}
               aria-label={translateCommon('ykiHomepage.ariaLabel')}
-            />
+              className="columns gapped-xxs"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t('links.ykiHomepage.text')}
+              <OpenInNewIcon />
+            </a>
           </div>
           <div className="footer__container footer__container__contact-details">
             <h2>{t('headings.contacts')}</h2>
@@ -50,19 +57,25 @@ export const Footer = () => {
             <br />
             <div className="columns gapped-xxs">
               <Text className="inline-text">{t('address.phone.title')}</Text>
-              <ExtLink
+              <a
                 className="inline-text"
-                text={t('address.phone.number')}
                 href={`tel:${t('address.phone.number')}`}
-              />
+                target="_blank"
+                rel="noreferrer"
+              >
+                {t('address.phone.number')}
+              </a>
             </div>
             <div className="footer__container__links__contact">
               <H3>{t('links.contact.title')}:</H3>
-              <ExtLink
+              <a
                 className="footer__container__links__contact__email"
                 href={`mailto:${translateCommon('contactEmail')}`}
-                text={translateCommon('contactEmail')}
-              ></ExtLink>
+                target="_blank"
+                rel="noreferrer"
+              >
+                {translateCommon('contactEmail')}
+              </a>
             </div>
           </div>
         </div>

--- a/frontend/packages/yki/src/components/layouts/Footer.tsx
+++ b/frontend/packages/yki/src/components/layouts/Footer.tsx
@@ -1,14 +1,8 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Divider, Paper } from '@mui/material';
-import {
-  CustomButtonLink,
-  ExtLink,
-  H3,
-  OPHLogoViewer,
-  Svg,
-  Text,
-} from 'shared/components';
-import { Direction, Variant } from 'shared/enums';
+import { Link } from 'react-router-dom';
+import { ExtLink, H3, OPHLogoViewer, Svg, Text } from 'shared/components';
+import { Direction } from 'shared/enums';
 import { FooterWave } from 'shared/statics';
 
 import {
@@ -28,12 +22,9 @@ export const Footer = () => {
       <Paper className="footer" elevation={3}>
         <div className="footer__info-row">
           <div className="footer__container footer__container__links">
-            <CustomButtonLink
-              to={AppRoutes.AccessibilityStatementPage}
-              variant={Variant.Text}
-            >
-              {t('links.accessibility.text')}
-            </CustomButtonLink>
+            <Link to={AppRoutes.AccessibilityStatementPage} target="_blank">
+              <Text>{t('links.accessibility.text')}</Text>
+            </Link>
             <ExtLink
               text={t('links.privacy.text')}
               href={t('links.privacy.url')}

--- a/frontend/packages/yki/src/configs/i18n.ts
+++ b/frontend/packages/yki/src/configs/i18n.ts
@@ -10,6 +10,7 @@ import { DateUtils } from 'shared/utils';
 
 import commonEN from 'public/i18n/en-GB/common.json';
 import publicEN from 'public/i18n/en-GB/public.json';
+import accessibilityFI from 'public/i18n/fi-FI/accessibility.json';
 import commonFI from 'public/i18n/fi-FI/common.json';
 import publicFI from 'public/i18n/fi-FI/public.json';
 import commonSV from 'public/i18n/sv-SE/common.json';
@@ -24,6 +25,7 @@ const supportedLangs = [langFI, langSV, langEN];
 
 const resources = {
   [langFI]: {
+    [I18nNamespace.Accessibility]: accessibilityFI,
     [I18nNamespace.Common]: commonFI,
     [I18nNamespace.Public]: publicFI,
   },
@@ -78,6 +80,16 @@ const useAppTranslation = (
   return useTranslation(ns, options);
 };
 
+export const useAccessibilityTranslation = () => {
+  const { t } = useAppTranslation(
+    {
+      keyPrefix: 'yki.accessibility',
+    },
+    I18nNamespace.Accessibility
+  );
+
+  return t;
+};
 export const usePublicTranslation = (
   options: UseTranslationOptions<string>
 ) => {

--- a/frontend/packages/yki/src/enums/app.ts
+++ b/frontend/packages/yki/src/enums/app.ts
@@ -3,6 +3,7 @@ export enum AppConstants {
 }
 
 export enum AppRoutes {
+  AccessibilityStatementPage = '/yki/saavutettavuus',
   Registration = '/yki/ilmoittautuminen',
   RegistrationPaymentStatus = '/yki/ilmoittautuminen/maksu/tila',
   ExamSessionRegistration = '/yki/ilmoittautuminen/tutkintotilaisuus/:examSessionId',

--- a/frontend/packages/yki/src/pages/AccessibilityStatementPage.tsx
+++ b/frontend/packages/yki/src/pages/AccessibilityStatementPage.tsx
@@ -1,0 +1,196 @@
+import { ArrowBackIosOutlined as ArrowBackIosOutlinedIcon } from '@mui/icons-material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { Grid, Paper, Typography } from '@mui/material';
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import {
+  CustomButtonLink,
+  H1,
+  H2,
+  H3,
+  HeaderSeparator,
+  Text,
+  WebLink,
+} from 'shared/components';
+import { Variant } from 'shared/enums';
+import { CommonUtils } from 'shared/utils';
+
+import {
+  useAccessibilityTranslation,
+  useCommonTranslation,
+} from 'configs/i18n';
+import { AppRoutes } from 'enums/app';
+import accessibilityFI from 'public/i18n/fi-FI/accessibility.json';
+
+const BackButton = () => {
+  const translateCommon = useCommonTranslation();
+
+  return (
+    <CustomButtonLink
+      to={AppRoutes.Registration}
+      variant={Variant.Text}
+      startIcon={<ArrowBackIosOutlinedIcon />}
+      className="color-secondary-dark"
+    >
+      {translateCommon('backToHomePage')}
+    </CustomButtonLink>
+  );
+};
+
+const ItemBulletList = ({
+  item,
+  bulletPoints,
+}: {
+  item: string;
+  bulletPoints: Array<string>;
+}) => (
+  <Typography variant="body1" component="div">
+    <ul className="accessibility-statement-page__item-bullet-list">
+      <li>{item}</li>
+      <ul>
+        {bulletPoints.map((bulletPoint, i) => (
+          <li key={`${bulletPoint}-${i}`}>{bulletPoint}</li>
+        ))}
+      </ul>
+    </ul>
+  </Typography>
+);
+
+export const AccessibilityStatementPage = () => {
+  const translateAccessibility = useAccessibilityTranslation();
+  const translateCommon = useCommonTranslation();
+  const { pathname } = useLocation();
+
+  const caveats = Object.keys(
+    accessibilityFI.yki.accessibility.content.caveats
+  );
+
+  useEffect(() => {
+    CommonUtils.scrollToTop();
+  }, [pathname]);
+
+  return (
+    <Grid
+      className="accessibility-statement-page"
+      container
+      rowSpacing={4}
+      direction="column"
+    >
+      <Grid item className="accessibility-statement-page__back-button">
+        <BackButton />
+      </Grid>
+      <Grid item className="accessibility-statement-page__heading">
+        <H1>{translateAccessibility('heading.title')}</H1>
+        <HeaderSeparator />
+        <Text>{translateAccessibility('heading.description')}</Text>
+      </Grid>
+      <Grid item>
+        <Paper className="accessibility-statement-page__content" elevation={3}>
+          <div className="accessibility-statement rows gapped-xxl">
+            <div className="rows gapped-xxs">
+              <H2>{translateAccessibility('content.status.title')}</H2>
+              <Text>
+                {translateAccessibility('content.status.description')}
+              </Text>
+            </div>
+            <div className="rows gapped-xxs">
+              <H3>{translateAccessibility('content.nonAccessible.title')}</H3>
+              <Text>
+                {translateAccessibility('content.nonAccessible.description1')}
+                {':'}
+              </Text>
+              <Text>
+                {translateAccessibility('content.nonAccessible.description2')}
+              </Text>
+              {caveats.map(({}, i) => (
+                <ItemBulletList
+                  key={`items-${i}`}
+                  item={translateAccessibility(`content.caveats.${i}.name`)}
+                  bulletPoints={translateAccessibility(
+                    `content.caveats.${i}.points`,
+                    { returnObjects: true }
+                  )}
+                />
+              ))}
+            </div>
+            <div className="rows gapped-xxs">
+              <H2>{translateAccessibility('content.composition.title')}</H2>
+              <Text>
+                {translateAccessibility('content.composition.description')}
+              </Text>
+            </div>
+            <div className="rows gapped-xxs">
+              <H2>{translateAccessibility('content.feedback.title')}</H2>
+              <Text>
+                {translateAccessibility('content.feedback.description1')}
+              </Text>
+              <Text>
+                {translateAccessibility('content.feedback.description2')}
+                {': '}
+                <WebLink
+                  href={`mailto:${translateCommon('contactEmail')}`}
+                  label={translateCommon('contactEmail')}
+                />
+              </Text>
+            </div>
+            <div className="rows gapped">
+              <div className="rows gapped-xxs">
+                <H3>{translateAccessibility('content.enforcement.title')}</H3>
+                <Text>
+                  {translateAccessibility('content.enforcement.description')}
+                </Text>
+              </div>
+              <div className="rows gapped-xxs">
+                <H3>
+                  {translateAccessibility('content.administrativeAgency.title')}
+                </H3>
+                <Text>
+                  {translateAccessibility(
+                    'content.administrativeAgency.description'
+                  )}
+                </Text>
+                <Text>
+                  <WebLink
+                    href={translateAccessibility(
+                      'content.administrativeAgency.link.url'
+                    )}
+                    label={translateAccessibility(
+                      'content.administrativeAgency.link.label'
+                    )}
+                    endIcon={<OpenInNewIcon />}
+                  />
+                </Text>
+                <Text>
+                  <WebLink
+                    href={`mailto:${translateAccessibility(
+                      'content.administrativeAgency.email'
+                    )}`}
+                    label={translateAccessibility(
+                      'content.administrativeAgency.email'
+                    )}
+                  />
+                </Text>
+                <Text>
+                  {translateAccessibility(
+                    'content.administrativeAgency.switchboard'
+                  )}
+                  {': '}
+                  {translateAccessibility('content.administrativeAgency.phone')}
+                </Text>
+              </div>
+            </div>
+            <div className="rows gapped-xxs">
+              <H2>{translateAccessibility('content.furtherImprove.title')}</H2>
+              <Text>
+                {translateAccessibility('content.furtherImprove.description1')}
+              </Text>
+              <Text>
+                {translateAccessibility('content.furtherImprove.description2')}
+              </Text>
+            </div>
+          </div>
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+};

--- a/frontend/packages/yki/src/routers/AppRouter.tsx
+++ b/frontend/packages/yki/src/routers/AppRouter.tsx
@@ -7,6 +7,7 @@ import { Header } from 'components/layouts/Header';
 import { useCommonTranslation } from 'configs/i18n';
 import { AppRoutes } from 'enums/app';
 import { useAPIErrorToast } from 'hooks/useAPIErrorToast';
+import { AccessibilityStatementPage } from 'pages/AccessibilityStatementPage';
 import { EvaluationOrderPage } from 'pages/EvaluationOrderPage';
 import { EvaluationOrderStatusPage } from 'pages/EvaluationOrderStatusPage';
 import { ExamDetailsPage } from 'pages/ExamDetailsPage';
@@ -59,6 +60,10 @@ export const AppRouter: FC = () => {
               <Route
                 path={AppRoutes.ReassessmentOrderStatus}
                 element={<EvaluationOrderStatusPage />}
+              />
+              <Route
+                path={AppRoutes.AccessibilityStatementPage}
+                element={<AccessibilityStatementPage />}
               />
             </Routes>
           </div>

--- a/frontend/packages/yki/src/styles/components/layouts/_footer.scss
+++ b/frontend/packages/yki/src/styles/components/layouts/_footer.scss
@@ -83,7 +83,6 @@
       letter-spacing: 0;
       line-height: 1.9rem;
       margin: 0;
-      padding: 6px 0;
       text-decoration: underline;
       text-transform: initial;
 

--- a/frontend/packages/yki/src/styles/components/layouts/_footer.scss
+++ b/frontend/packages/yki/src/styles/components/layouts/_footer.scss
@@ -42,6 +42,7 @@
     padding: 1.5rem;
 
     &__links,
+    &__info,
     &__contact-details {
       margin-top: 3rem;
 
@@ -70,6 +71,10 @@
       }
     }
 
+    & h2 {
+      font-size: 2rem;
+    }
+
     & a,
     & > a > button {
       color: $color-secondary-dark;
@@ -84,12 +89,6 @@
 
       @include phone {
         font-size: 1.5rem;
-      }
-    }
-
-    &:last-of-type {
-      @include phone {
-        order: -1;
       }
     }
   }

--- a/frontend/packages/yki/src/styles/components/layouts/_footer.scss
+++ b/frontend/packages/yki/src/styles/components/layouts/_footer.scss
@@ -74,12 +74,12 @@
     & > a > button {
       color: $color-secondary-dark;
       font-size: 1.6rem;
-      font-weight: 700;
+      font-weight: normal;
       letter-spacing: 0;
       line-height: 1.9rem;
       margin: 0;
       padding: 6px 0;
-      text-decoration: none;
+      text-decoration: underline;
       text-transform: initial;
 
       @include phone {

--- a/frontend/packages/yki/src/styles/pages/_accessibility-statement-page.scss
+++ b/frontend/packages/yki/src/styles/pages/_accessibility-statement-page.scss
@@ -1,0 +1,31 @@
+.accessibility-statement-page {
+  flex: 1;
+
+  & &__back-button {
+    @include phone {
+      margin-top: 2rem;
+      padding: 2rem 2rem 0;
+    }
+  }
+
+  & &__heading {
+    @include phone {
+      padding: 2rem 2rem 0;
+    }
+  }
+
+  & &__content {
+    padding: 4rem 3rem;
+
+    @include phone {
+      @include phone-divider-border-top;
+      @include phone-divider-border-bottom;
+      gap: 1.5rem;
+      padding: 1rem 2rem;
+    }
+  }
+
+  & &__item-bullet-list {
+    margin-block-end: 0;
+  }
+}

--- a/frontend/packages/yki/src/styles/styles.scss
+++ b/frontend/packages/yki/src/styles/styles.scss
@@ -11,6 +11,7 @@
 @import 'components/registration/public-registration';
 
 // Pages
+@import 'pages/accessibility-statement-page';
 @import 'pages/evaluation-order-page';
 @import 'pages/evaluation-order-status-page';
 @import 'pages/public-exam-details-page';

--- a/frontend/packages/yki/src/tests/jest/components/registration/examSession/__snapshots__/PublicExamSessionListing.test.tsx.snap
+++ b/frontend/packages/yki/src/tests/jest/components/registration/examSession/__snapshots__/PublicExamSessionListing.test.tsx.snap
@@ -287,7 +287,7 @@ Array [
           postAdmission
           :
           <br />
-          yki.co00on.2amte0.2amteTi0eFor0amt — yki.co00on.5pmte0.5pmteTi0eFor0pmt
+          yki.co00on.2amte0.2amteTi0eFor0amt — yki.co00on.0pmte0.0pmteTi0eFor0pmt
         </td>
         <td
           aria-sort={null}

--- a/frontend/packages/yki/src/tests/msw/fixtures/examSession.ts
+++ b/frontend/packages/yki/src/tests/msw/fixtures/examSession.ts
@@ -109,7 +109,7 @@ export const examSessions = {
       queue: 0,
       post_admission_quota: 10,
       post_admission_start_date: '2023-08-01',
-      post_admission_end_date: '2023-09-01',
+      post_admission_end_date: '2024-09-01',
       post_admission_active: true,
     },
     {


### PR DESCRIPTION
## Yhteenveto

Kopioin VKT:n saavutettavuusseloste-sivun pohjaksi tähän. Kun saadaan oikeat tekstit, ne voi vain lisätä käännöksiin.

Tietosuoja menee OPH:n YKI-sivullle otsikkoon henkilötietojen käsittelystä, samaan paikkaan joka tulee esille ilmoittautumisen lopussa.

 https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/yleiset-kielitutkinnot-yki/ilmoittautuminen-yki-testiin#anchor-tietoa-henkilotietojen-kasittelysta

