### PR TITLE
OPHKIOS-244: hyväksy/hylkää modaalit

### DIFF
--- a/frontend/packages/shared/CHANGELOG.MD
+++ b/frontend/packages/shared/CHANGELOG.MD
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Released]
 
+## [1.14.0] - 2025-10-09
+
+### Changed
+
+- CustomModal supports now ReactNode in addition to text. 
+
 ## [1.13.0] - 2025-08-01
 
 ### Changed

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opetushallitus/kieli-ja-kaantajatutkinnot.shared",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Shared Frontend Package",
   "exports": {
     "./components": "./src/components/index.tsx",

--- a/frontend/packages/shared/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/frontend/packages/shared/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -52,10 +52,10 @@ exports[`ComboBox should render ComboBox correctly 1`] = `
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-w4cd9x"
+              class="css-1nf2c5d-MuiNotchedOutlined-root"
             >
               <span
                 aria-hidden="true"

--- a/frontend/packages/shared/src/components/CustomDatePicker/__snapshots__/CustomDatePicker.test.tsx.snap
+++ b/frontend/packages/shared/src/components/CustomDatePicker/__snapshots__/CustomDatePicker.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`DatePicker should render correctly 1`] = `
     class="MuiFormControl-root MuiTextField-root custom-date-picker css-1xp5r68-MuiFormControl-root-MuiTextField-root"
   >
     <label
-      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
       data-shrink="true"
       for=":r0:"
       id=":r0:-label"
@@ -50,10 +50,10 @@ exports[`DatePicker should render correctly 1`] = `
       </div>
       <fieldset
         aria-hidden="true"
-        class="MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"
+        class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
       >
         <legend
-          class="css-w1u3ce"
+          class="css-ex8a5f-MuiNotchedOutlined-root"
         >
           <span>
             test label

--- a/frontend/packages/shared/src/components/CustomModal/CustomModal.tsx
+++ b/frontend/packages/shared/src/components/CustomModal/CustomModal.tsx
@@ -1,5 +1,5 @@
 import Modal, { ModalProps } from '@mui/material/Modal';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 
 import { H2 } from '../Text/Text';
 import './CustomModal.scss';
@@ -7,7 +7,7 @@ import './CustomModal.scss';
 type Role = 'dialog' | 'alertdialog';
 
 type CustomModalProps = ModalProps & {
-  modalTitle?: string;
+  modalTitle?: ReactNode | string;
   onCloseModal: () => void;
   role?: Role;
 };

--- a/frontend/packages/shared/src/components/CustomSelect/__snapshots__/CustomSelect.test.tsx.snap
+++ b/frontend/packages/shared/src/components/CustomSelect/__snapshots__/CustomSelect.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`CustomSelect should render correctly 1`] = `
       <div
         aria-expanded="false"
         aria-haspopup="listbox"
-        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-w76bbz-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-18jp67o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
         role="combobox"
         tabindex="0"
       >
@@ -31,7 +31,7 @@ exports[`CustomSelect should render correctly 1`] = `
       />
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-lohd6h-MuiSvgIcon-root-MuiSelect-icon"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
         data-testid="ArrowDropDownIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -42,10 +42,10 @@ exports[`CustomSelect should render correctly 1`] = `
       </svg>
       <fieldset
         aria-hidden="true"
-        class="MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"
+        class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
       >
         <legend
-          class="css-w4cd9x"
+          class="css-1nf2c5d-MuiNotchedOutlined-root"
         >
           <span
             aria-hidden="true"

--- a/frontend/packages/shared/src/components/CustomSwitch/__snapshots__/CustomSwitch.test.tsx.snap
+++ b/frontend/packages/shared/src/components/CustomSwitch/__snapshots__/CustomSwitch.test.tsx.snap
@@ -21,13 +21,13 @@ exports[`CustomSwitch should render correctly with an error label 1`] = `
         >
           <span
             aria-disabled="true"
-            class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorSecondary Mui-checked Mui-disabled Mui-disabled PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorSecondary Mui-checked Mui-disabled Mui-checked Mui-disabled css-zp7cnf-MuiButtonBase-root-MuiSwitch-switchBase"
+            class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorSecondary Mui-checked Mui-disabled Mui-disabled PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorSecondary Mui-checked Mui-disabled Mui-checked Mui-disabled css-1wwrlr5-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
             data-testid="just-a-test-id"
             tabindex="-1"
           >
             <input
               checked=""
-              class="PrivateSwitchBase-input MuiSwitch-input css-j8yymo"
+              class="PrivateSwitchBase-input MuiSwitch-input css-12xagqm-MuiSwitchBase-root"
               disabled=""
               type="checkbox"
             />
@@ -76,10 +76,10 @@ exports[`CustomSwitch should render correctly with just the minimal props 1`] = 
           class="MuiSwitch-root MuiSwitch-sizeMedium css-rehya9-MuiSwitch-root"
         >
           <span
-            class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorSecondary css-zp7cnf-MuiButtonBase-root-MuiSwitch-switchBase"
+            class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorSecondary css-1wwrlr5-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
           >
             <input
-              class="PrivateSwitchBase-input MuiSwitch-input css-j8yymo"
+              class="PrivateSwitchBase-input MuiSwitch-input css-12xagqm-MuiSwitchBase-root"
               type="checkbox"
             />
             <span

--- a/frontend/packages/shared/src/components/CustomTextField/__snapshots__/CustomTextField.test.tsx.snap
+++ b/frontend/packages/shared/src/components/CustomTextField/__snapshots__/CustomTextField.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CustomTextField should render correctly with error 1`] = `
     class="MuiFormControl-root MuiTextField-root css-1xp5r68-MuiFormControl-root-MuiTextField-root"
   >
     <label
-      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
       data-shrink="true"
       for=":r1:"
       id=":r1:-label"
@@ -25,10 +25,10 @@ exports[`CustomTextField should render correctly with error 1`] = `
       />
       <fieldset
         aria-hidden="true"
-        class="MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"
+        class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
       >
         <legend
-          class="css-w1u3ce"
+          class="css-ex8a5f-MuiNotchedOutlined-root"
         >
           <span>
             test label
@@ -46,7 +46,7 @@ exports[`CustomTextField should render correctly with text 1`] = `
     class="MuiFormControl-root MuiTextField-root css-1xp5r68-MuiFormControl-root-MuiTextField-root"
   >
     <label
-      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
       data-shrink="true"
       for=":r0:"
       id=":r0:-label"
@@ -65,10 +65,10 @@ exports[`CustomTextField should render correctly with text 1`] = `
       />
       <fieldset
         aria-hidden="true"
-        class="MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"
+        class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
       >
         <legend
-          class="css-w1u3ce"
+          class="css-ex8a5f-MuiNotchedOutlined-root"
         >
           <span>
             test label

--- a/frontend/packages/shared/src/components/LabeledTextField/__snapshots__/LabeledTextField.test.tsx.snap
+++ b/frontend/packages/shared/src/components/LabeledTextField/__snapshots__/LabeledTextField.test.tsx.snap
@@ -36,10 +36,10 @@ exports[`LabeledTextField should render correctly with error 1`] = `
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-w4cd9x"
+            class="css-1nf2c5d-MuiNotchedOutlined-root"
           >
             <span
               aria-hidden="true"
@@ -86,10 +86,10 @@ exports[`LabeledTextField should render correctly with text 1`] = `
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-w4cd9x"
+            class="css-1nf2c5d-MuiNotchedOutlined-root"
           >
             <span
               aria-hidden="true"

--- a/frontend/packages/shared/src/components/LanguageSelect/__snapshots__/LanguageSelect.test.tsx.snap
+++ b/frontend/packages/shared/src/components/LanguageSelect/__snapshots__/LanguageSelect.test.tsx.snap
@@ -52,10 +52,10 @@ exports[`LanguageSelect should render correctly 1`] = `
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-w4cd9x"
+              class="css-1nf2c5d-MuiNotchedOutlined-root"
             >
               <span
                 aria-hidden="true"

--- a/frontend/packages/shared/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/frontend/packages/shared/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -60,16 +60,6 @@ exports[`H5 should render correctly 1`] = `
 </div>
 `;
 
-exports[`H6 should render correctly 1`] = `
-<div>
-  <h6
-    class="MuiTypography-root MuiTypography-h6 css-1miy0lu-MuiTypography-root"
-  >
-    This is an H6
-  </h6>
-</div>
-`;
-
 exports[`Text should render correctly 1`] = `
 <div>
   <p

--- a/frontend/packages/yki/package.json
+++ b/frontend/packages/yki/package.json
@@ -34,7 +34,7 @@
     "yki:tslint": "yarn g:tsc --pretty --noEmit"
   },
   "dependencies": {
-    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.13.0"
+    "shared": "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.14.0"
   },
   "devDependencies": {
     "multer": "^1.4.5-lts.1"

--- a/frontend/packages/yki/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/public/i18n/en-GB/public.json
@@ -125,7 +125,15 @@
           "customerView": "Asiakkaan näkymä",
           "toasts": {
             "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy"
+          },
+          "modal": {
+            "title": "Vahvista maksuttomuuden hyväksyminen",
+            "subTitle": "Olet hyväksymässä ilmoittautumisen maksuttomuuden."
           }
+        },
+        "toasts": {
+          "approvalConfirmed": "Maksuttomuuden hyväksyminen onnistui",
+          "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui"
         }
       },
       "cookieBanner": {

--- a/frontend/packages/yki/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/public/i18n/en-GB/public.json
@@ -124,16 +124,14 @@
           "examView": "Tutkintotilaisuuden näkymä",
           "customerView": "Asiakkaan näkymä",
           "toasts": {
-            "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy"
+            "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy",
+            "approvalConfirmed": "Maksuttomuuden hyväksyminen onnistui",
+            "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui"
           },
           "modal": {
             "title": "Vahvista maksuttomuuden hyväksyminen",
             "subTitle": "Olet hyväksymässä ilmoittautumisen maksuttomuuden."
           }
-        },
-        "toasts": {
-          "approvalConfirmed": "Maksuttomuuden hyväksyminen onnistui",
-          "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui"
         }
       },
       "cookieBanner": {

--- a/frontend/packages/yki/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/public/i18n/en-GB/public.json
@@ -126,11 +126,19 @@
           "toasts": {
             "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy",
             "approvalConfirmed": "Maksuttomuuden hyväksyminen onnistui",
-            "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui"
+            "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui",
+            "rejectConfirmed": "Maksuttomuuden hylkääminen onnistui",
+            "rejectFailed": "Maksuttomuuden hylkääminen epäonnistui"
           },
-          "modal": {
-            "title": "Vahvista maksuttomuuden hyväksyminen",
-            "subTitle": "Olet hyväksymässä ilmoittautumisen maksuttomuuden."
+          "modals": {
+            "approve": {
+              "title": "Vahvista maksuttomuuden hyväksyminen",
+              "subTitle": "Olet hyväksymässä ilmoittautumisen maksuttomuuden."
+            },
+            "reject": {
+              "title": "Vahvista maksuttomuuden hylkääminen",
+              "subTitle": "Olet hylkäämässä ilmoittautumisen maksuttomuuden."
+            }
           }
         }
       },

--- a/frontend/packages/yki/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/public.json
@@ -124,7 +124,9 @@
           "examView": "Tutkintotilaisuuden näkymä",
           "customerView": "Asiakkaan näkymä",
           "toasts": {
-            "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy"
+            "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy",
+            "approvalConfirmed": "Maksuttomuuden hyväksyminen onnistui",
+            "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui"
           },
           "modal": {
             "title": "Vahvista maksuttomuuden hyväksyminen",

--- a/frontend/packages/yki/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/public.json
@@ -125,6 +125,10 @@
           "customerView": "Asiakkaan näkymä",
           "toasts": {
             "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy"
+          },
+          "modal": {
+            "title": "Vahvista maksuttomuuden hyväksyminen",
+            "subTitle": "Olet hyväksymässä ilmoittautumisen maksuttomuuden."
           }
         }
       },

--- a/frontend/packages/yki/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/public.json
@@ -126,11 +126,19 @@
           "toasts": {
             "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy",
             "approvalConfirmed": "Maksuttomuuden hyväksyminen onnistui",
-            "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui"
+            "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui",
+            "rejectConfirmed": "Maksuttomuuden hylkääminen onnistui",
+            "rejectFailed": "Maksuttomuuden hylkääminen epäonnistui"
           },
-          "modal": {
-            "title": "Vahvista maksuttomuuden hyväksyminen",
-            "subTitle": "Olet hyväksymässä ilmoittautumisen maksuttomuuden."
+          "modals": {
+            "approve": {
+              "title": "Vahvista maksuttomuuden hyväksyminen",
+              "subTitle": "Olet hyväksymässä ilmoittautumisen maksuttomuuden."
+            },
+            "reject": {
+              "title": "Vahvista maksuttomuuden hylkääminen",
+              "subTitle": "Olet hylkäämässä ilmoittautumisen maksuttomuuden."
+            }
           }
         }
       },

--- a/frontend/packages/yki/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/public.json
@@ -124,7 +124,9 @@
           "examView": "Tutkintotilaisuuden näkymä",
           "customerView": "Asiakkaan näkymä",
           "toasts": {
-            "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy"
+            "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy",
+            "approvalConfirmed": "Maksuttomuuden hyväksyminen onnistui",
+            "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui"
           },
           "modal": {
             "title": "Vahvista maksuttomuuden hyväksyminen",

--- a/frontend/packages/yki/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/public.json
@@ -125,6 +125,10 @@
           "customerView": "Asiakkaan näkymä",
           "toasts": {
             "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy"
+          },
+          "modal": {
+            "title": "Vahvista maksuttomuuden hyväksyminen",
+            "subTitle": "Olet hyväksymässä ilmoittautumisen maksuttomuuden."
           }
         }
       },

--- a/frontend/packages/yki/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/public.json
@@ -126,11 +126,19 @@
           "toasts": {
             "notFound": "Maksuttoman ilmoittautumisen tietoja ei löydy",
             "approvalConfirmed": "Maksuttomuuden hyväksyminen onnistui",
-            "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui"
+            "approvalFailed": "Maksuttomuuden hyväksyminen epäonnistui",
+            "rejectConfirmed": "Maksuttomuuden hylkääminen onnistui",
+            "rejectFailed": "Maksuttomuuden hylkääminen epäonnistui"
           },
-          "modal": {
-            "title": "Vahvista maksuttomuuden hyväksyminen",
-            "subTitle": "Olet hyväksymässä ilmoittautumisen maksuttomuuden."
+          "modals": {
+            "approve": {
+              "title": "Vahvista maksuttomuuden hyväksyminen",
+              "subTitle": "Olet hyväksymässä ilmoittautumisen maksuttomuuden."
+            },
+            "reject": {
+              "title": "Vahvista maksuttomuuden hylkääminen",
+              "subTitle": "Olet hylkäämässä ilmoittautumisen maksuttomuuden."
+            }
           }
         }
       },

--- a/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationDetails.tsx
+++ b/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationDetails.tsx
@@ -3,28 +3,22 @@ import {
   CheckCircle,
   HourglassBottom,
 } from '@mui/icons-material';
-import CloseIcon from '@mui/icons-material/Close';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { Box, Divider, TextField } from '@mui/material';
+import { Divider, TextField } from '@mui/material';
 import { ClockIcon } from '@mui/x-date-pickers';
 import { OphButton, ophColors } from '@opetushallitus/oph-design-system';
-import React, { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import {
-  CustomButton,
-  CustomModal,
-  Text as TextComponent,
-} from 'shared/components';
-import { APIResponseStatus, Color, Severity, Variant } from 'shared/enums';
+import { APIResponseStatus, Severity, Variant } from 'shared/enums';
 import { useToast } from 'shared/hooks';
 import { DateUtils } from 'shared/utils';
 
+import { FreeRegistrationModal } from 'components/clerkFreeRegistration/FreeRegistrationModal';
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
 import { FreeRegistrationStatus } from 'interfaces/clerkFreeRegistration';
 import { Label, Text } from 'ophTheme/Text';
-import { approveFreeRegistration } from 'redux/reducers/clerkFreeRegistration';
 import {
   loadClerkFreeRegistrationDetails,
   resetClerkFreeRegistrationDetails,
@@ -58,6 +52,8 @@ export const ClerkFreeRegistrationDetails = () => {
 
   const translateLevel = (level: string) =>
     translateCommon('languageLevel.' + level);
+
+  const [isAproveModalOpen, setIsApproveModal] = useState(false);
 
   useEffect(() => {
     if (
@@ -98,8 +94,6 @@ export const ClerkFreeRegistrationDetails = () => {
     }
   }, [registrationDetails, approvalStatus, showToast, t]);
 
-  const [modalOpen, handleModal] = React.useState(false);
-
   if (!registrationDetails) {
     return null;
   }
@@ -117,63 +111,10 @@ export const ClerkFreeRegistrationDetails = () => {
           <OphButton
             variant={Variant.Contained}
             style={{ backgroundColor: ophColors.blue2, color: ophColors.white }}
-            onClick={() => handleModal(true)}
+            onClick={() => setIsApproveModal(true)}
           >
             {t('details.buttons.approveFreeRegistration')}
           </OphButton>
-          <CustomModal
-            open={modalOpen}
-            onCloseModal={() => handleModal(false)}
-            aria-labelledby="modal-title"
-            modalTitle={
-              <Box
-                display="flex"
-                justifyContent="space-between"
-                alignItems="flex-start"
-                gap={1}
-              >
-                {t('details.modal.title')}
-                <CloseIcon
-                  color={Color.Primary}
-                  aria-hidden={true}
-                  onClick={() => handleModal(false)}
-                />
-              </Box>
-            }
-          >
-            <div className="rows gapped">
-              <TextComponent
-                className="margin-top"
-                style={{ fontSize: '0.8em' }}
-              >
-                {t('details.modal.subTitle')}
-              </TextComponent>
-
-              <div className="columns gapped flex-end">
-                <CustomButton
-                  data-testid="freeregistration-modal__cancel"
-                  variant={Variant.Outlined}
-                  color={Color.Primary}
-                  style={{ fontSize: '0.8em' }}
-                  onClick={() => handleModal(false)}
-                >
-                  {translateCommon('cancel')}
-                </CustomButton>
-                <CustomButton
-                  data-testid="freeregistration-modal__approve"
-                  variant={Variant.Contained}
-                  color={Color.Primary}
-                  style={{ fontSize: '0.8em' }}
-                  onClick={() => {
-                    dispatch(approveFreeRegistration());
-                    handleModal(false);
-                  }}
-                >
-                  {t('details.buttons.approveFreeRegistration')}
-                </CustomButton>
-              </div>
-            </div>
-          </CustomModal>
         </>
       );
     } else if (
@@ -284,6 +225,10 @@ export const ClerkFreeRegistrationDetails = () => {
 
   return (
     <div className="rows gapped free-registration-details">
+      <FreeRegistrationModal
+        isAproveModalOpen={isAproveModalOpen}
+        setIsApproveModal={setIsApproveModal}
+      />
       <div>
         <b>{`${registrationDetails.person.firstName} ${registrationDetails.person.lastName}`}</b>{' '}
         <Text>{`(${registrationDetails.person.socialSecurityNumber})`}</Text>

--- a/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationDetails.tsx
+++ b/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationDetails.tsx
@@ -19,11 +19,12 @@ import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
 import { FreeRegistrationStatus } from 'interfaces/clerkFreeRegistration';
 import { Label, Text } from 'ophTheme/Text';
+import { FreeRegistrationApprovalStatus } from 'redux/reducers/clerkFreeRegistration';
 import {
   loadClerkFreeRegistrationDetails,
   resetClerkFreeRegistrationDetails,
 } from 'redux/reducers/clerkFreeRegistrationDetails';
-import { freeRegistrationsStatusSelector } from 'redux/selectors/clerkFreeRegistration';
+import { freeRegistrationApprovalStatusSelector } from 'redux/selectors/clerkFreeRegistration';
 import { clerkFreeRegistrationDetailsSelector } from 'redux/selectors/clerkFreeRegistrationDetails';
 
 export const ClerkFreeRegistrationDetails = () => {
@@ -45,6 +46,8 @@ export const ClerkFreeRegistrationDetails = () => {
     clerkFreeRegistrationDetailsSelector,
   );
 
+  const approvalStatus = useAppSelector(freeRegistrationApprovalStatusSelector);
+
   const translateCommon = useCommonTranslation();
 
   const translateLanguage = (language: string) =>
@@ -53,7 +56,8 @@ export const ClerkFreeRegistrationDetails = () => {
   const translateLevel = (level: string) =>
     translateCommon('languageLevel.' + level);
 
-  const [isAproveModalOpen, setIsApproveModal] = useState(false);
+  const [isApproveModalOpen, setIsApproveModal] = useState(false);
+  const [isRejectModalOpen, setIsRejectModal] = useState(false);
 
   useEffect(() => {
     if (
@@ -78,21 +82,33 @@ export const ClerkFreeRegistrationDetails = () => {
     };
   }, [dispatch]);
 
-  const approvalStatus = useAppSelector(freeRegistrationsStatusSelector);
-
   useEffect(() => {
-    if (approvalStatus === APIResponseStatus.Success) {
+    if (approvalStatus === FreeRegistrationApprovalStatus.ApprovalSuccess) {
       showToast({
         severity: Severity.Success,
-        description: t('toasts.approvalConfirmed'),
+        description: t('details.toasts.approvalConfirmed'),
       });
-    } else if (approvalStatus === APIResponseStatus.Error) {
+    } else if (
+      approvalStatus === FreeRegistrationApprovalStatus.ApprovalError
+    ) {
       showToast({
         severity: Severity.Error,
-        description: t('toasts.approvalFailed'),
+        description: t('details.toasts.approvalFailed'),
+      });
+    } else if (
+      approvalStatus === FreeRegistrationApprovalStatus.RejectSuccess
+    ) {
+      showToast({
+        severity: Severity.Success,
+        description: t('details.toasts.rejectConfirmed'),
+      });
+    } else if (approvalStatus === FreeRegistrationApprovalStatus.RejectError) {
+      showToast({
+        severity: Severity.Error,
+        description: t('details.toasts.rejectFailed'),
       });
     }
-  }, [registrationDetails, approvalStatus, showToast, t]);
+  }, [approvalStatus, showToast, t]);
 
   if (!registrationDetails) {
     return null;
@@ -112,8 +128,21 @@ export const ClerkFreeRegistrationDetails = () => {
             variant={Variant.Contained}
             style={{ backgroundColor: ophColors.blue2, color: ophColors.white }}
             onClick={() => setIsApproveModal(true)}
+            disabled={
+              approvalStatus === FreeRegistrationApprovalStatus.RejectSuccess
+            }
           >
             {t('details.buttons.approveFreeRegistration')}
+          </OphButton>
+          <OphButton
+            variant="contained"
+            style={{ backgroundColor: '#0033CC', color: 'white' }}
+            onClick={() => setIsRejectModal(true)}
+            disabled={
+              approvalStatus === FreeRegistrationApprovalStatus.ApprovalSuccess
+            }
+          >
+            {t('details.buttons.rejectFreeRegistration')}
           </OphButton>
         </>
       );
@@ -226,8 +255,10 @@ export const ClerkFreeRegistrationDetails = () => {
   return (
     <div className="rows gapped free-registration-details">
       <FreeRegistrationModal
-        isAproveModalOpen={isAproveModalOpen}
+        isApproveModalOpen={isApproveModalOpen}
         setIsApproveModal={setIsApproveModal}
+        isRejectModalOpen={isRejectModalOpen}
+        setIsRejectModal={setIsRejectModal}
       />
       <div>
         <b>{`${registrationDetails.person.firstName} ${registrationDetails.person.lastName}`}</b>{' '}

--- a/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationDetails.tsx
+++ b/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationDetails.tsx
@@ -56,8 +56,8 @@ export const ClerkFreeRegistrationDetails = () => {
   const translateLevel = (level: string) =>
     translateCommon('languageLevel.' + level);
 
-  const [isApproveModalOpen, setIsApproveModal] = useState(false);
-  const [isRejectModalOpen, setIsRejectModal] = useState(false);
+  const [isApproveModalOpen, setIsApproveModalOpen] = useState(false);
+  const [isRejectModalOpen, setIsRejectModalOpen] = useState(false);
 
   useEffect(() => {
     if (
@@ -127,7 +127,7 @@ export const ClerkFreeRegistrationDetails = () => {
           <OphButton
             variant={Variant.Contained}
             style={{ backgroundColor: ophColors.blue2, color: ophColors.white }}
-            onClick={() => setIsApproveModal(true)}
+            onClick={() => setIsApproveModalOpen(true)}
             disabled={
               approvalStatus === FreeRegistrationApprovalStatus.RejectSuccess
             }
@@ -137,7 +137,7 @@ export const ClerkFreeRegistrationDetails = () => {
           <OphButton
             variant="contained"
             style={{ backgroundColor: '#0033CC', color: 'white' }}
-            onClick={() => setIsRejectModal(true)}
+            onClick={() => setIsRejectModalOpen(true)}
             disabled={
               approvalStatus === FreeRegistrationApprovalStatus.ApprovalSuccess
             }
@@ -256,9 +256,9 @@ export const ClerkFreeRegistrationDetails = () => {
     <div className="rows gapped free-registration-details">
       <FreeRegistrationModal
         isApproveModalOpen={isApproveModalOpen}
-        setIsApproveModal={setIsApproveModal}
+        setIsApproveModal={setIsApproveModalOpen}
         isRejectModalOpen={isRejectModalOpen}
-        setIsRejectModal={setIsRejectModal}
+        setIsRejectModal={setIsRejectModalOpen}
       />
       <div>
         <b>{`${registrationDetails.person.firstName} ${registrationDetails.person.lastName}`}</b>{' '}

--- a/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationDetails.tsx
+++ b/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationDetails.tsx
@@ -3,13 +3,19 @@ import {
   CheckCircle,
   HourglassBottom,
 } from '@mui/icons-material';
+import CloseIcon from '@mui/icons-material/Close';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { Divider, TextField } from '@mui/material';
+import { Box, Divider, TextField } from '@mui/material';
 import { ClockIcon } from '@mui/x-date-pickers';
 import { OphButton, ophColors } from '@opetushallitus/oph-design-system';
-import { ChangeEvent, useEffect, useState } from 'react';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { APIResponseStatus, Severity, Variant } from 'shared/enums';
+import {
+  CustomButton,
+  CustomModal,
+  Text as TextComponent,
+} from 'shared/components';
+import { APIResponseStatus, Color, Severity, Variant } from 'shared/enums';
 import { useToast } from 'shared/hooks';
 import { DateUtils } from 'shared/utils';
 
@@ -18,10 +24,12 @@ import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
 import { FreeRegistrationStatus } from 'interfaces/clerkFreeRegistration';
 import { Label, Text } from 'ophTheme/Text';
+import { approveFreeRegistration } from 'redux/reducers/clerkFreeRegistration';
 import {
   loadClerkFreeRegistrationDetails,
   resetClerkFreeRegistrationDetails,
 } from 'redux/reducers/clerkFreeRegistrationDetails';
+import { freeRegistrationsStatusSelector } from 'redux/selectors/clerkFreeRegistration';
 import { clerkFreeRegistrationDetailsSelector } from 'redux/selectors/clerkFreeRegistrationDetails';
 
 export const ClerkFreeRegistrationDetails = () => {
@@ -74,6 +82,24 @@ export const ClerkFreeRegistrationDetails = () => {
     };
   }, [dispatch]);
 
+  const approvalStatus = useAppSelector(freeRegistrationsStatusSelector);
+
+  useEffect(() => {
+    if (approvalStatus === APIResponseStatus.Success) {
+      showToast({
+        severity: Severity.Success,
+        description: t('toasts.approvalConfirmed'),
+      });
+    } else if (approvalStatus === APIResponseStatus.Error) {
+      showToast({
+        severity: Severity.Error,
+        description: t('toasts.approvalFailed'),
+      });
+    }
+  }, [registrationDetails, approvalStatus, showToast, t]);
+
+  const [modalOpen, handleModal] = React.useState(false);
+
   if (!registrationDetails) {
     return null;
   }
@@ -91,9 +117,63 @@ export const ClerkFreeRegistrationDetails = () => {
           <OphButton
             variant={Variant.Contained}
             style={{ backgroundColor: ophColors.blue2, color: ophColors.white }}
+            onClick={() => handleModal(true)}
           >
             {t('details.buttons.approveFreeRegistration')}
           </OphButton>
+          <CustomModal
+            open={modalOpen}
+            onCloseModal={() => handleModal(false)}
+            aria-labelledby="modal-title"
+            modalTitle={
+              <Box
+                display="flex"
+                justifyContent="space-between"
+                alignItems="flex-start"
+                gap={1}
+              >
+                {t('details.modal.title')}
+                <CloseIcon
+                  color={Color.Primary}
+                  aria-hidden={true}
+                  onClick={() => handleModal(false)}
+                />
+              </Box>
+            }
+          >
+            <div className="rows gapped">
+              <TextComponent
+                className="margin-top"
+                style={{ fontSize: '0.8em' }}
+              >
+                {t('details.modal.subTitle')}
+              </TextComponent>
+
+              <div className="columns gapped flex-end">
+                <CustomButton
+                  data-testid="freeregistration-modal__cancel"
+                  variant={Variant.Outlined}
+                  color={Color.Primary}
+                  style={{ fontSize: '0.8em' }}
+                  onClick={() => handleModal(false)}
+                >
+                  {translateCommon('cancel')}
+                </CustomButton>
+                <CustomButton
+                  data-testid="freeregistration-modal__approve"
+                  variant={Variant.Contained}
+                  color={Color.Primary}
+                  style={{ fontSize: '0.8em' }}
+                  onClick={() => {
+                    dispatch(approveFreeRegistration());
+                    handleModal(false);
+                  }}
+                >
+                  {t('details.buttons.approveFreeRegistration')}
+                </CustomButton>
+              </div>
+            </div>
+          </CustomModal>
         </>
       );
     } else if (

--- a/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationModal.tsx
+++ b/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationModal.tsx
@@ -1,0 +1,73 @@
+import CloseIcon from '@mui/icons-material/Close';
+import { Box } from '@mui/material';
+import { CustomButton, CustomModal, Text } from 'shared/components';
+import { Color, Variant } from 'shared/enums';
+
+import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
+import { approveFreeRegistration } from 'redux/reducers/clerkFreeRegistration';
+
+type FreeRegistrationModalProps = {
+  isAproveModalOpen: boolean;
+  setIsApproveModal: (isOpen: boolean) => void;
+};
+
+export const FreeRegistrationModal = ({
+  isAproveModalOpen,
+  setIsApproveModal,
+}: FreeRegistrationModalProps) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.clerkFreeRegistration',
+  });
+  const dispatch = useAppDispatch();
+  const translateCommon = useCommonTranslation();
+
+  return (
+    <CustomModal
+      open={isAproveModalOpen}
+      onCloseModal={() => setIsApproveModal(false)}
+      aria-labelledby="modal-title"
+      modalTitle={
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          alignItems="flex-start"
+          gap={1}
+        >
+          {t('details.modal.title')}
+          <CloseIcon
+            color={Color.Primary}
+            aria-hidden={true}
+            onClick={() => setIsApproveModal(false)}
+          />
+        </Box>
+      }
+    >
+      <div className="rows gapped">
+        <Text className="margin-top">{t('details.modal.subTitle')}</Text>
+
+        <div className="columns gapped flex-end">
+          <CustomButton
+            data-testid="freeregistration-modal__cancel"
+            variant={Variant.Outlined}
+            color={Color.Primary}
+            onClick={() => setIsApproveModal(false)}
+          >
+            {translateCommon('cancel')}
+          </CustomButton>
+          <CustomButton
+            data-testid="freeregistration-modal__approve"
+            variant={Variant.Contained}
+            color={Color.Primary}
+            onClick={() => {
+              dispatch(approveFreeRegistration());
+              setIsApproveModal(false);
+            }}
+          >
+            {t('details.buttons.approveFreeRegistration')}
+          </CustomButton>
+        </div>
+      </div>
+    </CustomModal>
+  );
+};

--- a/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationModal.tsx
+++ b/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationModal.tsx
@@ -1,20 +1,31 @@
 import CloseIcon from '@mui/icons-material/Close';
 import { Box } from '@mui/material';
+import { useEffect } from 'react';
 import { CustomButton, CustomModal, Text } from 'shared/components';
-import { Color, Variant } from 'shared/enums';
+import { Color, Severity, Variant } from 'shared/enums';
+import { useToast } from 'shared/hooks';
 
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
-import { useAppDispatch } from 'configs/redux';
-import { approveFreeRegistration } from 'redux/reducers/clerkFreeRegistration';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import {
+  approveFreeRegistration,
+  FreeRegistrationApprovalStatus,
+  rejectFreeRegistration,
+} from 'redux/reducers/clerkFreeRegistration';
+import { freeRegistrationApprovalStatusSelector } from 'redux/selectors/clerkFreeRegistration';
 
 type FreeRegistrationModalProps = {
-  isAproveModalOpen: boolean;
+  isApproveModalOpen: boolean;
   setIsApproveModal: (isOpen: boolean) => void;
+  isRejectModalOpen: boolean;
+  setIsRejectModal: (isOpen: boolean) => void;
 };
 
 export const FreeRegistrationModal = ({
-  isAproveModalOpen,
+  isApproveModalOpen,
   setIsApproveModal,
+  isRejectModalOpen,
+  setIsRejectModal,
 }: FreeRegistrationModalProps) => {
   const { t } = usePublicTranslation({
     keyPrefix: 'yki.component.clerkFreeRegistration',
@@ -23,51 +34,104 @@ export const FreeRegistrationModal = ({
   const translateCommon = useCommonTranslation();
 
   return (
-    <CustomModal
-      open={isAproveModalOpen}
-      onCloseModal={() => setIsApproveModal(false)}
-      aria-labelledby="modal-title"
-      modalTitle={
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          alignItems="flex-start"
-          gap={1}
-        >
-          {t('details.modal.title')}
-          <CloseIcon
-            color={Color.Primary}
-            aria-hidden={true}
-            onClick={() => setIsApproveModal(false)}
-          />
-        </Box>
-      }
-    >
-      <div className="rows gapped">
-        <Text className="margin-top">{t('details.modal.subTitle')}</Text>
+    <>
+      <CustomModal
+        open={isApproveModalOpen}
+        onCloseModal={() => setIsApproveModal(false)}
+        aria-labelledby="modal-title"
+        modalTitle={
+          <Box
+            display="flex"
+            justifyContent="space-between"
+            alignItems="flex-start"
+            gap={1}
+          >
+            {t('details.modals.approve.title')}
+            <CloseIcon
+              color={Color.Primary}
+              aria-hidden={true}
+              onClick={() => setIsApproveModal(false)}
+            />
+          </Box>
+        }
+      >
+        <div className="rows gapped">
+          <Text className="margin-top">
+            {t('details.modals.approve.subTitle')}
+          </Text>
 
-        <div className="columns gapped flex-end">
-          <CustomButton
-            data-testid="freeregistration-modal__cancel"
-            variant={Variant.Outlined}
-            color={Color.Primary}
-            onClick={() => setIsApproveModal(false)}
-          >
-            {translateCommon('cancel')}
-          </CustomButton>
-          <CustomButton
-            data-testid="freeregistration-modal__approve"
-            variant={Variant.Contained}
-            color={Color.Primary}
-            onClick={() => {
-              dispatch(approveFreeRegistration());
-              setIsApproveModal(false);
-            }}
-          >
-            {t('details.buttons.approveFreeRegistration')}
-          </CustomButton>
+          <div className="columns gapped flex-end">
+            <CustomButton
+              data-testid="freeregistration-modal__cancel"
+              variant={Variant.Outlined}
+              color={Color.Primary}
+              onClick={() => setIsApproveModal(false)}
+            >
+              {translateCommon('cancel')}
+            </CustomButton>
+            <CustomButton
+              data-testid="freeregistration-modal__approve"
+              variant={Variant.Contained}
+              color={Color.Primary}
+              onClick={() => {
+                dispatch(approveFreeRegistration());
+                setIsApproveModal(false);
+              }}
+            >
+              {t('details.buttons.approveFreeRegistration')}
+            </CustomButton>
+          </div>
         </div>
-      </div>
-    </CustomModal>
+      </CustomModal>
+
+      <CustomModal
+        open={isRejectModalOpen}
+        onCloseModal={() => setIsRejectModal(false)}
+        aria-labelledby="modal-title"
+        modalTitle={
+          <Box
+            display="flex"
+            justifyContent="space-between"
+            alignItems="flex-start"
+            gap={1}
+          >
+            {t('details.modals.reject.title')}
+            <CloseIcon
+              color={Color.Primary}
+              aria-hidden={true}
+              onClick={() => setIsRejectModal(false)}
+            />
+          </Box>
+        }
+      >
+        <div className="rows gapped">
+          <Text className="margin-top">
+            {t('details.modals.reject.subTitle')}
+          </Text>
+
+          <div className="columns gapped flex-end">
+            <CustomButton
+              data-testid="freeregistration-modal__cancel"
+              variant={Variant.Outlined}
+              color={Color.Primary}
+              onClick={() => setIsRejectModal(false)}
+            >
+              {translateCommon('cancel')}
+            </CustomButton>
+            <CustomButton
+              data-testid="freeregistration-modal__approve"
+              variant={Variant.Contained}
+              color={Color.Primary}
+              onClick={() => {
+                dispatch(rejectFreeRegistration());
+                setIsRejectModal(false);
+              }}
+            >
+              {t('details.buttons.rejectFreeRegistration')}
+            </CustomButton>
+          </div>
+        </div>
+      </CustomModal>
+    </>
   );
 };

--- a/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationModal.tsx
+++ b/frontend/packages/yki/src/components/clerkFreeRegistration/FreeRegistrationModal.tsx
@@ -1,18 +1,15 @@
 import CloseIcon from '@mui/icons-material/Close';
 import { Box } from '@mui/material';
-import { useEffect } from 'react';
 import { CustomButton, CustomModal, Text } from 'shared/components';
-import { Color, Severity, Variant } from 'shared/enums';
-import { useToast } from 'shared/hooks';
+import { Color, Variant } from 'shared/enums';
 
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
-import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { useAppDispatch } from 'configs/redux';
+import { H1 } from 'ophTheme/Text';
 import {
   approveFreeRegistration,
-  FreeRegistrationApprovalStatus,
   rejectFreeRegistration,
 } from 'redux/reducers/clerkFreeRegistration';
-import { freeRegistrationApprovalStatusSelector } from 'redux/selectors/clerkFreeRegistration';
 
 type FreeRegistrationModalProps = {
   isApproveModalOpen: boolean;
@@ -46,10 +43,11 @@ export const FreeRegistrationModal = ({
             alignItems="flex-start"
             gap={1}
           >
-            {t('details.modals.approve.title')}
+            <H1>{t('details.modals.approve.title')}</H1>
             <CloseIcon
               color={Color.Primary}
               aria-hidden={true}
+              fontSize="large"
               onClick={() => setIsApproveModal(false)}
             />
           </Box>
@@ -62,7 +60,6 @@ export const FreeRegistrationModal = ({
 
           <div className="columns gapped flex-end">
             <CustomButton
-              data-testid="freeregistration-modal__cancel"
               variant={Variant.Outlined}
               color={Color.Primary}
               onClick={() => setIsApproveModal(false)}
@@ -70,7 +67,6 @@ export const FreeRegistrationModal = ({
               {translateCommon('cancel')}
             </CustomButton>
             <CustomButton
-              data-testid="freeregistration-modal__approve"
               variant={Variant.Contained}
               color={Color.Primary}
               onClick={() => {
@@ -95,10 +91,11 @@ export const FreeRegistrationModal = ({
             alignItems="flex-start"
             gap={1}
           >
-            {t('details.modals.reject.title')}
+            <H1>{t('details.modals.reject.title')}</H1>
             <CloseIcon
               color={Color.Primary}
               aria-hidden={true}
+              fontSize="large"
               onClick={() => setIsRejectModal(false)}
             />
           </Box>
@@ -111,7 +108,6 @@ export const FreeRegistrationModal = ({
 
           <div className="columns gapped flex-end">
             <CustomButton
-              data-testid="freeregistration-modal__cancel"
               variant={Variant.Outlined}
               color={Color.Primary}
               onClick={() => setIsRejectModal(false)}
@@ -119,7 +115,6 @@ export const FreeRegistrationModal = ({
               {translateCommon('cancel')}
             </CustomButton>
             <CustomButton
-              data-testid="freeregistration-modal__approve"
               variant={Variant.Contained}
               color={Color.Primary}
               onClick={() => {

--- a/frontend/packages/yki/src/enums/api.ts
+++ b/frontend/packages/yki/src/enums/api.ts
@@ -28,6 +28,7 @@ export enum APIEndpoints {
   ClerkOrganizer = '/yki/api/clerk/organizer',
   ClerkFreeRegistration = '/yki/api/clerk/free-registrations',
   ClerkFreeRegistrationDetails = '/yki/api/clerk/free-registrations/:id',
+  ApproveClerkFreeRegistration = '/api/v1/clerk/registration/approval',
 }
 
 export enum PaymentStatus {

--- a/frontend/packages/yki/src/enums/api.ts
+++ b/frontend/packages/yki/src/enums/api.ts
@@ -29,6 +29,7 @@ export enum APIEndpoints {
   ClerkFreeRegistration = '/yki/api/clerk/free-registrations',
   ClerkFreeRegistrationDetails = '/yki/api/clerk/free-registrations/:id',
   ApproveClerkFreeRegistration = '/api/v1/clerk/registration/approval',
+  RejectClerkFreeRegistration = '/api/v1/clerk/registration/rejection',
 }
 
 export enum PaymentStatus {

--- a/frontend/packages/yki/src/redux/reducers/clerkFreeRegistration.ts
+++ b/frontend/packages/yki/src/redux/reducers/clerkFreeRegistration.ts
@@ -6,11 +6,13 @@ import { ClerkFreeRegistration } from 'interfaces/clerkFreeRegistration';
 interface ClerkFreeRegistrationState {
   freeRegistrations: Array<ClerkFreeRegistration>;
   status: APIResponseStatus;
+  registrationStatus: APIResponseStatus;
 }
 
 const initialState: ClerkFreeRegistrationState = {
   freeRegistrations: [],
   status: APIResponseStatus.NotStarted,
+  registrationStatus: APIResponseStatus.NotStarted,
 };
 
 const clerkFreeRegistrationSlice = createSlice({
@@ -30,6 +32,15 @@ const clerkFreeRegistrationSlice = createSlice({
       state.status = APIResponseStatus.Success;
       state.freeRegistrations = action.payload;
     },
+    approveFreeRegistration(state) {
+      state.registrationStatus = APIResponseStatus.InProgress;
+    },
+    acceptFreeRegistrationApproval(state) {
+      state.registrationStatus = APIResponseStatus.Success;
+    },
+    rejectFreeRegistrationApproval(state) {
+      state.registrationStatus = APIResponseStatus.Error;
+    },
   },
 });
 
@@ -38,4 +49,7 @@ export const {
   loadClerkFreeRegistrations,
   rejectClerkFreeRegistrations,
   storeClerkFreeRegistrations,
+  approveFreeRegistration,
+  acceptFreeRegistrationApproval,
+  rejectFreeRegistrationApproval,
 } = clerkFreeRegistrationSlice.actions;

--- a/frontend/packages/yki/src/redux/reducers/clerkFreeRegistration.ts
+++ b/frontend/packages/yki/src/redux/reducers/clerkFreeRegistration.ts
@@ -3,16 +3,26 @@ import { APIResponseStatus } from 'shared/enums';
 
 import { ClerkFreeRegistration } from 'interfaces/clerkFreeRegistration';
 
+export enum FreeRegistrationApprovalStatus {
+  NotStarted,
+  ApprovalInProgress,
+  ApprovalSuccess,
+  ApprovalError,
+  RejectInProgress,
+  RejectSuccess,
+  RejectError,
+}
+
 interface ClerkFreeRegistrationState {
   freeRegistrations: Array<ClerkFreeRegistration>;
   status: APIResponseStatus;
-  registrationStatus: APIResponseStatus;
+  registrationApprovalStatus: FreeRegistrationApprovalStatus;
 }
 
 const initialState: ClerkFreeRegistrationState = {
   freeRegistrations: [],
   status: APIResponseStatus.NotStarted,
-  registrationStatus: APIResponseStatus.NotStarted,
+  registrationApprovalStatus: FreeRegistrationApprovalStatus.NotStarted,
 };
 
 const clerkFreeRegistrationSlice = createSlice({
@@ -32,14 +42,20 @@ const clerkFreeRegistrationSlice = createSlice({
       state.status = APIResponseStatus.Success;
       state.freeRegistrations = action.payload;
     },
+
+    setFreeRegistrationStatus(
+      state,
+      action: PayloadAction<FreeRegistrationApprovalStatus>,
+    ) {
+      state.registrationApprovalStatus = action.payload;
+    },
     approveFreeRegistration(state) {
-      state.registrationStatus = APIResponseStatus.InProgress;
+      state.registrationApprovalStatus =
+        FreeRegistrationApprovalStatus.ApprovalInProgress;
     },
-    acceptFreeRegistrationApproval(state) {
-      state.registrationStatus = APIResponseStatus.Success;
-    },
-    rejectFreeRegistrationApproval(state) {
-      state.registrationStatus = APIResponseStatus.Error;
+    rejectFreeRegistration(state) {
+      state.registrationApprovalStatus =
+        FreeRegistrationApprovalStatus.RejectInProgress;
     },
   },
 });
@@ -49,7 +65,7 @@ export const {
   loadClerkFreeRegistrations,
   rejectClerkFreeRegistrations,
   storeClerkFreeRegistrations,
+  setFreeRegistrationStatus,
   approveFreeRegistration,
-  acceptFreeRegistrationApproval,
-  rejectFreeRegistrationApproval,
+  rejectFreeRegistration,
 } = clerkFreeRegistrationSlice.actions;

--- a/frontend/packages/yki/src/redux/sagas/clerkFreeRegistration.ts
+++ b/frontend/packages/yki/src/redux/sagas/clerkFreeRegistration.ts
@@ -29,7 +29,7 @@ function* loadClerkFreeRegistrationsSaga() {
 
 function* approveFreeRegistrationSaga() {
   try {
-    yield call(axiosInstance.put, '/api/v1/clerk/registration/approval');
+    yield call(axiosInstance.put, APIEndpoints.ApproveClerkFreeRegistration);
     yield put(acceptFreeRegistrationApproval());
   } catch (error) {
     yield put(rejectFreeRegistrationApproval());

--- a/frontend/packages/yki/src/redux/sagas/clerkFreeRegistration.ts
+++ b/frontend/packages/yki/src/redux/sagas/clerkFreeRegistration.ts
@@ -5,11 +5,12 @@ import axiosInstance from 'configs/axios';
 import { APIEndpoints } from 'enums/api';
 import { ClerkFreeRegistrationResponse } from 'interfaces/clerkFreeRegistration';
 import {
-  acceptFreeRegistrationApproval,
   approveFreeRegistration,
+  FreeRegistrationApprovalStatus,
   loadClerkFreeRegistrations,
   rejectClerkFreeRegistrations,
-  rejectFreeRegistrationApproval,
+  rejectFreeRegistration,
+  setFreeRegistrationStatus,
   storeClerkFreeRegistrations,
 } from 'redux/reducers/clerkFreeRegistration';
 import { SerializationUtils } from 'utils/serialization';
@@ -30,9 +31,26 @@ function* loadClerkFreeRegistrationsSaga() {
 function* approveFreeRegistrationSaga() {
   try {
     yield call(axiosInstance.put, APIEndpoints.ApproveClerkFreeRegistration);
-    yield put(acceptFreeRegistrationApproval());
+    yield put(
+      setFreeRegistrationStatus(FreeRegistrationApprovalStatus.ApprovalSuccess),
+    );
   } catch (error) {
-    yield put(rejectFreeRegistrationApproval());
+    yield put(
+      setFreeRegistrationStatus(FreeRegistrationApprovalStatus.ApprovalError),
+    );
+  }
+}
+
+function* rejectFreeRegistrationSaga() {
+  try {
+    yield call(axiosInstance.put, APIEndpoints.RejectClerkFreeRegistration);
+    yield put(
+      setFreeRegistrationStatus(FreeRegistrationApprovalStatus.RejectSuccess),
+    );
+  } catch (error) {
+    yield put(
+      setFreeRegistrationStatus(FreeRegistrationApprovalStatus.RejectError),
+    );
   }
 }
 
@@ -43,4 +61,5 @@ export function* watchClerkFreeRegistrations() {
   );
 
   yield takeLatest(approveFreeRegistration.type, approveFreeRegistrationSaga);
+  yield takeLatest(rejectFreeRegistration.type, rejectFreeRegistrationSaga);
 }

--- a/frontend/packages/yki/src/redux/sagas/clerkFreeRegistration.ts
+++ b/frontend/packages/yki/src/redux/sagas/clerkFreeRegistration.ts
@@ -5,8 +5,11 @@ import axiosInstance from 'configs/axios';
 import { APIEndpoints } from 'enums/api';
 import { ClerkFreeRegistrationResponse } from 'interfaces/clerkFreeRegistration';
 import {
+  acceptFreeRegistrationApproval,
+  approveFreeRegistration,
   loadClerkFreeRegistrations,
   rejectClerkFreeRegistrations,
+  rejectFreeRegistrationApproval,
   storeClerkFreeRegistrations,
 } from 'redux/reducers/clerkFreeRegistration';
 import { SerializationUtils } from 'utils/serialization';
@@ -24,9 +27,20 @@ function* loadClerkFreeRegistrationsSaga() {
   }
 }
 
+function* approveFreeRegistrationSaga() {
+  try {
+    yield call(axiosInstance.put, '/api/v1/clerk/registration/approval');
+    yield put(acceptFreeRegistrationApproval());
+  } catch (error) {
+    yield put(rejectFreeRegistrationApproval());
+  }
+}
+
 export function* watchClerkFreeRegistrations() {
   yield takeLatest(
     loadClerkFreeRegistrations.type,
     loadClerkFreeRegistrationsSaga,
   );
+
+  yield takeLatest(approveFreeRegistration.type, approveFreeRegistrationSaga);
 }

--- a/frontend/packages/yki/src/redux/selectors/clerkFreeRegistration.ts
+++ b/frontend/packages/yki/src/redux/selectors/clerkFreeRegistration.ts
@@ -25,3 +25,6 @@ export const selectFilteredFreeRegistrations = createSelector(
     });
   },
 );
+
+export const freeRegistrationsStatusSelector = (state: RootState) =>
+  state.clerkFreeRegistration.registrationStatus;

--- a/frontend/packages/yki/src/redux/selectors/clerkFreeRegistration.ts
+++ b/frontend/packages/yki/src/redux/selectors/clerkFreeRegistration.ts
@@ -26,5 +26,5 @@ export const selectFilteredFreeRegistrations = createSelector(
   },
 );
 
-export const freeRegistrationsStatusSelector = (state: RootState) =>
-  state.clerkFreeRegistration.registrationStatus;
+export const freeRegistrationApprovalStatusSelector = (state: RootState) =>
+  state.clerkFreeRegistration.registrationApprovalStatus;

--- a/frontend/packages/yki/src/tests/cypress/integration/clerk/clerk_free_registration_details_page.spec.ts
+++ b/frontend/packages/yki/src/tests/cypress/integration/clerk/clerk_free_registration_details_page.spec.ts
@@ -69,4 +69,20 @@ describe('ClerkFreeRegistrationDetailsPage', () => {
 
     onToast.expectText('Maksuttomuuden hyväksyminen onnistui');
   });
+
+  it('rejects a free registration from details page', () => {
+    const id = 1;
+    cy.openClerkFreeRegistrationDetailsPage(id);
+
+    // Click approve modal
+    cy.findByRole('button', { name: 'Hylkää maksuttomuus' }).click();
+
+    // Exepect the modal to be visible
+    cy.findByText('Vahvista maksuttomuuden hylkääminen').should('be.visible');
+
+    // Click confirm button in modal
+    cy.findByRole('button', { name: 'Hylkää maksuttomuus' }).click();
+
+    onToast.expectText('Maksuttomuuden hylkääminen onnistui');
+  });
 });

--- a/frontend/packages/yki/src/tests/cypress/integration/clerk/clerk_free_registration_details_page.spec.ts
+++ b/frontend/packages/yki/src/tests/cypress/integration/clerk/clerk_free_registration_details_page.spec.ts
@@ -2,6 +2,7 @@ import { AppLanguage } from 'shared/enums';
 import { DateUtils } from 'shared/utils';
 
 import { onClerkFreeRegistrationDetailsPage } from 'tests/cypress/support/page-objects/clerkFreeRegistrationDetailsPage';
+import { onToast } from 'tests/cypress/support/page-objects/toast';
 
 describe('ClerkFreeRegistrationDetailsPage', () => {
   before(() => {
@@ -51,5 +52,21 @@ describe('ClerkFreeRegistrationDetailsPage', () => {
     onClerkFreeRegistrationDetailsPage.expectDetailsVisible(id);
     onClerkFreeRegistrationDetailsPage.expectAttachmentsVisible(id);
     onClerkFreeRegistrationDetailsPage.expectCorrectActionButtonsVisible(id);
+  });
+
+  it('approves a free registration from details page', () => {
+    const id = 1;
+    cy.openClerkFreeRegistrationDetailsPage(id);
+
+    // Click approve modal
+    cy.findByRole('button', { name: 'Hyväksy maksuttomuus' }).click();
+
+    // Exepect the modal to be visible
+    cy.findByText('Vahvista maksuttomuuden hyväksyminen').should('be.visible');
+
+    // Click confirm button in modal
+    cy.findByRole('button', { name: 'Hyväksy maksuttomuus' }).click();
+
+    onToast.expectText('Maksuttomuuden hyväksyminen onnistui');
   });
 });

--- a/frontend/packages/yki/src/tests/cypress/support/page-objects/clerkFreeRegistrationDetailsPage.ts
+++ b/frontend/packages/yki/src/tests/cypress/support/page-objects/clerkFreeRegistrationDetailsPage.ts
@@ -73,7 +73,7 @@ class ClerkFreeRegistrationDetailsPage {
       }).should('be.visible');
       cy.findByRole('button', {
         name: 'Hylkää maksuttomuus',
-      }).should('not.exist');
+      }).should('exist');
     } else if (details.status === 'APPROVED') {
       cy.findByRole('button', { name: 'Hylkää maksuttomuus' }).should(
         'be.visible',

--- a/frontend/packages/yki/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/src/tests/msw/handlers.ts
@@ -191,4 +191,7 @@ export const handlers = [
   http.put(APIEndpoints.ApproveClerkFreeRegistration, () => {
     return HttpResponse.json({ success: true });
   }),
+  http.put(APIEndpoints.RejectClerkFreeRegistration, () => {
+    return HttpResponse.json({ success: true });
+  }),
 ];

--- a/frontend/packages/yki/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/src/tests/msw/handlers.ts
@@ -188,4 +188,7 @@ export const handlers = [
       return notFound();
     }
   }),
+  http.put('/api/v1/clerk/registration/approval', () => {
+    return HttpResponse.json({ success: true });
+  }),
 ];

--- a/frontend/packages/yki/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/src/tests/msw/handlers.ts
@@ -188,7 +188,7 @@ export const handlers = [
       return notFound();
     }
   }),
-  http.put('/api/v1/clerk/registration/approval', () => {
+  http.put(APIEndpoints.ApproveClerkFreeRegistration, () => {
     return HttpResponse.json({ success: true });
   }),
 ];

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2720,7 +2720,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.13.0":
+"@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared, shared@npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.14.0":
   version: 0.0.0-use.local
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.shared@workspace:packages/shared"
   languageName: unknown
@@ -2740,7 +2740,7 @@ __metadata:
   resolution: "@opetushallitus/kieli-ja-kaantajatutkinnot.yki@workspace:packages/yki"
   dependencies:
     multer: "npm:^1.4.5-lts.1"
-    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.13.0"
+    shared: "npm:@opetushallitus/kieli-ja-kaantajatutkinnot.shared@1.14.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Yhteenveto
https://jira.eduuni.fi/browse/OPHKIOS-244 - tehtävän

Uudet modaalit. Ei ole täysin figma-speksien mukainen, mutta voin viilata tyyliä vielä jos halutaan
<img width="666" height="423" alt="image" src="https://github.com/user-attachments/assets/c70bb5fc-8cc4-40f8-b7aa-74f0371c1217" />

## Lisätiedot

Ei kutsu bäkkäriä, vaan MSW:llä mokataan `PUT api/v1/clerk/registration/approval`

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [x] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
