### PR TITLE
VKT(Frontend) Reset loading states when initiating new contact request

### DIFF
--- a/frontend/packages/vkt/src/components/publicExaminerListing/PublicExaminerListing.tsx
+++ b/frontend/packages/vkt/src/components/publicExaminerListing/PublicExaminerListing.tsx
@@ -31,6 +31,7 @@ import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes, ExamLanguage } from 'enums/app';
 import { Municipality } from 'interfaces/municipality';
 import { PublicExaminer } from 'interfaces/publicExaminer';
+import { resetPublicEnrollmentContactStates } from 'redux/reducers/publicEnrollmentContact';
 import { setPublicExaminerLanguageFilter } from 'redux/reducers/publicExaminer';
 import { publicEnrollmentContactSelector } from 'redux/selectors/publicEnrollmentContact';
 import {
@@ -98,9 +99,11 @@ const DesktopPublicExaminerRow = ({
   });
   const navigate = useNavigate();
   const appLanguage = getCurrentLang();
+  const dispatch = useAppDispatch();
 
   const { id, name, language, municipalities, examDates } = examiner;
   const handleOnClick = () => {
+    dispatch(resetPublicEnrollmentContactStates());
     navigate(
       AppRoutes.PublicEnrollmentContactContactDetails.replace(
         ':examinerId',

--- a/frontend/packages/vkt/src/redux/reducers/publicEnrollmentContact.ts
+++ b/frontend/packages/vkt/src/redux/reducers/publicEnrollmentContact.ts
@@ -98,6 +98,15 @@ const publicEnrollmentContactSlice = createSlice({
     resetPublicEnrollmentContact() {
       return initialState;
     },
+    resetPublicEnrollmentContactStates(state) {
+      return {
+        ...state,
+        loadExaminerStatus: APIResponseStatus.NotStarted,
+        enrollmentSubmitStatus: APIResponseStatus.NotStarted,
+        paymentLoadingStatus: APIResponseStatus.NotStarted,
+        cancelStatus: APIResponseStatus.NotStarted,
+      };
+    },
   },
 });
 
@@ -116,4 +125,5 @@ export const {
   continueWithEnrollmentDetails,
   confirmContactDetails,
   rejectPreviousContactDetails,
+  resetPublicEnrollmentContactStates,
 } = publicEnrollmentContactSlice.actions;


### PR DESCRIPTION
## Yhteenveto

Requestien tilat täytyy resetoida kun ottaa yhteyttä useampaan TV:aan. Muita tietoja ei pidä resetoida, sillä lomakkeen on tarkoitus muistaa tiedot.