### PR TITLE
Snyk päivityksen tyylikorjauksia

### DIFF
--- a/backend/akr/pom.xml
+++ b/backend/akr/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.17.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -31,11 +31,11 @@
     <plugin.prettier.goal>write</plugin.prettier.goal>
 
     <!-- openai v2 https://springdoc.org/#migrating-from-springdoc-v1 -->
-    <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
+    <springdoc-openapi.version>2.8.6</springdoc-openapi.version>
     <!-- latest version for Java 17 https://github.com/lukas-krecan/ShedLock#versions -->
     <shedlock.version>5.16.0</shedlock.version>
-    <poi.version>5.4.0</poi.version>
-    <liquibase.version>4.30.0</liquibase.version>
+    <poi.version>5.4.1</poi.version>
+    <liquibase.version>4.31.1</liquibase.version>
     <spring-framework.version>6.2.5</spring-framework.version>
   </properties>
 
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.18.1</version>
+      <version>1.19.1</version>
     </dependency>
     <dependency>
       <groupId>net.minidev</groupId>

--- a/frontend/packages/akr/src/styles/pages/_clerk-homepage.scss
+++ b/frontend/packages/akr/src/styles/pages/_clerk-homepage.scss
@@ -2,7 +2,6 @@
   flex: 1;
 
   & &__grid-container {
-    display: grid;
     gap: 2rem;
     padding: 2.5rem;
     padding-bottom: 4rem;

--- a/frontend/packages/akr/src/styles/pages/_public-homepage.scss
+++ b/frontend/packages/akr/src/styles/pages/_public-homepage.scss
@@ -2,8 +2,6 @@
   flex: 1;
 
   & &__grid-container {
-    display: block;
-
     &__item-header {
       @include phone {
         margin-top: 2rem;
@@ -18,8 +16,6 @@
     }
 
     div &__result-box {
-      padding: 3rem;
-
       @include phone {
         padding: 0.5rem;
       }

--- a/frontend/packages/otr/src/components/publicInterpreter/filters/PublicInterpreterFilters.tsx
+++ b/frontend/packages/otr/src/components/publicInterpreter/filters/PublicInterpreterFilters.tsx
@@ -67,7 +67,7 @@ export const PublicInterpreterFilters = ({
   };
 
   const defaultValuesState: PublicInterpreterFilterValues = {
-    fromLang: '',
+    fromLang: QualificationUtils.defaultFromLang,
     toLang: '',
     name: '',
     region: '',

--- a/frontend/packages/otr/src/styles/pages/_public-homepage.scss
+++ b/frontend/packages/otr/src/styles/pages/_public-homepage.scss
@@ -2,8 +2,6 @@
   flex: 1;
 
   & &__grid-container {
-    display: block;
-
     &__item-header {
       @include phone {
         margin-top: 2rem;

--- a/frontend/packages/vkt/src/styles/pages/_clerk-homepage.scss
+++ b/frontend/packages/vkt/src/styles/pages/_clerk-homepage.scss
@@ -2,8 +2,6 @@
   flex: 1;
 
   & &__grid-container {
-    display: block;
-
     &__heading {
       margin: 2rem 0 1rem 1rem;
     }

--- a/frontend/packages/vkt/src/styles/pages/_public-homepage.scss
+++ b/frontend/packages/vkt/src/styles/pages/_public-homepage.scss
@@ -6,8 +6,6 @@
   }
 
   & &__grid-container {
-    display: block;
-
     &__item-header {
       @include phone {
         margin-top: 2rem;

--- a/frontend/packages/yki/src/styles/pages/_reassessment-page.scss
+++ b/frontend/packages/yki/src/styles/pages/_reassessment-page.scss
@@ -2,8 +2,6 @@
   flex: 1;
 
   & &__grid-container {
-    display: block;
-
     &__item-header {
       @include phone {
         margin-top: 2rem;
@@ -18,10 +16,6 @@
     }
 
     div &__result-box {
-      @include not-phone {
-        padding: 3rem;
-      }
-
       @include phone {
         padding: 2rem;
       }

--- a/frontend/packages/yki/src/styles/pages/_registration-page.scss
+++ b/frontend/packages/yki/src/styles/pages/_registration-page.scss
@@ -2,7 +2,7 @@
   flex: 1;
 
   & &__grid-container {
-    display: block;
+    display: grid;
 
     &__item-header {
       @include phone {
@@ -23,10 +23,6 @@
         padding-left: 1rem;
         padding-right: 1rem;
         padding-top: 3rem;
-      }
-
-      @include not-phone {
-        padding: 3rem;
       }
     }
   }


### PR DESCRIPTION
## Yhteenveto

`<Grid item ...>` oli deprekoitunut ja poistettu uusimmassa MUI:ssa ja sen myötä tietyt tyylit ei enää valuneet grid containereihin.

Lisäksi päivitetty OTR julkisen haun default fromLang:ksi FI 
