### PR TITLE
YKI(Frontend): OPHYKIKEH-307 Show user's active registrations in header

### DIFF
--- a/frontend/packages/yki/public/i18n/fi-FI/common.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/common.json
@@ -70,6 +70,9 @@
           "langSelectorAriaLabel": "Kieli / Språk / Language"
         },
         "sessionState": {
+          "activeRegistrations_one": "Sinulla on 1 käynnissä oleva ilmoittautuminen.",
+          "activeRegistrations_other": "Sinulla on {{count}} käynnissä olevaa ilmoittautumista.",
+          "continueToRegistration": "Siirry ilmoittautumissivulle.",
           "logOut": "Kirjaudu ulos"
         },
         "lang": {

--- a/frontend/packages/yki/setupProxy.js
+++ b/frontend/packages/yki/setupProxy.js
@@ -1032,7 +1032,7 @@ module.exports = function (app) {
   app.get('/yki/api/user/open-registrations', (req, res) => {
     try {
       res.set('Content-Type', 'application/json; charset=utf-8');
-      res.send({ 'open-registrations': [ { exam_session_id: 25, expires_at: '2200-01-01' }]});
+      res.send({ open_registrations: [ { exam_session_id: 25, expires_at: '2200-01-01' }]});
     } catch (err) {
       printError(req, err);
       res.status(404).send(err.message);

--- a/frontend/packages/yki/setupProxy.js
+++ b/frontend/packages/yki/setupProxy.js
@@ -1019,10 +1019,20 @@ module.exports = function (app) {
     }
   );
 
-  app.get('/yki/auth/user', (req, res) => {
+  app.get('/yki/api/user/identity', (req, res) => {
     try {
       res.set('Content-Type', 'application/json; charset=utf-8');
       res.send(adminUser);
+    } catch (err) {
+      printError(req, err);
+      res.status(404).send(err.message);
+    }
+  });
+
+  app.get('/yki/api/user/open-registrations', (req, res) => {
+    try {
+      res.set('Content-Type', 'application/json; charset=utf-8');
+      res.send({ 'open-registrations': [ { exam_session_id: 25 }]});
     } catch (err) {
       printError(req, err);
       res.status(404).send(err.message);

--- a/frontend/packages/yki/setupProxy.js
+++ b/frontend/packages/yki/setupProxy.js
@@ -1032,7 +1032,7 @@ module.exports = function (app) {
   app.get('/yki/api/user/open-registrations', (req, res) => {
     try {
       res.set('Content-Type', 'application/json; charset=utf-8');
-      res.send({ 'open-registrations': [ { exam_session_id: 25 }]});
+      res.send({ 'open-registrations': [ { exam_session_id: 25, expires_at: '2200-01-01' }]});
     } catch (err) {
       printError(req, err);
       res.status(404).send(err.message);

--- a/frontend/packages/yki/src/components/layouts/SessionStateHeader.tsx
+++ b/frontend/packages/yki/src/components/layouts/SessionStateHeader.tsx
@@ -47,22 +47,22 @@ export const SessionStateHeader: FC = () => {
   const userOpenRegistrations = useAppSelector(userOpenRegistrationsSelector);
   const session = useAppSelector(sessionSelector).loggedInSession;
   const dispatch = useAppDispatch();
-  const hasNullIdentity = !session || session.identity === null;
+  const isAuthenticated = session && session.identity !== null;
   const notOnRegistrationPage =
     matchPath(AppRoutes.ExamSessionRegistration, location.pathname) === null;
 
   useEffect(() => {
     const needsUserOpenRegistrations =
-      !hasNullIdentity &&
+      isAuthenticated &&
       notOnRegistrationPage &&
       userOpenRegistrations.status === APIResponseStatus.NotStarted;
 
     if (needsUserOpenRegistrations) {
       dispatch(loadUserOpenRegistrations());
     }
-  }, [hasNullIdentity, notOnRegistrationPage, userOpenRegistrations, dispatch]);
+  }, [isAuthenticated, notOnRegistrationPage, userOpenRegistrations, dispatch]);
 
-  if (hasNullIdentity) return <></>;
+  if (!isAuthenticated) return <></>;
 
   return (
     <div className="session-header columns gapped">

--- a/frontend/packages/yki/src/components/layouts/SessionStateHeader.tsx
+++ b/frontend/packages/yki/src/components/layouts/SessionStateHeader.tsx
@@ -68,8 +68,7 @@ export const SessionStateHeader: FC = () => {
     <div className="session-header columns gapped">
       {notOnRegistrationPage &&
         userOpenRegistrations.openRegistrations &&
-        userOpenRegistrations.openRegistrations['open-registrations'] &&
-        userOpenRegistrations.openRegistrations['open-registrations'][0] && (
+        userOpenRegistrations.openRegistrations[0] && (
           <div className="session-header__open-registrations columns gapped-xxs">
             <Text>
               {translateCommon('header.sessionState.activeRegistrations', {
@@ -79,9 +78,7 @@ export const SessionStateHeader: FC = () => {
             <Link
               to={generatePath(AppRoutes.ExamSessionRegistration, {
                 examSessionId:
-                  userOpenRegistrations.openRegistrations[
-                    'open-registrations'
-                  ][0].exam_session_id.toString(),
+                  userOpenRegistrations.openRegistrations[0].exam_session_id.toString(),
               })}
             >
               {translateCommon('header.sessionState.continueToRegistration')}

--- a/frontend/packages/yki/src/components/layouts/SessionStateHeader.tsx
+++ b/frontend/packages/yki/src/components/layouts/SessionStateHeader.tsx
@@ -3,12 +3,13 @@ import {
   Person as PersonIcon,
 } from '@mui/icons-material';
 import Button from '@mui/material/Button';
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
+import { generatePath, Link, matchPath, useLocation } from 'react-router-dom';
 import { Text } from 'shared/components';
-import { Color, Variant } from 'shared/enums';
+import { APIResponseStatus, Color, Variant } from 'shared/enums';
 
 import { useCommonTranslation } from 'configs/i18n';
-import { useAppSelector } from 'configs/redux';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { APIEndpoints } from 'enums/api';
 import { AppRoutes } from 'enums/app';
 import {
@@ -16,7 +17,9 @@ import {
   EmailAuthenticatedSession,
   SuomiFiAuthenticatedSession,
 } from 'interfaces/session';
+import { loadUserOpenRegistrations } from 'redux/reducers/userOpenRegistrations';
 import { sessionSelector } from 'redux/selectors/session';
+import { userOpenRegistrationsSelector } from 'redux/selectors/userOpenRegistrations';
 
 const getUserName = (
   user:
@@ -39,12 +42,52 @@ const generateLogoutURL = () => {
 };
 
 export const SessionStateHeader: FC = () => {
+  const location = useLocation();
   const translateCommon = useCommonTranslation();
+  const userOpenRegistrations = useAppSelector(userOpenRegistrationsSelector);
   const session = useAppSelector(sessionSelector).loggedInSession;
-  if (!session || session.identity === null) return <></>;
+  const dispatch = useAppDispatch();
+  const hasNullIdentity = !session || session.identity === null;
+  const notOnRegistrationPage =
+    matchPath(AppRoutes.ExamSessionRegistration, location.pathname) === null;
+
+  useEffect(() => {
+    const needsUserOpenRegistrations =
+      !hasNullIdentity &&
+      notOnRegistrationPage &&
+      userOpenRegistrations.status === APIResponseStatus.NotStarted;
+
+    if (needsUserOpenRegistrations) {
+      dispatch(loadUserOpenRegistrations());
+    }
+  }, [hasNullIdentity, notOnRegistrationPage, userOpenRegistrations, dispatch]);
+
+  if (hasNullIdentity) return <></>;
 
   return (
     <div className="session-header columns gapped">
+      {notOnRegistrationPage &&
+        userOpenRegistrations.openRegistrations &&
+        userOpenRegistrations.openRegistrations['open-registrations'] &&
+        userOpenRegistrations.openRegistrations['open-registrations'][0] && (
+          <div className="session-header__open-registrations columns gapped-xxs">
+            <Text>
+              {translateCommon('header.sessionState.activeRegistrations', {
+                count: userOpenRegistrations.openRegistrations.length,
+              })}
+            </Text>
+            <Link
+              to={generatePath(AppRoutes.ExamSessionRegistration, {
+                examSessionId:
+                  userOpenRegistrations.openRegistrations[
+                    'open-registrations'
+                  ][0].exam_session_id.toString(),
+              })}
+            >
+              {translateCommon('header.sessionState.continueToRegistration')}
+            </Link>
+          </div>
+        )}
       <Text className="columns gapped-xxs session-header__user-details">
         <PersonIcon className="session-header__user-icon" />
         {getUserName(session)}

--- a/frontend/packages/yki/src/enums/api.ts
+++ b/frontend/packages/yki/src/enums/api.ts
@@ -13,7 +13,8 @@ export enum APIEndpoints {
   Registration = '/yki/api/registration/:registrationId',
   SubmitRegistration = '/yki/api/registration/:registrationId/submit',
   SuomiFiAuthRedirect = '/yki/auth/',
-  User = '/yki/auth/user',
+  User = '/yki/api/user/identity',
+  OpenRegistrations = '/yki/api/user/open-registrations',
 }
 
 export enum PaymentStatus {

--- a/frontend/packages/yki/src/interfaces/publicRegistration.ts
+++ b/frontend/packages/yki/src/interfaces/publicRegistration.ts
@@ -73,3 +73,11 @@ export interface PublicRegistrationFormSubmitErrorResponse {
     person_creation?: boolean;
   };
 }
+
+interface UserOpenRegistration {
+  exam_session_id: number;
+}
+
+export interface UserOpenRegistrationsResponse {
+  'open-registrations': Array<UserOpenRegistration>;
+}

--- a/frontend/packages/yki/src/interfaces/publicRegistration.ts
+++ b/frontend/packages/yki/src/interfaces/publicRegistration.ts
@@ -74,8 +74,9 @@ export interface PublicRegistrationFormSubmitErrorResponse {
   };
 }
 
-interface UserOpenRegistration {
+export interface UserOpenRegistration {
   exam_session_id: number;
+  expires_at: string;
 }
 
 export interface UserOpenRegistrationsResponse {

--- a/frontend/packages/yki/src/interfaces/publicRegistration.ts
+++ b/frontend/packages/yki/src/interfaces/publicRegistration.ts
@@ -80,5 +80,5 @@ export interface UserOpenRegistration {
 }
 
 export interface UserOpenRegistrationsResponse {
-  'open-registrations': Array<UserOpenRegistration>;
+  open_registrations: Array<UserOpenRegistration>;
 }

--- a/frontend/packages/yki/src/redux/reducers/examSession.ts
+++ b/frontend/packages/yki/src/redux/reducers/examSession.ts
@@ -22,6 +22,9 @@ const examSessionSlice = createSlice({
     rejectExamSession(state) {
       state.status = APIResponseStatus.Error;
     },
+    resetExamSession() {
+      return initialState;
+    },
     storeExamSession(state, action: PayloadAction<ExamSession>) {
       state.status = APIResponseStatus.Success;
       state.examSession = action.payload;
@@ -30,5 +33,9 @@ const examSessionSlice = createSlice({
 });
 
 export const examSessionReducer = examSessionSlice.reducer;
-export const { loadExamSession, rejectExamSession, storeExamSession } =
-  examSessionSlice.actions;
+export const {
+  loadExamSession,
+  rejectExamSession,
+  resetExamSession,
+  storeExamSession,
+} = examSessionSlice.actions;

--- a/frontend/packages/yki/src/redux/reducers/userOpenRegistrations.ts
+++ b/frontend/packages/yki/src/redux/reducers/userOpenRegistrations.ts
@@ -24,7 +24,7 @@ const userOpenRegistrationsSlice = createSlice({
       action: PayloadAction<UserOpenRegistrationsResponse>
     ) {
       state.status = APIResponseStatus.Success;
-      state.openRegistrations = action.payload['open-registrations'];
+      state.openRegistrations = action.payload.open_registrations;
     },
     loadUserOpenRegistrations(state) {
       state.status = APIResponseStatus.InProgress;
@@ -34,7 +34,6 @@ const userOpenRegistrationsSlice = createSlice({
     },
     resetUserOpenRegistrations(state) {
       state.status = APIResponseStatus.NotStarted;
-      state.openRegistrations = undefined;
     },
   },
 });

--- a/frontend/packages/yki/src/redux/reducers/userOpenRegistrations.ts
+++ b/frontend/packages/yki/src/redux/reducers/userOpenRegistrations.ts
@@ -1,0 +1,45 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { APIResponseStatus } from 'shared/enums';
+
+import { UserOpenRegistrationsResponse } from 'interfaces/publicRegistration';
+
+interface UserOpenRegistrationsState {
+  status: APIResponseStatus;
+  openRegistrations?: UserOpenRegistrationsResponse;
+}
+
+const initialState: UserOpenRegistrationsState = {
+  status: APIResponseStatus.NotStarted,
+};
+
+const userOpenRegistrationsSlice = createSlice({
+  name: 'userOpenRegistrations',
+  initialState,
+  reducers: {
+    acceptUserOpenRegistrations(
+      state,
+      action: PayloadAction<UserOpenRegistrationsResponse>
+    ) {
+      state.status = APIResponseStatus.Success;
+      state.openRegistrations = action.payload;
+    },
+    loadUserOpenRegistrations(state) {
+      state.status = APIResponseStatus.InProgress;
+    },
+    rejectUserOpenRegistrations(state) {
+      state.status = APIResponseStatus.Error;
+    },
+    resetUserOpenRegistrations(state) {
+      state.status = APIResponseStatus.NotStarted;
+      state.openRegistrations = undefined;
+    },
+  },
+});
+
+export const userOpenRegistrationsReducer = userOpenRegistrationsSlice.reducer;
+export const {
+  acceptUserOpenRegistrations,
+  loadUserOpenRegistrations,
+  rejectUserOpenRegistrations,
+  resetUserOpenRegistrations,
+} = userOpenRegistrationsSlice.actions;

--- a/frontend/packages/yki/src/redux/reducers/userOpenRegistrations.ts
+++ b/frontend/packages/yki/src/redux/reducers/userOpenRegistrations.ts
@@ -1,11 +1,14 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { APIResponseStatus } from 'shared/enums';
 
-import { UserOpenRegistrationsResponse } from 'interfaces/publicRegistration';
+import {
+  UserOpenRegistration,
+  UserOpenRegistrationsResponse,
+} from 'interfaces/publicRegistration';
 
 interface UserOpenRegistrationsState {
   status: APIResponseStatus;
-  openRegistrations?: UserOpenRegistrationsResponse;
+  openRegistrations?: Array<UserOpenRegistration>;
 }
 
 const initialState: UserOpenRegistrationsState = {
@@ -21,7 +24,7 @@ const userOpenRegistrationsSlice = createSlice({
       action: PayloadAction<UserOpenRegistrationsResponse>
     ) {
       state.status = APIResponseStatus.Success;
-      state.openRegistrations = action.payload;
+      state.openRegistrations = action.payload['open-registrations'];
     },
     loadUserOpenRegistrations(state) {
       state.status = APIResponseStatus.InProgress;

--- a/frontend/packages/yki/src/redux/sagas/index.ts
+++ b/frontend/packages/yki/src/redux/sagas/index.ts
@@ -8,6 +8,7 @@ import { watchPublicIdentification } from 'redux/sagas/publicIdentification';
 import { watchRegistration } from 'redux/sagas/registration';
 import { watchReservationRequest } from 'redux/sagas/reservation';
 import { watchSession } from 'redux/sagas/session';
+import { watchUserOpenRegistrations } from 'redux/sagas/userOpenRegistrations';
 
 export default function* rootSaga() {
   yield all([
@@ -19,5 +20,6 @@ export default function* rootSaga() {
     watchRegistration(),
     watchReservationRequest(),
     watchSession(),
+    watchUserOpenRegistrations(),
   ]);
 }

--- a/frontend/packages/yki/src/redux/sagas/registration.ts
+++ b/frontend/packages/yki/src/redux/sagas/registration.ts
@@ -24,6 +24,7 @@ import {
   resetPublicRegistration,
   submitPublicRegistration,
 } from 'redux/reducers/registration';
+import { resetUserOpenRegistrations } from 'redux/reducers/userOpenRegistrations';
 import { nationalitiesSelector } from 'redux/selectors/nationalities';
 import { registrationSelector } from 'redux/selectors/registration';
 import { SerializationUtils } from 'utils/serialization';
@@ -80,6 +81,7 @@ function* submitRegistrationFormSaga() {
       }
     );
     yield put(acceptPublicRegistrationSubmission());
+    yield put(resetUserOpenRegistrations());
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('caught error!', error);

--- a/frontend/packages/yki/src/redux/sagas/registration.ts
+++ b/frontend/packages/yki/src/redux/sagas/registration.ts
@@ -111,6 +111,7 @@ function* cancelRegistrationSaga() {
     );
     yield put(acceptCancelRegistration());
     yield put(resetPublicRegistration());
+    yield put(resetUserOpenRegistrations());
   } catch (error) {
     yield put(rejectCancelRegistration());
   }

--- a/frontend/packages/yki/src/redux/sagas/registration.ts
+++ b/frontend/packages/yki/src/redux/sagas/registration.ts
@@ -10,7 +10,7 @@ import {
   PublicRegistrationInitErrorResponse,
   PublicRegistrationInitResponse,
 } from 'interfaces/publicRegistration';
-import { storeExamSession } from 'redux/reducers/examSession';
+import { resetExamSession, storeExamSession } from 'redux/reducers/examSession';
 import {
   acceptCancelRegistration,
   acceptPublicRegistrationInit,
@@ -111,6 +111,7 @@ function* cancelRegistrationSaga() {
     );
     yield put(acceptCancelRegistration());
     yield put(resetPublicRegistration());
+    yield put(resetExamSession());
     yield put(resetUserOpenRegistrations());
   } catch (error) {
     yield put(rejectCancelRegistration());

--- a/frontend/packages/yki/src/redux/sagas/userOpenRegistrations.ts
+++ b/frontend/packages/yki/src/redux/sagas/userOpenRegistrations.ts
@@ -1,0 +1,30 @@
+import { call, put, takeLatest } from '@redux-saga/core/effects';
+import { AxiosResponse } from 'axios';
+
+import axiosInstance from 'configs/axios';
+import { APIEndpoints } from 'enums/api';
+import { UserOpenRegistrationsResponse } from 'interfaces/publicRegistration';
+import {
+  acceptUserOpenRegistrations,
+  loadUserOpenRegistrations,
+  rejectUserOpenRegistrations,
+} from 'redux/reducers/userOpenRegistrations';
+
+function* loadUserOpenRegistrationsSaga() {
+  try {
+    const response: AxiosResponse<UserOpenRegistrationsResponse> = yield call(
+      axiosInstance.get,
+      APIEndpoints.OpenRegistrations
+    );
+    yield put(acceptUserOpenRegistrations(response.data));
+  } catch (error) {
+    yield put(rejectUserOpenRegistrations());
+  }
+}
+
+export function* watchUserOpenRegistrations() {
+  yield takeLatest(
+    loadUserOpenRegistrations.type,
+    loadUserOpenRegistrationsSaga
+  );
+}

--- a/frontend/packages/yki/src/redux/sagas/userOpenRegistrations.ts
+++ b/frontend/packages/yki/src/redux/sagas/userOpenRegistrations.ts
@@ -1,13 +1,17 @@
-import { call, put, takeLatest } from '@redux-saga/core/effects';
+import { call, delay, put, takeLatest } from '@redux-saga/core/effects';
 import { AxiosResponse } from 'axios';
 
 import axiosInstance from 'configs/axios';
 import { APIEndpoints } from 'enums/api';
-import { UserOpenRegistrationsResponse } from 'interfaces/publicRegistration';
+import {
+  UserOpenRegistration,
+  UserOpenRegistrationsResponse,
+} from 'interfaces/publicRegistration';
 import {
   acceptUserOpenRegistrations,
   loadUserOpenRegistrations,
   rejectUserOpenRegistrations,
+  resetUserOpenRegistrations,
 } from 'redux/reducers/userOpenRegistrations';
 
 function* loadUserOpenRegistrationsSaga() {
@@ -17,6 +21,28 @@ function* loadUserOpenRegistrationsSaga() {
       APIEndpoints.OpenRegistrations
     );
     yield put(acceptUserOpenRegistrations(response.data));
+
+    // Reset known open registrations after the first expires,
+    // possibly triggering a new API call
+    const nextToExpire: Date = response.data['open-registrations'].reduce(
+      (min: Date, reg: UserOpenRegistration) => {
+        const expires_at = new Date(reg.expires_at);
+
+        return expires_at < min ? expires_at : min;
+      },
+      new Date(8640000000000000)
+    );
+
+    // When expiry is very close or in the past, check every minute
+    const expires_in = Math.max(
+      60 * 1000,
+      nextToExpire.getTime() - new Date().getTime()
+    );
+    // Check at least every 10 minutes
+    const refreshDelay = Math.min(10 * 60 * 1000, expires_in);
+
+    yield delay(refreshDelay);
+    yield put(resetUserOpenRegistrations());
   } catch (error) {
     yield put(rejectUserOpenRegistrations());
   }

--- a/frontend/packages/yki/src/redux/selectors/userOpenRegistrations.ts
+++ b/frontend/packages/yki/src/redux/selectors/userOpenRegistrations.ts
@@ -1,0 +1,4 @@
+import { RootState } from 'configs/redux';
+
+export const userOpenRegistrationsSelector = (state: RootState) =>
+  state.userOpenRegistrations;

--- a/frontend/packages/yki/src/redux/store/index.ts
+++ b/frontend/packages/yki/src/redux/store/index.ts
@@ -16,6 +16,7 @@ import { publicIdentificationReducer } from 'redux/reducers/publicIdentification
 import { registrationReducer } from 'redux/reducers/registration';
 import { reservationReducer } from 'redux/reducers/reservation';
 import { sessionReducer } from 'redux/reducers/session';
+import { userOpenRegistrationsReducer } from 'redux/reducers/userOpenRegistrations';
 import rootSaga from 'redux/sagas/index';
 
 const saga = createSagaMiddleware();
@@ -31,6 +32,7 @@ export const rootReducer = combineReducers({
   registration: registrationReducer,
   reservation: reservationReducer,
   session: sessionReducer,
+  userOpenRegistrations: userOpenRegistrationsReducer,
 });
 
 export const setupStore = (preloadedState?: PreloadedState<RootState>) => {

--- a/frontend/packages/yki/src/styles/components/layouts/_session-header.scss
+++ b/frontend/packages/yki/src/styles/components/layouts/_session-header.scss
@@ -1,7 +1,7 @@
 .session-header {
   background: #f0f3f7;
   justify-content: flex-end;
-  padding: 2rem 6rem 2rem 2rem;
+  padding: 2rem 6rem;
 
   @include phone {
     align-items: flex-end;
@@ -14,5 +14,24 @@
   & &__user-icon {
     height: 2rem;
     width: 2rem;
+  }
+
+  & &__open-registrations {
+    margin-right: auto;
+
+    & a {
+      color: $color-secondary-dark;
+      font-size: 1.6rem;
+      font-weight: normal;
+      letter-spacing: 0;
+      line-height: 1.9rem;
+      margin: 0;
+      text-decoration: underline;
+      text-transform: initial;
+
+      @include phone {
+        font-size: 1.5rem;
+      }
+    }
   }
 }

--- a/frontend/packages/yki/src/tests/jest/components/layouts/Header.test.tsx
+++ b/frontend/packages/yki/src/tests/jest/components/layouts/Header.test.tsx
@@ -3,13 +3,36 @@ import { BrowserRouter } from 'react-router-dom';
 import renderer from 'react-test-renderer';
 
 import { Header } from 'components/layouts/Header';
+import { SuomiFiAuthenticatedSession } from 'interfaces/session';
+import { acceptSession } from 'redux/reducers/session';
+import { acceptUserOpenRegistrations } from 'redux/reducers/userOpenRegistrations';
 import { setupStore } from 'redux/store';
 
 describe('Header', () => {
   it('should render Header correctly', () => {
+    const suomiFiAuthenticatedUser: SuomiFiAuthenticatedSession = {
+      identity: {
+        first_name: 'Susanna',
+        ssn: '020502E902X',
+        last_name: 'Uusivälimerkki',
+      },
+      'auth-method': 'SUOMIFI',
+    };
+    const openRegistrationsResponse = {
+      'open-registrations': [
+        {
+          exam_session_id: 1,
+          expires_at: '2200-01-01',
+        },
+      ],
+    };
+
+    const store = setupStore();
+    store.dispatch(acceptSession(suomiFiAuthenticatedUser));
+    store.dispatch(acceptUserOpenRegistrations(openRegistrationsResponse));
     const tree = renderer
       .create(
-        <Provider store={setupStore()}>
+        <Provider store={store}>
           <BrowserRouter>
             <Header />
           </BrowserRouter>

--- a/frontend/packages/yki/src/tests/jest/components/layouts/Header.test.tsx
+++ b/frontend/packages/yki/src/tests/jest/components/layouts/Header.test.tsx
@@ -19,7 +19,7 @@ describe('Header', () => {
       'auth-method': 'SUOMIFI',
     };
     const openRegistrationsResponse = {
-      'open-registrations': [
+      open_registrations: [
         {
           exam_session_id: 1,
           expires_at: '2200-01-01',

--- a/frontend/packages/yki/src/tests/jest/components/layouts/__snapshots__/Header.test.tsx.snap
+++ b/frontend/packages/yki/src/tests/jest/components/layouts/__snapshots__/Header.test.tsx.snap
@@ -18,6 +18,76 @@ Array [
     className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic header css-hip9hq-MuiPaper-root-MuiAppBar-root"
   >
     <div
+      className="session-header columns gapped"
+    >
+      <div
+        className="session-header__open-registrations columns gapped-xxs"
+      >
+        <p
+          className="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+        >
+          header.sessionState.activeRegistrations
+        </p>
+        <a
+          href="/yki/ilmoittautuminen/tutkintotilaisuus/1"
+          onClick={[Function]}
+        >
+          header.sessionState.continueToRegistration
+        </a>
+      </div>
+      <p
+        className="MuiTypography-root MuiTypography-body1 columns gapped-xxs session-header__user-details css-ahj2mt-MuiTypography-root"
+      >
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium session-header__user-icon css-i4bv87-MuiSvgIcon-root"
+          data-testid="PersonIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+          />
+        </svg>
+        Susanna Uusivälimerkki
+      </p>
+      <a
+        href="/yki/auth/logout?redirect=http://localhost/yki/uloskirjautuminen-onnistui"
+      >
+        <button
+          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedSecondary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedSecondary MuiButton-sizeMedium MuiButton-outlinedSizeMedium css-1l9sosn-MuiButtonBase-root-MuiButton-root"
+          disabled={false}
+          onBlur={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="LogoutOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m17 8-1.41 1.41L17.17 11H9v2h8.17l-1.58 1.58L17 16l4-4-4-4zM5 5h7V3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h7v-2H5V5z"
+            />
+          </svg>
+          header.sessionState.logOut
+        </button>
+      </a>
+    </div>
+    <div
       className="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular header__toolbar css-hyum1k-MuiToolbar-root"
     >
       <div


### PR DESCRIPTION
(Liittyy: https://github.com/Opetushallitus/yki/pull/229)

Tämä on vielä vähän raakile. Tarkoitus oli vielä parantaa rajatapauksien hallintaa (erityisesti tilan päivittäminen palvelimelta sopivissa kohdissa), mutta aika jäi vähän kesken.

Avaan tämän nyt tällaisena draftina, jos tätä haluaa tutkiskella lomani aikana.

Erityisesti kuulisin saisiko tuon vähän turhan monimutkainen useEffects-kohdan tehtyä siistimmin. Aavistelisin että tähän olisi joku hyvä ideomaattinen saga-tapa, mutta en vielä ainakaan keksinyt sitä.

TODO:
- [x] Testit
- [x] Joko ajoittainen päivitys, tai sitten haetaan palvelimelta suoraan kauanko rekisteröinti on voimassa
- [x] Muut tilanteet jossa tämä nykyinen tieto pitää nollata tai hakea tieto uudestaan. 