### PR TITLE
YKI(Frontend): OPHKIOS-184 Add new tab and page placeholder, CustomerSearch

### DIFF
--- a/frontend/packages/yki/public/i18n/en-GB/common.json
+++ b/frontend/packages/yki/public/i18n/en-GB/common.json
@@ -143,6 +143,7 @@
       "reassessment": "Reassessment",
       "registration": "Registration",
       "freeRegistration": "Maksuttomuus",
+      "customerSearch": "Asiakashaku",
       "registrationPeriod": "Registration period",
       "specialArrangementsLink": "https://www.oph.fi/en/education-and-qualifications/registering-yki-test#anchor-do-you-need-special-arrangements",
       "userRegistrations": "My registrations",
@@ -166,7 +167,8 @@
         "transferRegistration": "Reschedule registration",
         "confirmRegistration": "Confirm registration",
         "notFound": "Page not found",
-        "expiredLoginLink": "The link has expired"
+        "expiredLoginLink": "The link has expired",
+        "customerSearch": "Asiakashaku"
       },
       "previous": "Previous"
     }

--- a/frontend/packages/yki/public/i18n/fi-FI/common.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/common.json
@@ -143,6 +143,7 @@
       "reassessment": "Tarkistusarviointi",
       "registration": "Ilmoittautuminen",
       "freeRegistration": "Maksuttomuus",
+      "customerSearch": "Asiakashaku",
       "registrationPeriod": "Ilmoittautumisaika",
       "specialArrangementsLink": "https://www.oph.fi/fi/koulutus-ja-tutkinnot/kieli-ja-kaantajatutkinnot/yleiset-kielitutkinnot-yki/ilmoittautuminen-yki-testiin",
       "userRegistrations": "Omat ilmoittautumiset",
@@ -166,7 +167,8 @@
         "transferRegistration": "Siirrä ilmoittautuminen",
         "confirmRegistration": "Vahvista ilmoittautuminen",
         "notFound": "Etsimääsi sivua ei löytynyt",
-        "expiredLoginLink": "Linkki on vanhentunut"
+        "expiredLoginLink": "Linkki on vanhentunut",
+        "customerSearch": "Asiakashaku"
       },
       "previous": "Edellinen"
     }

--- a/frontend/packages/yki/public/i18n/sv-SE/common.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/common.json
@@ -143,6 +143,7 @@
       "reassessment": "Kontrollbedömning",
       "registration": "Anmälan",
       "freeRegistration": "Maksuttomuus",
+      "customerSearch": "Asiakashaku",
       "registrationPeriod": "Anmälningstid",
       "specialArrangementsLink": "https://www.oph.fi/sv/utbildning-och-examina/anmalan-till-yki-test#anchor-behover-du-specialarrangemang",
       "userRegistrations": "Mina anmälningar",
@@ -166,7 +167,8 @@
         "transferRegistration": "Flytta anmälan",
         "confirmRegistration": "Bekräfta anmälan",
         "notFound": "Sidan hittades inte",
-        "expiredLoginLink": "Länken gäller inte längre"
+        "expiredLoginLink": "Länken gäller inte längre",
+        "customerSearch": "Asiakashaku"
       },
       "previous": "Tidigare"
     }

--- a/frontend/packages/yki/src/components/layouts/clerkHeader/ClerkNavigationLinks.tsx
+++ b/frontend/packages/yki/src/components/layouts/clerkHeader/ClerkNavigationLinks.tsx
@@ -9,6 +9,8 @@ const getTabForPath = (path: string) => {
     return 'registration';
   } else if (path.includes(AppRoutes.ClerkFreeRegistration)) {
     return 'freeRegistration';
+  } else if (path.includes(AppRoutes.CustomerSearch)) {
+    return 'customerSearch';
   } else {
     return false;
   }
@@ -33,6 +35,11 @@ export const ClerkNavigationLinks = () => {
           active: getTabForPath(pathname) === 'freeRegistration',
           href: AppRoutes.ClerkFreeRegistration,
           label: translateCommon('freeRegistration'),
+        },
+        {
+          active: getTabForPath(pathname) === 'customerSearch',
+          href: AppRoutes.CustomerSearch,
+          label: translateCommon('customerSearch'),
         },
       ]}
     />

--- a/frontend/packages/yki/src/enums/app.ts
+++ b/frontend/packages/yki/src/enums/app.ts
@@ -21,6 +21,7 @@ export enum AppRoutes {
   ExpiredLoginLinkPage = '/yki/linkki-vanhentunut/:code',
   NotFoundPage = '*',
   ClerkRoot = '/yki/v2/virkailija',
+  CustomerSearch = '/yki/v2/virkailija/asiakashaku',
   ClerkOrganizerRegister = '/yki/v2/virkailija/jarjestajarekisteri',
   ClerkFreeRegistration = '/yki/v2/virkailija/maksuttomuus',
   ClerkFreeRegistrationDetails = '/yki/v2/virkailija/maksuttomuus/:id',

--- a/frontend/packages/yki/src/pages/clerk/ClerkCustomerSearchPage.tsx
+++ b/frontend/packages/yki/src/pages/clerk/ClerkCustomerSearchPage.tsx
@@ -1,0 +1,9 @@
+import { FC } from 'react';
+
+export const ClerkCustomerSearchPage: FC = () => {
+  return (
+    <>
+      <h2>Asiakashaku</h2>
+    </>
+  );
+};

--- a/frontend/packages/yki/src/routers/AppRouter.tsx
+++ b/frontend/packages/yki/src/routers/AppRouter.tsx
@@ -30,6 +30,7 @@ import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes, RegistrationKind } from 'enums/app';
 import { useAPIErrorToast } from 'hooks/useAPIErrorToast';
 import { AccessibilityStatementPage } from 'pages/AccessibilityStatementPage';
+import { ClerkCustomerSearchPage } from 'pages/clerk/ClerkCustomerSearchPage';
 import { ClerkFreeRegistrationDetailsPage } from 'pages/clerk/ClerkFreeRegistrationDetailsPage';
 import { ClerkFreeRegistrationPage } from 'pages/clerk/ClerkFreeRegistrationPage';
 import { ClerkHomePage } from 'pages/clerk/ClerkHomePage';
@@ -180,6 +181,14 @@ export const AppRouter: FC = () => {
             element={
               <YkiTitlePage title="clerk">
                 <ClerkFreeRegistrationDetailsPage />
+              </YkiTitlePage>
+            }
+          />
+          <Route
+            path={AppRoutes.CustomerSearch}
+            element={
+              <YkiTitlePage title="customerSearch">
+                <ClerkCustomerSearchPage />
               </YkiTitlePage>
             }
           />

--- a/frontend/packages/yki/src/tests/cypress/integration/customerSearch/customer_search_page.spec.ts
+++ b/frontend/packages/yki/src/tests/cypress/integration/customerSearch/customer_search_page.spec.ts
@@ -1,0 +1,9 @@
+describe('CustomerSearchPage', () => {
+  beforeEach(() => {
+    cy.openCustomerSearchPage();
+  });
+
+  it('is visible', () => {
+    cy.findByRole('heading', { name: 'Asiakashaku' }).should('be.visible');
+  });
+});

--- a/frontend/packages/yki/src/tests/cypress/support/commands.ts
+++ b/frontend/packages/yki/src/tests/cypress/support/commands.ts
@@ -50,3 +50,7 @@ Cypress.Commands.add('openClerkFreeRegistrationPage', (cookies) => {
 Cypress.Commands.add('openClerkFreeRegistrationDetailsPage', (id: number) => {
   cy.visit(AppRoutes.ClerkFreeRegistrationDetails.replace(/:id/, `${id}`));
 });
+
+Cypress.Commands.add('openCustomerSearchPage', () => {
+  cy.visit(AppRoutes.CustomerSearch);
+});

--- a/frontend/packages/yki/src/tests/cypress/support/types/index.d.ts
+++ b/frontend/packages/yki/src/tests/cypress/support/types/index.d.ts
@@ -13,6 +13,7 @@ declare global {
       openClerkRegistrationPage(): void;
       openClerkFreeRegistrationPage(cookie?: Record<string, string>): void;
       openClerkFreeRegistrationDetailsPage(id: number): void;
+      openCustomerSearchPage(): void;
     }
   }
 }


### PR DESCRIPTION
## Yhteenveto

Lisätty headeriin uusi välilehti, asiakashaku. Tällä hetkellä palauttaa vain tyhjän sivun. 

<img width="948" height="484" alt="image" src="https://github.com/user-attachments/assets/f06b2a4e-a8d3-4e5c-a688-1ba5b9b7da3c" />

## Lisätiedot

_Tehdyt muutokset..._

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
