### PR TITLE
OPHKIOS-239: YKI ajastin

### DIFF
--- a/frontend/packages/yki/package.json
+++ b/frontend/packages/yki/package.json
@@ -19,6 +19,7 @@
     "yki:lint": "yarn yki:eslint && yarn yki:tslint && yarn yki:stylelint && yarn yki:exportlint",
     "yki:qa": "yarn yki:lint && yarn yki:format && yarn yki:test:jest && yarn yki:start:ci",
     "yki:start": "yarn g:webpack serve --config webpack.config.js --env proxy=http://localhost:8080",
+    "yki:start:msw": "yarn g:webpack serve --config webpack.config.js",
     "yki:clerk:clerk": "yarn g:webpack serve --config webpack.config.js --env proxy=http://localhost:8083",
     "yki:clerk:start:msw": "yarn g:webpack serve --env goal=yki-clerk --config webpack.config.js",
     "yki:start:ci": "yarn g:webpack serve --env cypress --env prod --config webpack.config.js --no-open --no-client-overlay",

--- a/frontend/packages/yki/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/public.json
@@ -397,7 +397,7 @@
         },
         "expirationTimer": {
           "reservationExpired": "Anmälan misslyckades",
-          "reservationExpiredContinue": "Gå tillbaka till förstasidan",
+          "reservationExpiredContinue": "Gå tillbaka till startsidan",
           "reservationExpiredText": "Tiden tog slut och platsen på examenstillfället är inte längre reserverad. Om du vill anmäla dig till YKI-examen ska du gå tillbaka till förstasidan och påbörja anmälan på nytt.",
           "reservationExpiresIn": "Reservationen av din plats på examenstillfället löper ut: {{minutes}}:{{seconds}}"
         },

--- a/frontend/packages/yki/src/components/registration/PublicRegistrationControlButtons.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicRegistrationControlButtons.tsx
@@ -1,12 +1,16 @@
+import { useCallback, useState } from 'react';
 import {
   CustomButton,
   CustomButtonLink,
   LoadingProgressIndicator,
+  StackableMobileAppBar,
   Text,
 } from 'shared/components';
 import { APIResponseStatus, Color, Severity, Variant } from 'shared/enums';
-import { useDialog } from 'shared/hooks';
+import { useDialog, useWindowProperties } from 'shared/hooks';
+import { MobileAppBarState } from 'shared/interfaces';
 
+import { MemoizedPublicRegistrationTimer } from 'components/registration/PublicRegistrationTimer';
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { AppRoutes } from 'enums/app';
@@ -65,6 +69,7 @@ const SubmitButton = () => {
   const { showDialog } = useDialog();
   const dispatch = useAppDispatch();
   const getRegistrationErrors = usePublicRegistrationErrors(true);
+  const { isPhone } = useWindowProperties();
 
   const isSubmitInProgress =
     submitRegistrationStatus === APIResponseStatus.InProgress;
@@ -114,7 +119,7 @@ const SubmitButton = () => {
         className="margin-top-lg"
         disabled={isSubmitInProgress}
         size="large"
-        sx={{ width: '30rem', padding: '15px 22px' }}
+        sx={!isPhone ? { width: '30rem', padding: '15px 22px' } : {}}
         variant={Variant.Contained}
         color={Color.Secondary}
         onClick={handleSubmitBtnClick}
@@ -127,15 +132,18 @@ const SubmitButton = () => {
 };
 
 export const PublicRegistrationControlButtons = () => {
+  const [appBarState, setAppBarState] = useState<MobileAppBarState>({});
   const emailLinkOrderStatus = useAppSelector(publicIdentificationSelector)
     .emailLinkOrder.status;
   const {
     activeStep,
+    initRegistration: { expiresIn },
     submitRegistration: {
       status: submitRegistrationStatus,
       error: submitRegistrationError,
     },
   } = useAppSelector(registrationSelector);
+  const { isPhone } = useWindowProperties();
 
   const unrecoverableError =
     submitRegistrationError &&
@@ -155,8 +163,44 @@ export const PublicRegistrationControlButtons = () => {
     submitRegistrationStatus !== APIResponseStatus.Success &&
     !unrecoverableError;
 
+  const memoizedSetAppBarState = useCallback(
+    (order: number, height: number) =>
+      setAppBarState((prev) => ({
+        ...prev,
+        [order]: height,
+      })),
+    [],
+  );
+
   if (renderAbort || renderSubmit) {
-    return (
+    return isPhone ? (
+      <>
+        <StackableMobileAppBar
+          order={1}
+          state={appBarState}
+          setState={memoizedSetAppBarState}
+        >
+          <div className="rows" style={{ width: '100%' }}>
+            {expiresIn &&
+              activeStep === PublicRegistrationFormStep.Register && (
+                <MemoizedPublicRegistrationTimer expiresIn={expiresIn} />
+              )}
+          </div>
+        </StackableMobileAppBar>
+        <StackableMobileAppBar
+          order={2}
+          state={appBarState}
+          setState={memoizedSetAppBarState}
+        >
+          <div className="rows" style={{ width: '100%' }}>
+            <div className="columns margin-top-lg space-between">
+              {renderAbort && <AbortButton />}
+              {renderSubmit && <SubmitButton />}
+            </div>
+          </div>
+        </StackableMobileAppBar>
+      </>
+    ) : (
       <div className="columns margin-top-lg justify-content-center">
         <div className="rows flex-end gapped margin-top-lg align-items-center">
           {renderSubmit && <SubmitButton />}

--- a/frontend/packages/yki/src/components/registration/PublicRegistrationGrid.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicRegistrationGrid.tsx
@@ -15,6 +15,7 @@ import { PublicRegistrationControlButtons } from 'components/registration/Public
 import { PublicRegistrationExamSessionDetails } from 'components/registration/PublicRegistrationExamSessionDetails';
 import { PublicRegistrationStepContents } from 'components/registration/PublicRegistrationStepContents';
 import { PublicRegistrationStepper } from 'components/registration/PublicRegistrationStepper';
+import { MemoizedPublicRegistrationTimer } from 'components/registration/PublicRegistrationTimer';
 import { useCommonTranslation, usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { PaymentStatus } from 'enums/api';
@@ -197,10 +198,12 @@ const Heading = () => {
 
 export const PublicRegistrationGrid = () => {
   const { status: examSessionStatus } = useAppSelector(examSessionSelector);
+  const { activeStep } = useAppSelector(registrationSelector);
+  const { status: initRegistrationStatus, expiresIn } =
+    useAppSelector(registrationSelector).initRegistration;
+
   const stepHeading = <Heading />;
-
   const isLoading = examSessionStatus === APIResponseStatus.InProgress;
-
   const { isPhone } = useWindowProperties();
 
   return (
@@ -215,8 +218,18 @@ export const PublicRegistrationGrid = () => {
           <div className="rows gapped-xxl">
             <PublicRegistrationStepper />
             <div className="rows public-registration__grid__heading">
-              <H1>{stepHeading}</H1>
-              <HeaderSeparator />
+              <div className="rows">
+                <div className="columns space-between align-items-start">
+                  <H1>{stepHeading}</H1>
+                  {!isPhone &&
+                    initRegistrationStatus === APIResponseStatus.Success &&
+                    expiresIn &&
+                    activeStep === PublicRegistrationFormStep.Register && (
+                      <MemoizedPublicRegistrationTimer expiresIn={expiresIn} />
+                    )}
+                </div>
+                <HeaderSeparator />
+              </div>
             </div>
           </div>
           <Paper elevation={isPhone ? 0 : 3}>

--- a/frontend/packages/yki/src/components/registration/PublicRegistrationTimer.tsx
+++ b/frontend/packages/yki/src/components/registration/PublicRegistrationTimer.tsx
@@ -1,0 +1,122 @@
+import { Box, LinearProgress } from '@mui/material';
+import { memo, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { CustomButton, CustomModal, Text } from 'shared/components';
+import { Color, Variant } from 'shared/enums';
+
+import { usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch } from 'configs/redux';
+import { AppRoutes } from 'enums/app';
+import { useInterval } from 'hooks/useInterval';
+import { setHasTimerExpired } from 'redux/reducers/registration';
+
+const TOTAL_RESERVATION_TIME = 30 * 60 * 1000;
+let expirationTime: number;
+
+const calcProgress = (total: number) => (expiresIn: number) => {
+  const millisecondsDiff = Math.max(0, expiresIn);
+  const minutes = Math.floor(millisecondsDiff / 60000);
+  const seconds = Math.floor((millisecondsDiff % 60000) / 1000);
+
+  return {
+    value: Math.floor((millisecondsDiff / total) * 100),
+    seconds: String(seconds).padStart(2, '0'),
+    minutes: String(minutes).padStart(2, '0'),
+    millisecondsDiff,
+  };
+};
+
+const calcProgressWithTotal = calcProgress(TOTAL_RESERVATION_TIME);
+
+const getTimeRemaning = (expiresIn: number) => {
+  const newExpirationTime = Date.now() + expiresIn;
+  // Changing e.g. the app language re-renders the timer and resets inital state
+  // use the expirationTime that was set when the file was first loadded unless
+  // the backend provides expiresIn value less than previously recorded
+  if (expirationTime && expirationTime < newExpirationTime) {
+    return expirationTime - Date.now();
+  }
+
+  expirationTime = newExpirationTime;
+
+  return newExpirationTime - Date.now();
+};
+
+const PublicRegistrationTimer = ({ expiresIn }: { expiresIn: number }) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.registration.expirationTimer',
+  });
+
+  const [progress, setProgress] = useState(() => {
+    const timeRemaning = getTimeRemaning(expiresIn * 1000);
+
+    return calcProgressWithTotal(timeRemaning);
+  });
+
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  const updateProgress = () =>
+    setProgress(() => {
+      const delta = Math.floor(expirationTime - Date.now());
+
+      return calcProgressWithTotal(delta);
+    });
+
+  useInterval(updateProgress, 1000);
+
+  const isExpired = progress.millisecondsDiff <= 0;
+
+  useEffect(() => {
+    if (isExpired) {
+      dispatch(setHasTimerExpired(true));
+    }
+  }, [isExpired, dispatch]);
+
+  return (
+    <Box className="public-registration__grid__progress-container">
+      <div
+        data-testid="public-registration__reservation-timer-text"
+        className="public-registration__grid__progress-text"
+      >
+        {t('reservationExpiresIn', {
+          minutes: progress.minutes,
+          seconds: progress.seconds,
+        })}
+      </div>
+      <LinearProgress
+        className="public-registration__grid__timer-progressbar"
+        variant="determinate"
+        value={progress.value}
+        aria-hidden={true}
+      />
+      <CustomModal
+        data-testid="public-registration__reservation-expired-modal"
+        className="public-registration__renew-reservation-modal"
+        open={isExpired}
+        onCloseModal={() => {}}
+        aria-labelledby="expired-modal-title"
+        aria-describedby="expired-modal-description"
+        modalTitle={t('reservationExpired')}
+      >
+        <>
+          <Text id="expired-modal-description">
+            {t('reservationExpiredText')}
+          </Text>
+          <div className="columns gapped flex-end">
+            <CustomButton
+              data-testid="public-registration__reservation-expired-ok-button"
+              variant={Variant.Text}
+              color={Color.Secondary}
+              onClick={() => navigate(AppRoutes.Registration)}
+            >
+              {t('reservationExpiredContinue')}
+            </CustomButton>
+          </div>
+        </>
+      </CustomModal>
+    </Box>
+  );
+};
+
+export const MemoizedPublicRegistrationTimer = memo(PublicRegistrationTimer);

--- a/frontend/packages/yki/src/components/registration/steps/register/SubmitRegistrationDetails.tsx
+++ b/frontend/packages/yki/src/components/registration/steps/register/SubmitRegistrationDetails.tsx
@@ -202,8 +202,9 @@ const Success = () => {
 
 export const SubmitRegistrationDetails = () => {
   const { status } = useAppSelector(registrationSelector).submitRegistration;
+  const { hasTimerExpired } = useAppSelector(registrationSelector);
   useRegistrationNavigationProtection(
-    status !== APIResponseStatus.Success,
+    !hasTimerExpired && status !== APIResponseStatus.Success,
     <DialogContents />,
   );
 

--- a/frontend/packages/yki/src/hooks/useInterval.ts
+++ b/frontend/packages/yki/src/hooks/useInterval.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+
+export const useInterval = (callback: () => void, delay: number | null) => {
+  const savedCallback = useRef<() => void>();
+  savedCallback.current = callback;
+
+  useEffect(() => {
+    if (delay !== null) {
+      const id = setInterval(() => {
+        if (savedCallback.current) {
+          savedCallback.current();
+        }
+      }, delay);
+
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+};

--- a/frontend/packages/yki/src/interfaces/publicRegistration.ts
+++ b/frontend/packages/yki/src/interfaces/publicRegistration.ts
@@ -72,6 +72,7 @@ export interface PublicRegistrationInitResponse {
   };
   is_strongly_identified: boolean;
   registration_kind: RegistrationKind;
+  expires_in?: number;
 }
 
 interface OtherExamSessionRegistration {

--- a/frontend/packages/yki/src/redux/reducers/registration.ts
+++ b/frontend/packages/yki/src/redux/reducers/registration.ts
@@ -25,6 +25,7 @@ export interface RegistrationState {
     error?: PublicRegistrationInitErrorState;
     examSessionId?: number;
     registrationKind?: RegistrationKind;
+    expiresIn?: number;
   };
   submitRegistration: {
     code?: string;
@@ -41,6 +42,7 @@ export interface RegistrationState {
   registration: Partial<PublicSuomiFiRegistration | PublicEmailRegistration>;
   activeStep: PublicRegistrationFormStep;
   showErrors: boolean;
+  hasTimerExpired: boolean;
 }
 
 export const initialState: RegistrationState = {
@@ -58,6 +60,7 @@ export const initialState: RegistrationState = {
     termsAndConditionsAgreed: false,
   },
   showErrors: false,
+  hasTimerExpired: false,
 };
 
 const registrationSlice = createSlice({
@@ -124,6 +127,8 @@ const registrationSlice = createSlice({
       action: PayloadAction<PublicRegistrationInitResponse>,
     ) {
       state.initRegistration.status = APIResponseStatus.Success;
+      state.initRegistration.expiresIn = action.payload?.expires_in;
+
       const {
         registration_id,
         is_strongly_identified,
@@ -219,6 +224,9 @@ const registrationSlice = createSlice({
     rejectCancelRegistration(state) {
       state.cancelRegistration.status = APIResponseStatus.Error;
     },
+    setHasTimerExpired(state, action: PayloadAction<boolean>) {
+      state.hasTimerExpired = action.payload;
+    },
     identifyRegistration(
       state,
       action: PayloadAction<PublicRegistrationInitPayload>,
@@ -247,4 +255,5 @@ export const {
   acceptCancelRegistration,
   rejectCancelRegistration,
   identifyRegistration,
+  setHasTimerExpired,
 } = registrationSlice.actions;

--- a/frontend/packages/yki/src/styles/components/registration/_mobile-app-bar.scss
+++ b/frontend/packages/yki/src/styles/components/registration/_mobile-app-bar.scss
@@ -1,0 +1,11 @@
+.mobile {
+  & &-app-bar {
+    @include app-bar-bottom;
+
+    &__tool-bar {
+      button {
+        margin: 0;
+      }
+    }
+  }
+}

--- a/frontend/packages/yki/src/styles/components/registration/_public-registration.scss
+++ b/frontend/packages/yki/src/styles/components/registration/_public-registration.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 .public-registration {
   & &__grid {
     &__no-stepper {
@@ -92,6 +94,27 @@
       @include phone {
         max-width: 100%;
       }
+    }
+
+    &__timer-progressbar {
+      background-color: color.adjust($color-secondary, $alpha: -0.7);
+
+      & span {
+        background-color: $color-secondary;
+      }
+    }
+
+    &__progress-container {
+      max-width: 38rem;
+
+      @include phone {
+        margin: 0;
+      }
+    }
+
+    &__progress-text {
+      font-size: 1.8em;
+      margin: 0 0 0.5em;
     }
   }
 

--- a/frontend/packages/yki/src/styles/styles.scss
+++ b/frontend/packages/yki/src/styles/styles.scss
@@ -15,6 +15,7 @@
 @import 'components/registration/exam-session-filters';
 @import 'components/registration/exam-session-listing';
 @import 'components/registration/public-registration';
+@import 'components/registration/mobile-app-bar';
 @import 'components/userDetails/cancel-registration-modal';
 @import 'components/freeRegistration/free-registration';
 @import 'components/freeRegistrationListing/free-registration-listing';

--- a/frontend/packages/yki/src/tests/cypress/integration/public/public_registration_page.spec.ts
+++ b/frontend/packages/yki/src/tests/cypress/integration/public/public_registration_page.spec.ts
@@ -183,7 +183,7 @@ describe('PublicRegistrationPage', () => {
       cy.get('.MuiButton-contained').click();
       onPublicRegistrationPage.expectReservationTimerText(
         true,
-        'Paikkavarauksesi tutkintoon umpeutuu: 30:00',
+        'Paikkavarauksesi YKI-testiin umpeutuu: 30:00',
       );
     });
 

--- a/frontend/packages/yki/src/tests/cypress/integration/public/public_registration_page.spec.ts
+++ b/frontend/packages/yki/src/tests/cypress/integration/public/public_registration_page.spec.ts
@@ -164,4 +164,47 @@ describe('PublicRegistrationPage', () => {
       worker.start();
     });
   });
+
+  describe('when registering for an exam on Desktop', () => {
+    it('shows timer with time remaining when type is ADMISSION', () => {
+      onPublicRegistrationPage.selectExamLanguage('kaikki kielet');
+      onPublicRegistrationPage.selectExamLevel('kaikki tasot');
+      onPublicRegistrationPage.toggleShowOnlyIfAvailablePlaces();
+      onPublicRegistrationPage.toggleShowOnlyIfOngoingAdmission();
+      onPublicRegistrationPage.search();
+
+      onPublicRegistrationPage
+        .getResultRowsNth(1)
+        .findByRole('button', { name: /Ilmoittaudu/ })
+        .click();
+
+      onInitRegistrationPage.expectTitle('Tunnistaudu ilmoittautumista varten');
+
+      cy.get('.MuiButton-contained').click();
+      onPublicRegistrationPage.expectReservationTimerText(
+        true,
+        'Paikkavarauksesi tutkintoon umpeutuu: 30:00',
+      );
+    });
+
+    it('no timer is shown when type is QUEUE', () => {
+      onPublicRegistrationPage.selectExamLanguage('kaikki kielet');
+      onPublicRegistrationPage.selectExamLevel('kaikki tasot');
+      onPublicRegistrationPage.toggleShowOnlyIfAvailablePlaces();
+      onPublicRegistrationPage.toggleShowOnlyIfOngoingAdmission();
+      onPublicRegistrationPage.search();
+
+      onPublicRegistrationPage
+        .getResultRowsNth(0)
+        .findByRole('button', { name: /Ilmoittaudu/ })
+        .click();
+
+      onInitRegistrationPage.expectTitle(
+        'Tunnistaudu jonoon ilmoittautumista varten',
+      );
+
+      cy.get('.MuiButton-contained').click();
+      onPublicRegistrationPage.expectReservationTimerText(false);
+    });
+  });
 });

--- a/frontend/packages/yki/src/tests/cypress/integration/public/public_registration_page_mobile.spec.ts
+++ b/frontend/packages/yki/src/tests/cypress/integration/public/public_registration_page_mobile.spec.ts
@@ -26,7 +26,7 @@ describe('PublicRegistrationPage', () => {
       cy.get('.MuiButton-contained').click();
       onPublicRegistrationPage.expectReservationTimerText(
         true,
-        'Paikkavarauksesi tutkintoon umpeutuu: 30:00',
+        'Paikkavarauksesi YKI-testiin umpeutuu: 30:00',
       );
     });
 
@@ -47,14 +47,14 @@ describe('PublicRegistrationPage', () => {
       cy.get('.MuiButton-contained').click();
       onPublicRegistrationPage.expectReservationTimerText(
         true,
-        'Paikkavarauksesi tutkintoon umpeutuu: 30:00',
+        'Paikkavarauksesi YKI-testiin umpeutuu: 30:00',
       );
       cy.clock().tick(30 * 60 * 1000); // Advance time by 30 minutes
 
       cy.findByTestId('public-registration__reservation-expired-modal').should(
         'be.visible',
       );
-      cy.findByRole('button', { name: 'Jatka etusivulle' }).click();
+      cy.findByRole('button', { name: 'Palaa aloitussivulle' }).click();
       cy.url().should('eq', Cypress.config().baseUrl + '/yki/ilmoittautuminen');
     });
   });

--- a/frontend/packages/yki/src/tests/cypress/integration/public/public_registration_page_mobile.spec.ts
+++ b/frontend/packages/yki/src/tests/cypress/integration/public/public_registration_page_mobile.spec.ts
@@ -1,0 +1,61 @@
+import { onInitRegistrationPage } from 'tests/cypress/support/page-objects/initRegistrationPage';
+import { onPublicRegistrationPage } from 'tests/cypress/support/page-objects/publicRegistrationPage';
+
+describe('PublicRegistrationPage', () => {
+  beforeEach(() => {
+    cy.viewport('iphone-x');
+    cy.openPublicRegistrationPage();
+    cy.findByRole('button', { name: 'Hae' }).should('not.be.disabled');
+  });
+
+  describe('when registering for an exam on Mobile', () => {
+    it('shows timer with time remaining', () => {
+      onPublicRegistrationPage.selectExamLanguage('kaikki kielet', true);
+      onPublicRegistrationPage.selectExamLevel('kaikki tasot', true);
+      onPublicRegistrationPage.toggleShowOnlyIfAvailablePlaces();
+      onPublicRegistrationPage.toggleShowOnlyIfOngoingAdmission();
+      onPublicRegistrationPage.search();
+
+      onPublicRegistrationPage
+        .getResultRowsNth(1)
+        .findByRole('button', { name: /Ilmoittaudu/ })
+        .click();
+
+      onInitRegistrationPage.expectTitle('Tunnistaudu ilmoittautumista varten');
+
+      cy.get('.MuiButton-contained').click();
+      onPublicRegistrationPage.expectReservationTimerText(
+        true,
+        'Paikkavarauksesi tutkintoon umpeutuu: 30:00',
+      );
+    });
+
+    it('displays reservation expired modal when reservation expires and allows navigation to frontpage', () => {
+      onPublicRegistrationPage.selectExamLanguage('kaikki kielet', true);
+      onPublicRegistrationPage.selectExamLevel('kaikki tasot', true);
+      onPublicRegistrationPage.toggleShowOnlyIfAvailablePlaces();
+      onPublicRegistrationPage.toggleShowOnlyIfOngoingAdmission();
+      onPublicRegistrationPage.search();
+
+      onPublicRegistrationPage
+        .getResultRowsNth(1)
+        .findByRole('button', { name: /Ilmoittaudu/ })
+        .click();
+
+      onInitRegistrationPage.expectTitle('Tunnistaudu ilmoittautumista varten');
+
+      cy.get('.MuiButton-contained').click();
+      onPublicRegistrationPage.expectReservationTimerText(
+        true,
+        'Paikkavarauksesi tutkintoon umpeutuu: 30:00',
+      );
+      cy.clock().tick(30 * 60 * 1000); // Advance time by 30 minutes
+
+      cy.findByTestId('public-registration__reservation-expired-modal').should(
+        'be.visible',
+      );
+      cy.findByRole('button', { name: 'Jatka etusivulle' }).click();
+      cy.url().should('eq', Cypress.config().baseUrl + '/yki/ilmoittautuminen');
+    });
+  });
+});

--- a/frontend/packages/yki/src/tests/cypress/support/page-objects/publicRegistrationPage.ts
+++ b/frontend/packages/yki/src/tests/cypress/support/page-objects/publicRegistrationPage.ts
@@ -8,11 +8,7 @@ class PublicRegistrationPage {
         : cy.findByRole('combobox', { name: /Valitse kieli/ }),
     filterByLevel: (isPhone: boolean = false) =>
       isPhone
-        ? cy
-            .findAllByRole('combobox')
-            .eq(1)
-            .should('be.visible')
-            .should('be.visible')
+        ? cy.findAllByRole('combobox').eq(1).should('be.visible')
         : cy.findByRole('combobox', { name: /Valitse taso/ }),
     resultBox: () =>
       cy.findByTestId('public-registration-page__grid-container__result-box'),

--- a/frontend/packages/yki/src/tests/cypress/support/page-objects/publicRegistrationPage.ts
+++ b/frontend/packages/yki/src/tests/cypress/support/page-objects/publicRegistrationPage.ts
@@ -2,9 +2,18 @@ import { selectComboBoxOptionByName } from 'tests/cypress/support/utils/comboBox
 
 class PublicRegistrationPage {
   elements = {
-    filterByLanguage: () =>
-      cy.findByRole('combobox', { name: /Valitse kieli/ }),
-    filterByLevel: () => cy.findByRole('combobox', { name: /Valitse taso/ }),
+    filterByLanguage: (isPhone: boolean = false) =>
+      isPhone
+        ? cy.findAllByRole('combobox').eq(0).should('be.visible')
+        : cy.findByRole('combobox', { name: /Valitse kieli/ }),
+    filterByLevel: (isPhone: boolean = false) =>
+      isPhone
+        ? cy
+            .findAllByRole('combobox')
+            .eq(1)
+            .should('be.visible')
+            .should('be.visible')
+        : cy.findByRole('combobox', { name: /Valitse taso/ }),
     resultBox: () =>
       cy.findByTestId('public-registration-page__grid-container__result-box'),
     showOnlyIfAvailablePlaces: () =>
@@ -53,12 +62,20 @@ class PublicRegistrationPage {
     this.elements.title().should('be.visible');
   }
 
-  selectExamLanguage(language: string) {
-    selectComboBoxOptionByName(this.elements.filterByLanguage(), language);
+  selectExamLanguage(language: string, isPhone: boolean = false) {
+    selectComboBoxOptionByName(
+      this.elements.filterByLanguage(isPhone),
+      language,
+      isPhone,
+    );
   }
 
-  selectExamLevel(level: string) {
-    selectComboBoxOptionByName(this.elements.filterByLevel(), level);
+  selectExamLevel(level: string, isPhone: boolean = false) {
+    selectComboBoxOptionByName(
+      this.elements.filterByLevel(isPhone),
+      level,
+      isPhone,
+    );
   }
 
   search() {
@@ -72,6 +89,17 @@ class PublicRegistrationPage {
 
   toggleShowOnlyIfOngoingAdmission() {
     this.elements.showOnlyIfOngoingAdmission().click();
+  }
+
+  expectReservationTimerText(visible, text?) {
+    visible
+      ? cy
+          .findByTestId('public-registration__reservation-timer-text')
+          .should('be.visible')
+          .and('have.text', text)
+      : cy
+          .findByTestId('public-registration__reservation-timer-text')
+          .should('not.exist');
   }
 }
 

--- a/frontend/packages/yki/src/tests/cypress/support/utils/comboBox.ts
+++ b/frontend/packages/yki/src/tests/cypress/support/utils/comboBox.ts
@@ -1,9 +1,16 @@
 export const selectComboBoxOptionByName = (
   comboBox: Cypress.Chainable,
   name: string,
+  isPhone: boolean = false,
 ) => {
   cy.wait(50);
-  comboBox.click();
-  cy.findByRole('option', { name }).scrollIntoView();
-  cy.findByRole('option', { name }).should('be.visible').click();
+  if (isPhone) {
+    // On mobile, the component renders as a native select
+    comboBox.select(name);
+  } else {
+    // On desktop, it's an autocomplete combobox
+    comboBox.click();
+    cy.findByRole('option', { name }).scrollIntoView();
+    cy.findByRole('option', { name }).should('be.visible').click();
+  }
 };

--- a/frontend/packages/yki/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/src/tests/msw/handlers.ts
@@ -78,6 +78,9 @@ const initRegistration = async ({
         exam_session_id % 2 === 0
           ? RegistrationKind.Admission
           : RegistrationKind.Queue;
+      const thirtyMinutesInSeconds = 1800;
+      const expires_in =
+        exam_session_id % 2 === 0 ? thirtyMinutesInSeconds : undefined;
 
       return HttpResponse.json(
         {
@@ -91,6 +94,7 @@ const initRegistration = async ({
           // return different registration kind (admission vs. queue)
           // based on the parity of registration id.
           registration_id: exam_session_id,
+          expires_in,
           ...rest,
         },
         /*exam_session_id % 2 === 0


### PR DESCRIPTION
## Yhteenveto

Lisätty ajastin deskari- ja mobiilinäkymiin tutkinnon rekisteröitymisvaiheeseen

Oletukset:

1. Normaali init, ajastin palauttaa 30min sekunteina
2. Refresh kun aikaa jäjellä, identiy palauttaa jäljellä olevan ajan sekunteina, joka alustaa ajastimen tällä uudella ajalla.
3. Aika on loppunut, refresh => idenity => antaa expires_in: 0 => TimerExpired modaali triggeröityy välittömästi ja tästä pääsee vain takaisin etusivulle


