### PR TITLE
OTR(Backend & Frontend) OPHOTRKEH-248: NPE/Enum korjaus kun ONR-tiedot muuttuneet

### DIFF
--- a/backend/otr/src/main/java/fi/oph/otr/api/clerk/ClerkInterpreterController.java
+++ b/backend/otr/src/main/java/fi/oph/otr/api/clerk/ClerkInterpreterController.java
@@ -42,6 +42,12 @@ public class ClerkInterpreterController {
     return clerkInterpreterService.list();
   }
 
+  @GetMapping(path = "/missing")
+  @Operation(tags = TAG_INTERPRETER, summary = "List interpreters that are missing from ONR")
+  public List<String> listMissingInterpreters() {
+    return clerkInterpreterService.listMissing();
+  }
+
   @Operation(tags = TAG_INTERPRETER, summary = "Create new interpreter")
   @PostMapping(consumes = APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.CREATED)

--- a/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/OnrOperationApiImpl.java
@@ -1,6 +1,7 @@
 package fi.oph.otr.onr;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.oph.otr.config.Constants;
 import fi.oph.otr.onr.dto.ContactDetailsGroupDTO;
@@ -12,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONArray;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
@@ -21,7 +21,6 @@ import org.asynchttpclient.util.HttpConstants.Methods;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-@RequiredArgsConstructor
 public class OnrOperationApiImpl implements OnrOperationApi {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -29,6 +28,13 @@ public class OnrOperationApiImpl implements OnrOperationApi {
   private final CasClient onrClient;
 
   private final String onrServiceUrl;
+
+  public OnrOperationApiImpl(final CasClient onrClient, final String onrServiceUrl) {
+    this.onrClient = onrClient;
+    this.onrServiceUrl = onrServiceUrl;
+
+    OBJECT_MAPPER.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+  }
 
   @Override
   public Map<String, PersonalData> fetchPersonalDatas(final List<String> onrIds) throws Exception {

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupSource.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupSource.java
@@ -1,7 +1,9 @@
 package fi.oph.otr.onr.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public enum ContactDetailsGroupSource {
   @JsonProperty("alkupera1")
   VTJ,

--- a/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupType.java
+++ b/backend/otr/src/main/java/fi/oph/otr/onr/dto/ContactDetailsGroupType.java
@@ -1,7 +1,9 @@
 package fi.oph.otr.onr.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public enum ContactDetailsGroupType {
   @JsonProperty("yhteystietotyyppi1")
   KOTIOSOITE,

--- a/backend/otr/src/main/java/fi/oph/otr/service/email/ClerkEmailService.java
+++ b/backend/otr/src/main/java/fi/oph/otr/service/email/ClerkEmailService.java
@@ -90,7 +90,7 @@ public class ClerkEmailService {
 
       createQualificationReminder(qualification, email);
     } else {
-      LOG.warn("Personal data by onr id {} not found", interpreter.getOnrId());
+      LOG.error("Personal data by onr id {} not found", interpreter.getOnrId());
     }
   }
 

--- a/backend/otr/src/test/java/fi/oph/otr/onr/OnrRequestTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/onr/OnrRequestTest.java
@@ -1,29 +1,32 @@
 package fi.oph.otr.onr;
 
-import fi.oph.otr.onr.model.PersonalData;
-import fi.vm.sade.javautils.nio.cas.CasClient;
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.util.Optional;
-import org.asynchttpclient.Response;
-import org.springframework.beans.factory.annotation.Value;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import fi.oph.otr.onr.model.PersonalData;
+import fi.vm.sade.javautils.nio.cas.CasClient;
+import java.io.IOException;
+import java.util.Optional;
+import org.asynchttpclient.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WithMockUser
+@DataJpaTest
 class OnrRequestTest {
 
-  @Value("classpath:payment/henkilo-hetu-response.json")
+  @Value("classpath:json/henkilo-hetu-response.json")
   private org.springframework.core.io.Resource hetuRequestResponse;
 
   @Test
   void testFindPersonByIdentityNumberDeserializes() throws Exception {
     final Response response = mock(Response.class);
     final CasClient casClient = mock(CasClient.class);
-    final OnrOperationApiImpl onrOperationApi = new OnrOperationApiImpl(casClient, "");
+    final OnrOperationApiImpl onrOperationApi = new OnrOperationApiImpl(casClient, "http://localhost");
 
     when(casClient.executeBlocking(any())).thenReturn(response);
     when(response.getStatusCode()).thenReturn(200);

--- a/backend/otr/src/test/java/fi/oph/otr/onr/OnrRequestTest.java
+++ b/backend/otr/src/test/java/fi/oph/otr/onr/OnrRequestTest.java
@@ -1,0 +1,40 @@
+package fi.oph.otr.onr;
+
+import fi.oph.otr.onr.model.PersonalData;
+import fi.vm.sade.javautils.nio.cas.CasClient;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.asynchttpclient.Response;
+import org.springframework.beans.factory.annotation.Value;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OnrRequestTest {
+
+  @Value("classpath:payment/henkilo-hetu-response.json")
+  private org.springframework.core.io.Resource hetuRequestResponse;
+
+  @Test
+  void testFindPersonByIdentityNumberDeserializes() throws Exception {
+    final Response response = mock(Response.class);
+    final CasClient casClient = mock(CasClient.class);
+    final OnrOperationApiImpl onrOperationApi = new OnrOperationApiImpl(casClient, "");
+
+    when(casClient.executeBlocking(any())).thenReturn(response);
+    when(response.getStatusCode()).thenReturn(200);
+    when(response.getResponseBody()).thenReturn(getHetuMockJsonResponse());
+
+    final Optional<PersonalData> personalDataOptional = onrOperationApi.findPersonalDataByIdentityNumber("54321-54312");
+
+    assertTrue(personalDataOptional.isPresent());
+  }
+
+  private String getHetuMockJsonResponse() throws IOException {
+    return new String(hetuRequestResponse.getInputStream().readAllBytes());
+  }
+}

--- a/backend/otr/src/test/resources/json/henkilo-hetu-response.json
+++ b/backend/otr/src/test/resources/json/henkilo-hetu-response.json
@@ -1,0 +1,136 @@
+{
+  "id": 68338658,
+  "etunimet": "NORDEA",
+  "syntymaaika": "1981-02-21",
+  "kuolinpaiva": null,
+  "hetu": "210281-9988",
+  "kaikkiHetut": [
+    "210281-9988"
+  ],
+  "kutsumanimi": "Nordea",
+  "oidHenkilo": "1.2.246.562.24.73833272757",
+  "oppijanumero": "1.2.246.562.24.73833272757",
+  "sukunimi": "DEMO",
+  "sukupuoli": "2",
+  "kotikunta": null,
+  "turvakielto": false,
+  "eiSuomalaistaHetua": false,
+  "passivoitu": false,
+  "yksiloity": false,
+  "yksiloityVTJ": true,
+  "yksilointiYritetty": true,
+  "duplicate": false,
+  "created": 1545035888736,
+  "modified": 1686756274731,
+  "vtjsynced": 1611668647507,
+  "kasittelijaOid": "1.2.246.562.24.29628449338",
+  "asiointiKieli": {
+    "id": 1,
+    "kieliKoodi": "fi",
+    "kieliTyyppi": "suomi"
+  },
+  "aidinkieli": {
+    "id": 1,
+    "kieliKoodi": "fi",
+    "kieliTyyppi": "suomi"
+  },
+  "kansalaisuus": [
+    {
+      "id": 1,
+      "kansalaisuusKoodi": "246"
+    }
+  ],
+  "yhteystiedotRyhma": [
+    {
+      "id": 81325525,
+      "ryhmaKuvaus": "yhteystietotyyppi12",
+      "ryhmaAlkuperaTieto": "alkupera17",
+      "readOnly": false,
+      "yhteystieto": [
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_MATKAPUHELINNUMERO",
+          "yhteystietoArvo": null
+        },
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_SAHKOPOSTI",
+          "yhteystietoArvo": "test@test.fi"
+        },
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_KATUOSOITE",
+          "yhteystietoArvo": null
+        },
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_KUNTA",
+          "yhteystietoArvo": null
+        },
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_POSTINUMERO",
+          "yhteystietoArvo": null
+        },
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_PUHELINNUMERO",
+          "yhteystietoArvo": null
+        }
+      ]
+    },
+    {
+      "id": 81325532,
+      "ryhmaKuvaus": "yhteystietotyyppi2",
+      "ryhmaAlkuperaTieto": "alkupera6",
+      "readOnly": false,
+      "yhteystieto": [
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_KUNTA",
+          "yhteystietoArvo": null
+        },
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_MATKAPUHELINNUMERO",
+          "yhteystietoArvo": null
+        },
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_POSTINUMERO",
+          "yhteystietoArvo": null
+        },
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_KATUOSOITE",
+          "yhteystietoArvo": null
+        },
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_PUHELINNUMERO",
+          "yhteystietoArvo": null
+        },
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_SAHKOPOSTI",
+          "yhteystietoArvo": "lauratestaa@testi.fi"
+        }
+      ]
+    },
+    {
+      "id": 81325521,
+      "ryhmaKuvaus": "yhteystietotyyppi2",
+      "ryhmaAlkuperaTieto": "alkupera6",
+      "readOnly": false,
+      "yhteystieto": [
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_SAHKOPOSTI",
+          "yhteystietoArvo": "testi@laura.fi"
+        }
+      ]
+    },
+    {
+      "id": 81325523,
+      "ryhmaKuvaus": "yhteystietotyyppi2",
+      "ryhmaAlkuperaTieto": "alkupera6",
+      "readOnly": false,
+      "yhteystieto": [
+        {
+          "yhteystietoTyyppi": "YHTEYSTIETO_SAHKOPOSTI",
+          "yhteystietoArvo": "heidi.bergstrom@oph.fi"
+        }
+      ]
+    }
+  ],
+  "passinumerot": [],
+  "kielisyys": [],
+  "henkiloTyyppi": "OPPIJA"
+}

--- a/frontend/packages/otr/public/i18n/fi-FI/translation.json
+++ b/frontend/packages/otr/public/i18n/fi-FI/translation.json
@@ -284,7 +284,8 @@
           "emptySelection": "Tyhjennä valinnat"
         },
         "register": "Rekisteri",
-        "title": "Oikeustulkkirekisteri"
+        "title": "Oikeustulkkirekisteri",
+        "missingInterpreters": "Tulkkien määrä ei täsmää OTR ja ONR välillä. Oppijanumerorekisteristä puuttuvat tulkit: {{interpreters}}"
       },
       "clerkInterpreterOverviewPage": {
         "title": "Oikeustulkin tiedot",

--- a/frontend/packages/otr/src/enums/api.ts
+++ b/frontend/packages/otr/src/enums/api.ts
@@ -1,6 +1,7 @@
 export enum APIEndpoints {
   PublicInterpreter = '/otr/api/v1/interpreter',
   ClerkInterpreter = '/otr/api/v1/clerk/interpreter',
+  ClerkMissingInterpreters = '/otr/api/v1/clerk/interpreter/missing',
   ClerkPersonSearch = '/otr/api/v1/clerk/person',
   ClerkUser = '/otr/api/v1/clerk/user',
   Qualification = '/otr/api/v1/clerk/interpreter/qualification',

--- a/frontend/packages/otr/src/pages/ClerkHomePage.tsx
+++ b/frontend/packages/otr/src/pages/ClerkHomePage.tsx
@@ -1,8 +1,8 @@
 import { Add as AddIcon } from '@mui/icons-material';
-import { Divider, Grid, Paper } from '@mui/material';
-import { FC, useState } from 'react';
+import { Alert, Divider, Grid, Paper } from '@mui/material';
+import { FC, useEffect, useState } from 'react';
 import { CustomButtonLink, H1, H2, Text } from 'shared/components';
-import { APIResponseStatus, Color, Variant } from 'shared/enums';
+import { APIResponseStatus, Color, Severity, Variant } from 'shared/enums';
 
 import { ClerkHomePageControlButtons } from 'components/clerkHomePage/ClerkHomePageControlButtons';
 import { ClerkInterpreterAutocompleteFilters } from 'components/clerkInterpreter/filters/ClerkInterpreterAutocompleteFilters';
@@ -10,14 +10,23 @@ import { ClerkInterpreterToggleFilters } from 'components/clerkInterpreter/filte
 import { ClerkInterpreterListing } from 'components/clerkInterpreter/listing/ClerkInterpreterListing';
 import { ClerkHomePageSkeleton } from 'components/skeletons/ClerkHomePageSkeleton';
 import { useAppTranslation } from 'configs/i18n';
-import { useAppSelector } from 'configs/redux';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
+import { loadClerkMissingInterpreters } from 'redux/reducers/clerkInterpreter';
 import { clerkInterpretersSelector } from 'redux/selectors/clerkInterpreter';
 
 export const ClerkHomePage: FC = () => {
   const [page, setPage] = useState(0);
-  const { interpreters, status } = useAppSelector(clerkInterpretersSelector);
+  const { interpreters, missingInterpreters, status, missingStatus } =
+    useAppSelector(clerkInterpretersSelector);
   const isLoading = status === APIResponseStatus.InProgress;
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (missingStatus === APIResponseStatus.NotStarted) {
+      dispatch(loadClerkMissingInterpreters());
+    }
+  }, [dispatch, missingStatus]);
 
   const { t } = useAppTranslation({ keyPrefix: 'otr.pages.clerkHomepage' });
 
@@ -66,6 +75,15 @@ export const ClerkHomePage: FC = () => {
       <Grid item>
         <Divider />
       </Grid>
+      {missingInterpreters?.length > 0 && (
+        <Grid item>
+          <Alert severity={Severity.Error}>
+            {t('missingInterpreters', {
+              interpreters: missingInterpreters.join(', '),
+            })}
+          </Alert>
+        </Grid>
+      )}
       <Grid item>
         <ClerkInterpreterListing page={page} setPage={setPage} />
       </Grid>

--- a/frontend/packages/otr/src/redux/reducers/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkInterpreter.ts
@@ -11,6 +11,8 @@ import { QualificationUtils } from 'utils/qualifications';
 interface ClerkInterpreterState {
   interpreters: Array<ClerkInterpreter>;
   status: APIResponseStatus;
+  missingStatus: APIResponseStatus;
+  missingInterpreters: Array<string>;
   filters: ClerkInterpreterFilters;
   distinctToLangs: Array<string>;
 }
@@ -18,6 +20,8 @@ interface ClerkInterpreterState {
 const initialState: ClerkInterpreterState = {
   interpreters: [],
   status: APIResponseStatus.NotStarted,
+  missingStatus: APIResponseStatus.NotStarted,
+  missingInterpreters: [],
   filters: {
     qualificationStatus: QualificationStatus.Effective,
     fromLang: QualificationUtils.defaultFromLang,
@@ -80,6 +84,13 @@ const clerkInterpreterSlice = createSlice({
       updatedInterpreters.splice(spliceIndex, 1, interpreter);
       state.interpreters = updatedInterpreters;
     },
+    loadClerkMissingInterpreters(state) {
+      state.missingStatus = APIResponseStatus.InProgress;
+    },
+    storeClerkMissingInterpreters(state, action: PayloadAction<Array<string>>) {
+      state.missingStatus = APIResponseStatus.Success;
+      state.missingInterpreters = action.payload;
+    },
   },
 });
 
@@ -91,4 +102,6 @@ export const {
   resetClerkInterpreterFilters,
   storeClerkInterpreters,
   upsertClerkInterpreter,
+  loadClerkMissingInterpreters,
+  storeClerkMissingInterpreters,
 } = clerkInterpreterSlice.actions;

--- a/frontend/packages/otr/src/redux/reducers/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/redux/reducers/clerkInterpreter.ts
@@ -91,6 +91,9 @@ const clerkInterpreterSlice = createSlice({
       state.missingStatus = APIResponseStatus.Success;
       state.missingInterpreters = action.payload;
     },
+    rejectClerkMissingInterpreters(state) {
+      state.missingStatus = APIResponseStatus.Error;
+    },
   },
 });
 
@@ -99,6 +102,7 @@ export const {
   addClerkInterpreterFilter,
   loadClerkInterpreters,
   rejectClerkInterpreters,
+  rejectClerkMissingInterpreters,
   resetClerkInterpreterFilters,
   storeClerkInterpreters,
   upsertClerkInterpreter,

--- a/frontend/packages/otr/src/redux/sagas/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/redux/sagas/clerkInterpreter.ts
@@ -8,6 +8,7 @@ import {
   loadClerkInterpreters,
   loadClerkMissingInterpreters,
   rejectClerkInterpreters,
+  rejectClerkMissingInterpreters,
   storeClerkInterpreters,
   storeClerkMissingInterpreters,
 } from 'redux/reducers/clerkInterpreter';
@@ -21,7 +22,7 @@ function* loadClerkMissingInterpretersSaga() {
     );
     yield put(storeClerkMissingInterpreters(response.data));
   } catch (error) {
-    yield put(rejectClerkInterpreters());
+    yield put(rejectClerkMissingInterpreters());
   }
 }
 

--- a/frontend/packages/otr/src/redux/sagas/clerkInterpreter.ts
+++ b/frontend/packages/otr/src/redux/sagas/clerkInterpreter.ts
@@ -6,10 +6,24 @@ import { APIEndpoints } from 'enums/api';
 import { ClerkInterpreterResponse } from 'interfaces/clerkInterpreter';
 import {
   loadClerkInterpreters,
+  loadClerkMissingInterpreters,
   rejectClerkInterpreters,
   storeClerkInterpreters,
+  storeClerkMissingInterpreters,
 } from 'redux/reducers/clerkInterpreter';
 import { SerializationUtils } from 'utils/serialization';
+
+function* loadClerkMissingInterpretersSaga() {
+  try {
+    const response: AxiosResponse<Array<string>> = yield call(
+      axiosInstance.get,
+      APIEndpoints.ClerkMissingInterpreters
+    );
+    yield put(storeClerkMissingInterpreters(response.data));
+  } catch (error) {
+    yield put(rejectClerkInterpreters());
+  }
+}
 
 function* loadClerkInterpretersSaga() {
   try {
@@ -28,4 +42,8 @@ function* loadClerkInterpretersSaga() {
 
 export function* watchClerkInterpreters() {
   yield takeLatest(loadClerkInterpreters.type, loadClerkInterpretersSaga);
+  yield takeLatest(
+    loadClerkMissingInterpreters.type,
+    loadClerkMissingInterpretersSaga
+  );
 }

--- a/frontend/packages/otr/src/tests/msw/handlers.ts
+++ b/frontend/packages/otr/src/tests/msw/handlers.ts
@@ -18,6 +18,9 @@ export const handlers = [
   rest.get(APIEndpoints.ClerkInterpreter, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(clerkInterpreters10));
   }),
+  rest.get(APIEndpoints.ClerkMissingInterpreters, (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json([]));
+  }),
   rest.put(APIEndpoints.ClerkInterpreter, async (req, res, ctx) => {
     const interpreterDetails = await req.json();
 


### PR DESCRIPTION
## Yhteenveto

Estetään NPE ja logitetaan virhe kun tulkin tietoja ei löydy cachesta. Toistuu untuvalla. Oletettavasti koska AKR ylikirjoittanut tiedot.

```
java.lang.NullPointerException: Cannot invoke "fi.oph.otr.onr.model.PersonalData.getNickName()" because "personalData" is null
	at fi.oph.otr.service.PublicInterpreterService.toDTO(PublicInterpreterService.java:90)
	at fi.oph.otr.service.PublicInterpreterService.lambda$list$0(PublicInterpreterService.java:66)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.collect(Unknown Source)
	at fi.oph.otr.service.PublicInterpreterService.list(PublicInterpreterService.java:68)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
```