### PR TITLE
VKT(Backend): Korjausyritys WebClient timeouteihin

### DIFF
--- a/backend/akr/src/main/java/fi/oph/akr/config/AppConfig.java
+++ b/backend/akr/src/main/java/fi/oph/akr/config/AppConfig.java
@@ -9,6 +9,7 @@ import fi.oph.akr.service.email.sender.EmailSenderViestintapalvelu;
 import fi.vm.sade.javautils.nio.cas.CasClient;
 import fi.vm.sade.javautils.nio.cas.CasClientBuilder;
 import fi.vm.sade.javautils.nio.cas.CasConfig;
+import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,9 +17,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.templatemode.TemplateMode;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
 @Configuration
 public class AppConfig {
@@ -36,7 +40,9 @@ public class AppConfig {
   @ConditionalOnProperty(name = "app.email.sending-enabled", havingValue = "true")
   public EmailSender emailSender(@Value("${app.email.service-url}") final String emailServiceUrl) {
     LOG.info("emailServiceUrl: {}", emailServiceUrl);
-    final WebClient webClient = webClientBuilderWithCallerId().baseUrl(emailServiceUrl).build();
+    final WebClient webClient = webClientBuilderWithCallerId("email-sender-connection-provider")
+      .baseUrl(emailServiceUrl)
+      .build();
     return new EmailSenderViestintapalvelu(webClient, Constants.SERVICENAME, Constants.EMAIL_SENDER_NAME);
   }
 
@@ -79,7 +85,19 @@ public class AppConfig {
     return templateResolver;
   }
 
-  private static WebClient.Builder webClientBuilderWithCallerId() {
-    return WebClient.builder().defaultHeader("Caller-Id", Constants.CALLER_ID);
+  private static WebClient.Builder webClientBuilderWithCallerId(final String connectionProviderName) {
+    ConnectionProvider connectionProvider = ConnectionProvider
+      .builder(connectionProviderName)
+      .maxConnections(50)
+      .maxIdleTime(Duration.ofSeconds(20))
+      .maxLifeTime(Duration.ofSeconds(60))
+      .pendingAcquireTimeout(Duration.ofSeconds(60))
+      .evictInBackground(Duration.ofSeconds(120))
+      .build();
+    HttpClient httpClient = HttpClient.create(connectionProvider);
+    return WebClient
+      .builder()
+      .defaultHeader("Caller-Id", Constants.CALLER_ID)
+      .clientConnector(new ReactorClientHttpConnector(httpClient));
   }
 }

--- a/backend/otr/src/main/java/fi/oph/otr/config/AppConfig.java
+++ b/backend/otr/src/main/java/fi/oph/otr/config/AppConfig.java
@@ -9,6 +9,7 @@ import fi.oph.otr.service.email.sender.EmailSenderViestintapalvelu;
 import fi.vm.sade.javautils.nio.cas.CasClient;
 import fi.vm.sade.javautils.nio.cas.CasClientBuilder;
 import fi.vm.sade.javautils.nio.cas.CasConfig;
+import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,9 +17,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.templatemode.TemplateMode;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
 @Configuration
 public class AppConfig {
@@ -36,7 +40,9 @@ public class AppConfig {
   @ConditionalOnProperty(name = "app.email.sending-enabled", havingValue = "true")
   public EmailSender emailSender(@Value("${app.email.service-url}") String emailServiceUrl) {
     LOG.info("emailServiceUrl: {}", emailServiceUrl);
-    final WebClient webClient = webClientBuilderWithCallerId().baseUrl(emailServiceUrl).build();
+    final WebClient webClient = webClientBuilderWithCallerId("email-sender-connection-provider")
+      .baseUrl(emailServiceUrl)
+      .build();
     return new EmailSenderViestintapalvelu(webClient, Constants.SERVICENAME, Constants.EMAIL_SENDER_NAME);
   }
 
@@ -79,7 +85,19 @@ public class AppConfig {
     return templateResolver;
   }
 
-  private static WebClient.Builder webClientBuilderWithCallerId() {
-    return WebClient.builder().defaultHeader("Caller-Id", Constants.CALLER_ID);
+  private static WebClient.Builder webClientBuilderWithCallerId(final String connectionProviderName) {
+    ConnectionProvider connectionProvider = ConnectionProvider
+      .builder(connectionProviderName)
+      .maxConnections(50)
+      .maxIdleTime(Duration.ofSeconds(20))
+      .maxLifeTime(Duration.ofSeconds(60))
+      .pendingAcquireTimeout(Duration.ofSeconds(60))
+      .evictInBackground(Duration.ofSeconds(120))
+      .build();
+    HttpClient httpClient = HttpClient.create(connectionProvider);
+    return WebClient
+      .builder()
+      .defaultHeader("Caller-Id", Constants.CALLER_ID)
+      .clientConnector(new ReactorClientHttpConnector(httpClient));
   }
 }

--- a/backend/vkt/src/main/java/fi/oph/vkt/config/AppConfig.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/config/AppConfig.java
@@ -52,7 +52,9 @@ public class AppConfig {
   @ConditionalOnProperty(name = "app.email.sending-enabled", havingValue = "true")
   public EmailSender emailSender(@Value("${app.email.service-url}") String emailServiceUrl) {
     LOG.info("emailServiceUrl: {}", emailServiceUrl);
-    final WebClient webClient = webClientBuilderWithCallerId().baseUrl(emailServiceUrl).build();
+    final WebClient webClient = webClientBuilderWithCallerId("email-sender-connection-provider")
+      .baseUrl(emailServiceUrl)
+      .build();
     return new EmailSenderViestintapalvelu(webClient, Constants.SERVICENAME, Constants.EMAIL_SENDER_NAME);
   }
 
@@ -65,7 +67,7 @@ public class AppConfig {
       .baseUrl(environment.getRequiredProperty("app.base-url.api"))
       .build();
 
-    final WebClient webClient = webClientBuilderWithCallerId()
+    final WebClient webClient = webClientBuilderWithCallerId("paytrail-connection-provider")
       .baseUrl(environment.getRequiredProperty("app.payment.paytrail.url"))
       .build();
 
@@ -76,7 +78,7 @@ public class AppConfig {
 
   @Bean
   public WebClient koskiClient(final Environment environment) {
-    return webClientBuilderWithCallerId()
+    return webClientBuilderWithCallerId("koski-connection-provider")
       .baseUrl(environment.getRequiredProperty("app.koski.url"))
       .defaultHeaders(headers -> {
         headers.setBasicAuth(
@@ -90,7 +92,7 @@ public class AppConfig {
 
   @Bean
   public CasTicketValidator casTicketValidator(final Environment environment) {
-    final WebClient webClient = webClientBuilderWithCallerId()
+    final WebClient webClient = webClientBuilderWithCallerId("cas-ticket-validator-connection-provider")
       .baseUrl(environment.getRequiredProperty("app.cas-oppija.validate-ticket-url"))
       .build();
 
@@ -141,9 +143,9 @@ public class AppConfig {
     return ContainerCredentialsProvider.builder().build();
   }
 
-  private static WebClient.Builder webClientBuilderWithCallerId() {
+  private static WebClient.Builder webClientBuilderWithCallerId(final String connectionProviderName) {
     ConnectionProvider connectionProvider = ConnectionProvider
-      .builder("custom-connection-provider")
+      .builder(connectionProviderName)
       .maxConnections(50)
       .maxIdleTime(Duration.ofSeconds(20))
       .maxLifeTime(Duration.ofSeconds(60))

--- a/backend/vkt/src/main/java/fi/oph/vkt/service/koski/KoskiService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/koski/KoskiService.java
@@ -58,14 +58,15 @@ public class KoskiService {
         .block();
     } catch (final WebClientResponseException e) {
       LOG.error(
-        "KOSKI returned error status {}\n response body: {}",
+        "KOSKI request for OID {} returned error status {}\n response body: {}",
+        oid,
         e.getStatusCode().value(),
         e.getResponseBodyAsString()
       );
       throw new RuntimeException(e);
     } catch (final Exception e) {
       final int retries = attemptsRemaining - 1;
-      LOG.error("KOSKI request failed! Retries remaining: {}", retries, e);
+      LOG.error("KOSKI request failed! Retries remaining: {}, OID: {}", retries, e, oid);
       if (retries > 0) {
         return requestWithRetries(oid, retries);
       } else {


### PR DESCRIPTION
Tuotannossa havaittu ongelmia KOSKI-tietojen lataamisessa käyttäjällä. 

Lokeja tarkastelemalla syyksi tuntuu paljastuvan sovelluksen käyttämien TCP-yhteyksien kuoleminen:
`Caused by: io.netty.channel.unix.Errors$NativeIoException: recvAddress(..) failed: Connection reset by peer`

Oletusasetuksilla (https://projectreactor.io/docs/netty/release/reference/index.html#_connection_pool_2) WebClient pyrkii pitämään TCP-yhteyksiä auki ikuisesti, jolloin jokin muu taho (esim. WAF, toinen osapuoli, ...) yleensä pätkäisee tämän yhteyden. Tässä PR:ssä konfiguroidaan connection pool siivoamaan vanhoja yhteyksiä useammin, toiveena ehkäistä päätymistä tilanteeseen, jossa sovelluksen käyttökokemus alenee yhteysvirheiden johdosta.

Konfiguraatiot kopioitu tutoriaalin ja muiden netistä löydettyjen esimerkkien pohjalta.