### PR TITLE
VKT(Frontend) OPHVKTKEH-213: "hyväksy ehdot" checkboxille UI viilauksia

### DIFF
--- a/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/PublicEnrollmentControlButtons.tsx
@@ -20,6 +20,7 @@ import {
   cancelPublicEnrollment,
   cancelPublicEnrollmentAndRemoveReservation,
   loadPublicEnrollmentSave,
+  setLoadingPayment,
 } from 'redux/reducers/publicEnrollment';
 import { RouteUtils } from 'utils/routes';
 
@@ -101,6 +102,7 @@ export const PublicEnrollmentControlButtons = ({
             enrollment.id
           );
         }, 200);
+        dispatch(setLoadingPayment());
       } else {
         navigate(
           RouteUtils.stepToRoute(PublicEnrollmentFormStep.Done, examEventId)

--- a/frontend/packages/vkt/src/components/publicEnrollment/steps/Preview.tsx
+++ b/frontend/packages/vkt/src/components/publicEnrollment/steps/Preview.tsx
@@ -3,15 +3,16 @@ import { Checkbox, FormControlLabel, FormHelperText } from '@mui/material';
 import { useEffect } from 'react';
 import { Trans } from 'react-i18next';
 import { H2, Text, WebLink } from 'shared/components';
-import { Color } from 'shared/enums';
+import { APIResponseStatus, Color } from 'shared/enums';
 
 import { PersonDetails } from 'components/publicEnrollment/steps/PersonDetails';
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
-import { useAppDispatch } from 'configs/redux';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
 import { PartialExamsAndSkills } from 'interfaces/common/enrollment';
 import { PublicEnrollment } from 'interfaces/publicEnrollment';
 import { updatePublicEnrollment } from 'redux/reducers/publicEnrollment';
+import { publicEnrollmentSelector } from 'redux/selectors/publicEnrollment';
 
 const ContactDetails = ({
   email,
@@ -187,6 +188,8 @@ export const Preview = ({
 }) => {
   const translateCommon = useCommonTranslation();
 
+  const { paymentLoadingStatus } = useAppSelector(publicEnrollmentSelector);
+
   useEffect(() => {
     setIsStepValid(enrollment.privacyStatementConfirmation);
   }, [setIsStepValid, enrollment]);
@@ -224,7 +227,10 @@ export const Preview = ({
                 onClick={handleCheckboxClick}
                 color={Color.Secondary}
                 checked={enrollment.privacyStatementConfirmation}
-                disabled={isLoading}
+                disabled={
+                  isLoading ||
+                  paymentLoadingStatus === APIResponseStatus.InProgress
+                }
               />
             }
             label={<PrivacyStatementCheckboxLabel />}

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollment.ts
@@ -14,6 +14,7 @@ export interface PublicEnrollmentState {
   enrollmentInitialisationStatus: APIResponseStatus;
   renewReservationStatus: APIResponseStatus;
   enrollmentSubmitStatus: APIResponseStatus;
+  paymentLoadingStatus: APIResponseStatus;
   cancelStatus: APIResponseStatus;
   enrollment: PublicEnrollment;
   examEvent?: PublicExamEvent;
@@ -26,6 +27,7 @@ export const initialState: PublicEnrollmentState = {
   enrollmentInitialisationStatus: APIResponseStatus.NotStarted,
   renewReservationStatus: APIResponseStatus.NotStarted,
   enrollmentSubmitStatus: APIResponseStatus.NotStarted,
+  paymentLoadingStatus: APIResponseStatus.NotStarted,
   cancelStatus: APIResponseStatus.NotStarted,
   enrollment: {
     email: '',
@@ -174,6 +176,9 @@ const publicEnrollmentSlice = createSlice({
         state.enrollment.examEventId = action.payload;
       }
     },
+    setLoadingPayment(state) {
+      state.paymentLoadingStatus = APIResponseStatus.InProgress;
+    },
   },
 });
 
@@ -196,4 +201,5 @@ export const {
   rejectPublicEnrollmentSave,
   storePublicEnrollmentSave,
   setPublicEnrollmentExamEventIdIfNotSet,
+  setLoadingPayment,
 } = publicEnrollmentSlice.actions;

--- a/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
+++ b/frontend/packages/vkt/src/styles/components/publicEnrollment/_public-enrollment.scss
@@ -71,6 +71,10 @@
       &__privacy-statement-checkbox-label {
         margin-right: 0;
         padding-left: 1rem;
+
+        & span:last-child {
+          margin-bottom: -0.5rem;
+        }
       }
     }
 


### PR DESCRIPTION
## Yhteenveto

Pari pientä UI glitchiä korjattu "hyväksy ehdot" -checkboxista
- teksti ei enää välky disabloitu/enabloitu tilan välillä kun siirrytään maksamaan
- tekstin asemointia vähän viilattu