### PR TITLE
VKT(Backend) Don't allow failed payment to change status of completed enrollment

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/service/PaymentService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/PaymentService.java
@@ -206,12 +206,13 @@ public class PaymentService {
 
     if (payment.getEnrollment() != null) {
       final Enrollment enrollment = payment.getEnrollment();
-      setEnrollmentStatus(enrollment, newStatus);
       final FreeEnrollmentDetails freeEnrollmentDetails = enrollmentRepository.countEnrollmentsByPerson(
         enrollment.getPerson()
       );
 
-      setEnrollmentStatus(enrollment, newStatus);
+      if (enrollment.getStatus() != EnrollmentStatus.COMPLETED) {
+        setEnrollmentStatus(enrollment, newStatus);
+      }
 
       payment.setPaymentStatus(newStatus);
       if (newStatus == PaymentStatus.OK) {
@@ -232,7 +233,9 @@ public class PaymentService {
       }
     } else {
       final EnrollmentAppointment enrollmentAppointment = payment.getEnrollmentAppointment();
-      setEnrollmentStatus(enrollmentAppointment, newStatus);
+      if (enrollmentAppointment.getStatus() != EnrollmentAppointmentStatus.COMPLETED) {
+        setEnrollmentStatus(enrollmentAppointment, newStatus);
+      }
 
       payment.setPaymentStatus(newStatus);
       if (newStatus == PaymentStatus.OK) {

--- a/backend/vkt/src/test/java/fi/oph/vkt/service/PaymentServiceTest.java
+++ b/backend/vkt/src/test/java/fi/oph/vkt/service/PaymentServiceTest.java
@@ -612,6 +612,42 @@ public class PaymentServiceTest {
   }
 
   @Test
+  public void testFinalizePaymentFailWhenEnrollmentAlreadyCompleted() throws IOException, InterruptedException {
+    final Pair<Payment, Enrollment> pair = createPayment();
+    final Payment payment = pair.getFirst();
+    final Enrollment enrollment = pair.getSecond();
+    final EnrollmentAppointment enrollmentAppointment = createEnrollmentAppointment(enrollment.getPerson());
+
+    enrollmentAppointment.setStatus(EnrollmentAppointmentStatus.COMPLETED);
+
+    payment.setPaymentStatus(PaymentStatus.NEW);
+    payment.setEnrollment(null);
+    payment.setEnrollmentAppointment(enrollmentAppointment);
+
+    final Map<String, String> paymentParams = new LinkedHashMap<>();
+    paymentParams.put("checkout-status", PaymentStatus.FAIL.toString());
+    paymentParams.put("checkout-amount", "51400");
+    paymentParams.put("checkout-reference", payment.getMerchantReference());
+    final PaytrailPaymentProvider paymentProvider = mock(PaytrailPaymentProvider.class);
+    final PublicEnrollmentEmailService publicEnrollmentEmailService = mock(PublicEnrollmentEmailService.class);
+    when(paymentProvider.validate(anyMap())).thenReturn(true);
+
+    final PaymentService paymentService = new PaymentService(
+      paymentProvider,
+      paymentRepository,
+      enrollmentRepository,
+      enrollmentAppointmentRepository,
+      environment,
+      publicEnrollmentEmailService
+    );
+
+    paymentService.finalizePayment(payment.getId(), paymentParams);
+    verifyNoInteractions(publicEnrollmentEmailService);
+    assertEquals(PaymentStatus.FAIL, payment.getPaymentStatus());
+    assertEquals(EnrollmentAppointmentStatus.COMPLETED, enrollmentAppointment.getStatus());
+  }
+
+  @Test
   public void testFinalizePaymentAmountMustMatch() {
     final Pair<Payment, Enrollment> pair = createPayment();
     final Payment payment = pair.getFirst();


### PR DESCRIPTION
## Yhteenveto

This can happen when Paytrail callback for failed payment arrives after enrollment has already been completed
