### PR TITLE
AKR(Backend) OPHKIOS-16: NPE kun tallentaa kääntäjää ilman yhtään osoitetta

### DIFF
--- a/backend/akr/src/main/java/fi/oph/akr/onr/ContactDetailsUtil.java
+++ b/backend/akr/src/main/java/fi/oph/akr/onr/ContactDetailsUtil.java
@@ -27,6 +27,7 @@ import fi.oph.akr.util.CustomOrderComparator;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -116,15 +117,18 @@ public class ContactDetailsUtil {
       ContactDetailsType.PHONE_NUMBER
     );
 
-    final TranslatorAddressDTO address = findAkrAddressDetails(personalData);
+    final Optional<TranslatorAddressDTO> address = findAkrAddressDetails(personalData);
     final Set<ContactDetailsDTO> contactDetailsSet = Stream
       .of(
         createContactDetailsDTO(ContactDetailsType.EMAIL, personalData.getEmail()),
         createContactDetailsDTO(ContactDetailsType.PHONE_NUMBER, personalData.getPhoneNumber()),
-        createContactDetailsDTO(ContactDetailsType.STREET, address.street()),
-        createContactDetailsDTO(ContactDetailsType.POSTAL_CODE, address.postalCode()),
-        createContactDetailsDTO(ContactDetailsType.TOWN, address.town()),
-        createContactDetailsDTO(ContactDetailsType.COUNTRY, address.country())
+        createContactDetailsDTO(ContactDetailsType.STREET, address.map(TranslatorAddressDTO::street).orElse(null)),
+        createContactDetailsDTO(
+          ContactDetailsType.POSTAL_CODE,
+          address.map(TranslatorAddressDTO::postalCode).orElse(null)
+        ),
+        createContactDetailsDTO(ContactDetailsType.TOWN, address.map(TranslatorAddressDTO::town).orElse(null)),
+        createContactDetailsDTO(ContactDetailsType.COUNTRY, address.map(TranslatorAddressDTO::country).orElse(null))
       )
       .filter(dto -> !personalData.getHasIndividualisedAddress() || akrContactDetailsTypes.contains(dto.getType()))
       .collect(Collectors.toSet());
@@ -136,15 +140,14 @@ public class ContactDetailsUtil {
     return contactDetailsGroupDTO;
   }
 
-  private static TranslatorAddressDTO findAkrAddressDetails(final PersonalData personalData) {
+  private static Optional<TranslatorAddressDTO> findAkrAddressDetails(final PersonalData personalData) {
     return personalData
       .getAddress()
       .stream()
       .filter(addr ->
         addr.source().equals(ContactDetailsGroupSource.AKR) && addr.type().equals(ContactDetailsGroupType.AKR_OSOITE)
       )
-      .findFirst()
-      .orElse(null);
+      .findFirst();
   }
 
   private static ContactDetailsDTO createContactDetailsDTO(final ContactDetailsType type, final String value) {

--- a/backend/akr/src/main/java/fi/oph/akr/onr/ContactDetailsUtil.java
+++ b/backend/akr/src/main/java/fi/oph/akr/onr/ContactDetailsUtil.java
@@ -150,7 +150,7 @@ public class ContactDetailsUtil {
       .findFirst();
   }
 
-  private static ContactDetailsDTO createContactDetailsDTO(final ContactDetailsType type, final String value) {
+  public static ContactDetailsDTO createContactDetailsDTO(final ContactDetailsType type, final String value) {
     final ContactDetailsDTO contactDetailsDTO = new ContactDetailsDTO();
     contactDetailsDTO.setType(type);
     contactDetailsDTO.setValue(value);

--- a/backend/akr/src/test/java/fi/oph/akr/Factory.java
+++ b/backend/akr/src/test/java/fi/oph/akr/Factory.java
@@ -1,5 +1,6 @@
 package fi.oph.akr;
 
+import fi.oph.akr.api.dto.translator.TranslatorAddressDTO;
 import fi.oph.akr.model.Authorisation;
 import fi.oph.akr.model.AuthorisationBasis;
 import fi.oph.akr.model.AuthorisationTermReminder;
@@ -12,7 +13,10 @@ import fi.oph.akr.model.EmailType;
 import fi.oph.akr.model.ExaminationDate;
 import fi.oph.akr.model.MeetingDate;
 import fi.oph.akr.model.Translator;
+import fi.oph.akr.onr.dto.ContactDetailsGroupSource;
+import fi.oph.akr.onr.dto.ContactDetailsGroupType;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 public class Factory {
@@ -176,5 +180,24 @@ public class Factory {
     e.setEmailType(emailType);
     e.setCount(count);
     return e;
+  }
+
+  public static List<TranslatorAddressDTO> createAddress(
+    final String street,
+    final String postalCode,
+    final String town,
+    final String country
+  ) {
+    return List.of(
+      TranslatorAddressDTO
+        .builder()
+        .street(street)
+        .postalCode(postalCode)
+        .town(town)
+        .country(country)
+        .source(ContactDetailsGroupSource.AKR)
+        .type(ContactDetailsGroupType.AKR_OSOITE)
+        .build()
+    );
   }
 }

--- a/backend/akr/src/test/java/fi/oph/akr/service/ClerkTranslatorServiceTest.java
+++ b/backend/akr/src/test/java/fi/oph/akr/service/ClerkTranslatorServiceTest.java
@@ -279,7 +279,7 @@ class ClerkTranslatorServiceTest {
             .lastName(lastNames.get(i))
             .email(emails.get(i))
             .phoneNumber(phoneNumbers.get(i))
-            .address(createAddress(streets.get(i), postalCodes.get(i), towns.get(i), countries.get(i)))
+            .address(Factory.createAddress(streets.get(i), postalCodes.get(i), towns.get(i), countries.get(i)))
             .individualised(false)
             .hasIndividualisedAddress(false)
             .build()
@@ -328,25 +328,6 @@ class ClerkTranslatorServiceTest {
         .source(ContactDetailsGroupSource.AKR)
         .type(ContactDetailsGroupType.AKR_OSOITE)
         .selected(true)
-        .build()
-    );
-  }
-
-  private List<TranslatorAddressDTO> createAddress(
-    final String street,
-    final String postalCode,
-    final String town,
-    final String country
-  ) {
-    return List.of(
-      TranslatorAddressDTO
-        .builder()
-        .street(street)
-        .postalCode(postalCode)
-        .town(town)
-        .country(country)
-        .source(ContactDetailsGroupSource.AKR)
-        .type(ContactDetailsGroupType.AKR_OSOITE)
         .build()
     );
   }
@@ -1036,7 +1017,7 @@ class ClerkTranslatorServiceTest {
       .lastName("Suku")
       .firstName("Etu")
       .nickName("Etu")
-      .address(createAddress("st", "pstl", "tw", "FI"))
+      .address(Factory.createAddress("st", "pstl", "tw", "FI"))
       .identityNumber("112233")
       .individualised(true)
       .hasIndividualisedAddress(false)

--- a/backend/akr/src/test/java/fi/oph/akr/service/OnrContactDetailsTest.java
+++ b/backend/akr/src/test/java/fi/oph/akr/service/OnrContactDetailsTest.java
@@ -1,6 +1,7 @@
 package fi.oph.akr.service;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -10,12 +11,19 @@ import fi.oph.akr.model.Translator;
 import fi.oph.akr.onr.ContactDetailsUtil;
 import fi.oph.akr.onr.OnrOperationApi;
 import fi.oph.akr.onr.OnrOperationApiImpl;
+import fi.oph.akr.onr.dto.ContactDetailsDTO;
+import fi.oph.akr.onr.dto.ContactDetailsGroupDTO;
 import fi.oph.akr.onr.dto.ContactDetailsGroupSource;
 import fi.oph.akr.onr.dto.ContactDetailsGroupType;
+import fi.oph.akr.onr.dto.ContactDetailsType;
 import fi.oph.akr.onr.model.PersonalData;
 import fi.vm.sade.javautils.nio.cas.CasClient;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import org.apache.commons.collections4.CollectionUtils;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,6 +72,57 @@ public class OnrContactDetailsTest {
   }
 
   @Test
+  public void shouldCreateAkrContactDetailsGroupWithAddress() {
+    final PersonalData personalData = PersonalData
+      .builder()
+      .onrId("1.2.3.4")
+      .lastName("Suku")
+      .email("foo@bar")
+      .phoneNumber("1234")
+      .firstName("Etu")
+      .nickName("Etu")
+      .address(Factory.createAddress("st", "pstl", "tw", "FI"))
+      .identityNumber("112233")
+      .individualised(true)
+      .hasIndividualisedAddress(false)
+      .build();
+
+    final ContactDetailsGroupDTO contactDetailsGroupDTO = ContactDetailsUtil.createAkrContactDetailsGroup(personalData);
+    final Set<ContactDetailsDTO> contactDetailsDTO = contactDetailsGroupDTO.getContactDetailsSet();
+
+    assertEquals(ContactDetailsGroupType.AKR_OSOITE, contactDetailsGroupDTO.getType());
+    assertEquals(ContactDetailsGroupSource.AKR, contactDetailsGroupDTO.getSource());
+    assertEquals(6, contactDetailsDTO.size());
+    assertEquals("foo@bar", findValue(contactDetailsDTO, ContactDetailsType.EMAIL));
+    assertEquals("1234", findValue(contactDetailsDTO, ContactDetailsType.PHONE_NUMBER));
+    assertEquals("st", findValue(contactDetailsDTO, ContactDetailsType.STREET));
+    assertEquals("tw", findValue(contactDetailsDTO, ContactDetailsType.TOWN));
+    assertEquals("pstl", findValue(contactDetailsDTO, ContactDetailsType.POSTAL_CODE));
+    assertEquals("FI", findValue(contactDetailsDTO, ContactDetailsType.COUNTRY));
+  }
+
+  @Test
+  public void shouldCreateAkrContactDetailsGroupWithEmptyAddress() {
+    final PersonalData personalData = PersonalData
+      .builder()
+      .onrId("1.2.3.4")
+      .lastName("Suku")
+      .firstName("Etu")
+      .nickName("Etu")
+      .address(Collections.emptyList())
+      .identityNumber("112233")
+      .individualised(true)
+      .hasIndividualisedAddress(false)
+      .build();
+
+    final ContactDetailsGroupDTO contactDetailsGroupDTO = ContactDetailsUtil.createAkrContactDetailsGroup(personalData);
+
+    assertEquals(ContactDetailsGroupType.AKR_OSOITE, contactDetailsGroupDTO.getType());
+    assertEquals(ContactDetailsGroupSource.AKR, contactDetailsGroupDTO.getSource());
+    assertEquals(6, contactDetailsGroupDTO.getContactDetailsSet().size());
+  }
+
+  @Test
   public void fetchShouldPickCorrectCorrectContactDetails() throws Exception {
     final PersonalData personalData = onrOperationApi.findPersonalDataByIdentityNumber("111111-1111").orElseThrow();
     final Translator translator = Factory.translator();
@@ -81,5 +140,14 @@ public class OnrContactDetailsTest {
     translator.setSelectedSource(ContactDetailsGroupSource.VTJ.toString());
 
     assertEquals("Suomi", ContactDetailsUtil.getPrimaryAddress(personalData, translator).country());
+  }
+
+  private String findValue(final Set<ContactDetailsDTO> expectContactDetailsDTO, final ContactDetailsType type) {
+    return expectContactDetailsDTO
+      .stream()
+      .filter(e -> e.getType() == type)
+      .findFirst()
+      .map(ContactDetailsDTO::getValue)
+      .orElse(null);
   }
 }


### PR DESCRIPTION
## Yhteenveto

Näköjään oli väärä oletus, että ONR:stä tulisi aina joku osoite. Korjattu tähän liittyvä NPE.