### PR TITLE
VKT(Backend) Email translation syntax errors fix [deploy]

### DIFF
--- a/backend/vkt/src/main/resources/email-templates/enrollment-appointment-auth-link.html
+++ b/backend/vkt/src/main/resources/email-templates/enrollment-appointment-auth-link.html
@@ -15,14 +15,15 @@
 
         <p>
             Vahvista ilmoittautumisesi tunnistautumalla vahvasti ja maksamalla tutkintomaksu:
-        <ul>
-                <li>Tunnistaudu Suomi.fi-palvelussa.</li>
-                <li>Sinut ohjataan automaattisesti ilmoittautumislomakkeelle.</li>
-                <li>Tarkista ilmoittautumisesi tiedot lomakkeella.</li>
-                <li>Siirry maksamaan tutkintomaksu.</li>
-                <li>Kun olet maksanut tutkintomaksun, ilmoittautuminen vahvistuu ja saat kuitin maksusta sähköpostilla.</li>
-            </ul>
         </p>
+
+        <ul>
+            <li>Tunnistaudu Suomi.fi-palvelussa.</li>
+            <li>Sinut ohjataan automaattisesti ilmoittautumislomakkeelle.</li>
+            <li>Tarkista ilmoittautumisesi tiedot lomakkeella.</li>
+            <li>Siirry maksamaan tutkintomaksu.</li>
+            <li>Kun olet maksanut tutkintomaksun, ilmoittautuminen vahvistuu ja saat kuitin maksusta sähköpostilla.</li>
+        </ul>
 
         <p>
             <b>Huom! Linkin viimeinen voimassaolopäivä on <span th:text="${expiresAt}"></span>.</b> Et voi osallistua tutkintoon, jos et ole maksanut tutkintomaksua linkin kautta.
@@ -55,6 +56,8 @@
 
         <p>
             Bekräfta din anmälan genom att identifiera dig starkt och betala examensavgiften:
+        </p>
+
         <ul>
             <li>Identifiera dig i Suomi.fi-tjänsten.</li>
             <li>Du styrs automatiskt till anmälningsblanketten.</li>
@@ -62,7 +65,6 @@
             <li>Gå till att betala examensavgiften.</li>
             <li>När du har betalat examensavgiften bekräftas anmälan och du får ett kvitto över betalningen per e-post.</li>
         </ul>
-        </p>
 
         <p>
             <b>Obs! Länkens sista giltighetsdag är  <span th:text="${expiresAt}"></span>.</b> Du kan inte delta i examen om du inte har betalat examensavgiften via länken.

--- a/backend/vkt/src/main/resources/email-templates/examiner-contact-request.html
+++ b/backend/vkt/src/main/resources/email-templates/examiner-contact-request.html
@@ -63,6 +63,6 @@
         <p style="border-bottom: 1px solid black; padding-bottom: 15px;">
             Med vänlig hälsning<br/>
             Utbildningsstyrelsen
-        </p
+        </p>
     </body>
 </html>


### PR DESCRIPTION
## Yhteenveto

Ruotsin käännösten päivityksessä oli lipsahtanut muutama syntaksivirhe sähköpostipohjiin. Korjattu. Päivitetty pallerolle
