### PR TITLE
AKR(Backend): OPHAKRKEH-523 Remove translator personal data

### DIFF
--- a/backend/akr/src/main/java/fi/oph/akr/model/Translator.java
+++ b/backend/akr/src/main/java/fi/oph/akr/model/Translator.java
@@ -34,40 +34,6 @@ public class Translator extends BaseEntity {
   @OneToMany(mappedBy = "translator")
   private Collection<ContactRequestTranslator> contactRequestTranslators = new ArrayList<>();
 
-  // TODO: after old AKR data deletion is done remove the below code
-  @Size(max = 255)
-  @Column(name = "identity_number")
-  private String identityNumber;
-
-  @Size(max = 255)
-  @Column(name = "first_name")
-  private String firstName;
-
-  @Size(max = 255)
-  @Column(name = "last_name")
-  private String lastName;
-
-  @Size(max = 255)
-  @Column(name = "email")
-  private String email;
-
-  @Column(name = "phone_number")
-  private String phone;
-
-  @Column(name = "street")
-  private String street;
-
-  @Column(name = "town")
-  private String town;
-
-  @Column(name = "postal_code")
-  private String postalCode;
-
-  @Column(name = "country")
-  private String country;
-
-  //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
   @Column(name = "extra_information")
   private String extraInformation;
 

--- a/backend/akr/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/backend/akr/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -824,4 +824,16 @@
         <addNotNullConstraint tableName="translator" columnName="onr_id" />
     </changeSet>
 
+    <changeSet id="2023-12-20-drop-personal-data" author="lket">
+        <dropColumn tableName="translator" columnName="identity_number"/>
+        <dropColumn tableName="translator" columnName="first_name"/>
+        <dropColumn tableName="translator" columnName="last_name"/>
+        <dropColumn tableName="translator" columnName="email"/>
+        <dropColumn tableName="translator" columnName="phone_number"/>
+        <dropColumn tableName="translator" columnName="street"/>
+        <dropColumn tableName="translator" columnName="town"/>
+        <dropColumn tableName="translator" columnName="postal_code"/>
+        <dropColumn tableName="translator" columnName="country"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/backend/akr/src/test/java/fi/oph/akr/Factory.java
+++ b/backend/akr/src/test/java/fi/oph/akr/Factory.java
@@ -41,8 +41,6 @@ public class Factory {
 
   public static Translator translator() {
     final Translator translator = new Translator();
-    translator.setFirstName("Foo");
-    translator.setLastName("Bar");
     translator.setOnrId(UUID.randomUUID().toString());
     translator.setAssuranceGiven(true);
 


### PR DESCRIPTION
Näiden muutosten pitäisi nyt olla riittävät että kaikki toimii henkilötietojen poistamisen jälkeenkin. Lopulta tarvitsi vähemmän tekemistä kuin arvelin ensin. Mark olikin tosiaan tehnyt jo toimivat ONR-mockaukset, eli (tämänkin jälkeen) lokaali testaus toimii hyvin.

En nyt tehnyt mitään muutoksia tietokannan init-skripteihin, eli sinne jää nyt testihenkilöiden tietoja, jotka kuitenkin sitten välittömästi poistetaan migraatioita ajaessa. Näiden välille oli muodostumassa vähän hankala riippuvuuskehä, minkä vuoksi niitä ei voi ihan suoraviivaisesti vain jättää pois. Olkoon siis näin, ainakin minun puolestani.