### PR TITLE
VKT(Backend) Examiner phone number should be optional [deploy]

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/api/dto/examiner/ExaminerDetailsUpsertDTO.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/api/dto/examiner/ExaminerDetailsUpsertDTO.java
@@ -9,7 +9,7 @@ import lombok.NonNull;
 @Builder
 public record ExaminerDetailsUpsertDTO(
   @NonNull String email,
-  @NonNull String phoneNumber,
+  String phoneNumber,
   @NonNull Boolean examLanguageFinnish,
   @NonNull Boolean examLanguageSwedish,
   @NonNull Boolean isPublic,


### PR DESCRIPTION
## Yhteenveto

Puhelinnumero oli jäänyt DTO:ssa pakolliseksi. Päivitetty pallerolle