### PR TITLE
YKI(Frontend): show available places as 'full' if queue exists

### DIFF
--- a/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingRow.tsx
+++ b/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingRow.tsx
@@ -1,6 +1,6 @@
 import { TableCell, TableRow, Typography } from '@mui/material';
 import { Dayjs } from 'dayjs';
-import { ReactNode } from 'react';
+import { ReactNode, useCallback } from 'react';
 import { CustomButton, Text } from 'shared/components';
 import { Color, Variant } from 'shared/enums';
 import { useWindowProperties } from 'shared/hooks';
@@ -232,19 +232,23 @@ export const PublicExamSessionListingRow = ({
     getCurrentLang(),
   );
 
-  const { open, availablePlaces } =
+  const { open, availablePlaces, queue } =
     ExamSessionUtils.getEffectiveRegistrationPeriodDetails(examSession);
 
-  // TODO Different text when registering to queue?
-  const availablePlacesText =
-    availablePlaces > 0 ? '' + availablePlaces : t('full');
+  const getAvailablePlacesText = useCallback(() => {
+    if (queue || availablePlaces === 0) {
+      return t('full');
+    }
+
+    return `${availablePlaces}`;
+  }, [availablePlaces, queue, t]);
 
   if (isPhone) {
     return (
       <TableRow className="rows gapped-xs">
         <PublicExamSessionListingCellsForPhone
           examSession={examSession}
-          availablePlacesText={availablePlacesText}
+          availablePlacesText={getAvailablePlacesText()}
           registerActionAvailable={!!open}
           locationInfo={locationInfo}
         />
@@ -255,7 +259,7 @@ export const PublicExamSessionListingRow = ({
       <TableRow data-testid={`public-exam-session__id-${examSession.id}-row`}>
         <PublicExamSessionListingCellsForDesktop
           examSession={examSession}
-          availablePlacesText={availablePlacesText}
+          availablePlacesText={getAvailablePlacesText()}
           registerActionAvailable={!!open}
           locationInfo={locationInfo}
         />

--- a/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingRow.tsx
+++ b/frontend/packages/yki/src/components/registration/examSession/PublicExamSessionListingRow.tsx
@@ -1,6 +1,6 @@
 import { TableCell, TableRow, Typography } from '@mui/material';
 import { Dayjs } from 'dayjs';
-import { ReactNode, useCallback } from 'react';
+import { ReactNode } from 'react';
 import { CustomButton, Text } from 'shared/components';
 import { Color, Variant } from 'shared/enums';
 import { useWindowProperties } from 'shared/hooks';
@@ -232,23 +232,18 @@ export const PublicExamSessionListingRow = ({
     getCurrentLang(),
   );
 
-  const { open, availablePlaces, queue } =
+  const { open, availablePlaces } =
     ExamSessionUtils.getEffectiveRegistrationPeriodDetails(examSession);
 
-  const getAvailablePlacesText = useCallback(() => {
-    if (queue || availablePlaces === 0) {
-      return t('full');
-    }
-
-    return `${availablePlaces}`;
-  }, [availablePlaces, queue, t]);
+  const availablePlacesText =
+    availablePlaces > 0 ? '' + availablePlaces : t('full');
 
   if (isPhone) {
     return (
       <TableRow className="rows gapped-xs">
         <PublicExamSessionListingCellsForPhone
           examSession={examSession}
-          availablePlacesText={getAvailablePlacesText()}
+          availablePlacesText={availablePlacesText}
           registerActionAvailable={!!open}
           locationInfo={locationInfo}
         />
@@ -259,7 +254,7 @@ export const PublicExamSessionListingRow = ({
       <TableRow data-testid={`public-exam-session__id-${examSession.id}-row`}>
         <PublicExamSessionListingCellsForDesktop
           examSession={examSession}
-          availablePlacesText={getAvailablePlacesText()}
+          availablePlacesText={availablePlacesText}
           registerActionAvailable={!!open}
           locationInfo={locationInfo}
         />

--- a/frontend/packages/yki/src/utils/examSession.ts
+++ b/frontend/packages/yki/src/utils/examSession.ts
@@ -125,6 +125,7 @@ export class ExamSessionUtils {
       quota: examSession.max_participants,
       availablePlaces: ExamSessionUtils.getAvailablePlaces(examSession),
       open: examSession.open,
+      queue: examSession.queue,
     };
   }
 

--- a/frontend/packages/yki/src/utils/examSession.ts
+++ b/frontend/packages/yki/src/utils/examSession.ts
@@ -11,7 +11,7 @@ export class ExamSessionUtils {
   }
 
   static getAvailablePlaces(examSession: ExamSession) {
-    if (!examSession.upcoming_admission) {
+    if (!examSession.upcoming_admission || examSession.queue) {
       return 0;
     } else {
       return ExamSessionUtils.getRegistrationAvailablePlaces(examSession);


### PR DESCRIPTION
## Yhteenveto

Ilmojonossa näytetään nyt “Täynnä” vaikka paikat eivät olisi täynnä jos ilmoon on kuitenkin jonoa (jonosta tulee ottaa ihmiset ensin sisään):

<img width="1265" height="100" alt="image" src="https://github.com/user-attachments/assets/ab6e9178-c745-4e36-8fba-06f3e286937a" />

