### PR TITLE
VKT(Backend): OPHKIOS-121 Fix determining when queue enrollment is partially free…

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PublicEnrollmentService.java
@@ -493,7 +493,10 @@ public class PublicEnrollmentService extends AbstractEnrollmentService {
     );
 
     if (freeEnrollmentDetails != null && freeEnrollment != null) {
-      if (freeEnrollmentDetails.textualSkillCount() == 0 || freeEnrollmentDetails.oralSkillCount() == 0) {
+      if (
+        EnrollmentUtil.getFreeExamsLeft(freeEnrollmentDetails.textualSkillCount()) == 0 ||
+        EnrollmentUtil.getFreeExamsLeft(freeEnrollmentDetails.oralSkillCount()) == 0
+      ) {
         publicEnrollmentEmailService.sendPartiallyFreeEnrollmentToQueueConfirmationEmail(
           enrollment,
           person,


### PR DESCRIPTION
Eli bugi oli simppeli: jäljellä olevien ilmaisten kertojen väärä tulkittiin juuri väärin päin.