### PR TITLE
VKT(Frontend) Canceled payments listing were missing. Also added missing translation

### DIFF
--- a/frontend/packages/vkt/public/i18n/fi-FI/examiner.json
+++ b/frontend/packages/vkt/public/i18n/fi-FI/examiner.json
@@ -155,6 +155,7 @@
             "link": "Linkki",
             "title": "Maksulinkki"
           },
+          "historyTitle": "Maksuhistoria",
           "recentTitle": "Maksun tila"
         },
         "paymentStatus": {

--- a/frontend/packages/vkt/public/i18n/sv-SE/examiner.json
+++ b/frontend/packages/vkt/public/i18n/sv-SE/examiner.json
@@ -153,6 +153,7 @@
             "link": "Länk",
             "title": "Betalningslänk"
           },
+          "historyTitle": "Betalningshistorik",
           "recentTitle": "Betalningens status"
         },
         "paymentStatus": {

--- a/frontend/packages/vkt/src/components/examinerExamEvent/overview/ExaminerExamEventDetails.tsx
+++ b/frontend/packages/vkt/src/components/examinerExamEvent/overview/ExaminerExamEventDetails.tsx
@@ -147,6 +147,10 @@ export const ExaminerExamEventDetails = () => {
       />
       <EnrollmentList
         enrollments={enrollments}
+        status={EnrollmentAppointmentStatus.CANCELED_PAYMENT}
+      />
+      <EnrollmentList
+        enrollments={enrollments}
         status={EnrollmentAppointmentStatus.ENROLLMENT_CREATED}
       />
       {enrollments.length > 0 && (


### PR DESCRIPTION
## Yhteenveto

Peruutetut maksut listaus puuttui HTT ilmoittautumisen listauksista. Myös yksi käännös puuttui maksuhistoriasta HTT puolella.