### PR TITLE
OPHKIOS-278: YKI maksuttomien kertojen laskenta ilman Koski-tietoja

### DIFF
--- a/frontend/packages/yki/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/public/i18n/en-GB/public.json
@@ -446,6 +446,7 @@
             "freeAttemptsExhausted": "Olet käyttänyt kaikki ilmaiset kerrat.",
             "freeAttemptsLeft": "Sinulla on maksuttomia ilmoittautumisia jäljellä: <strong>{{amount}}</strong>.",
             "freeAttemptsOffered": "Voit ilmoittautua maksuttomasti kolme (3) kertaa.",
+            "freeAttemptsOfferedYKI": "Voit ilmoittautua YKI-testiin maksuttomasti kolme (3) kertaa.",
             "loading": {
               "checkingEligibility": "Tarkastamme täyttyvätkö maksuttomuuden ehdot kohdallasi.",
               "pleaseWait": "Tietoja ladataan, ole hyvä ja odota hetki."

--- a/frontend/packages/yki/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/public.json
@@ -446,6 +446,7 @@
             "freeAttemptsExhausted": "Olet käyttänyt kaikki ilmaiset kerrat.",
             "freeAttemptsLeft": "Sinulla on maksuttomia ilmoittautumisia jäljellä: <strong>{{amount}}</strong>.",
             "freeAttemptsOffered": "Voit ilmoittautua maksuttomasti kolme (3) kertaa.",
+            "freeAttemptsOfferedYKI": "Voit ilmoittautua YKI-testiin maksuttomasti kolme (3) kertaa.",
             "loading": {
               "checkingEligibility": "Tarkastamme täyttyvätkö maksuttomuuden ehdot kohdallasi.",
               "pleaseWait": "Tietoja ladataan, ole hyvä ja odota hetki."

--- a/frontend/packages/yki/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/public.json
@@ -446,6 +446,7 @@
             "freeAttemptsExhausted": "Olet käyttänyt kaikki ilmaiset kerrat.",
             "freeAttemptsLeft": "Sinulla on maksuttomia ilmoittautumisia jäljellä: <strong>{{amount}}</strong>.",
             "freeAttemptsOffered": "Voit ilmoittautua maksuttomasti kolme (3) kertaa.",
+            "freeAttemptsOfferedYKI": "Voit ilmoittautua YKI-testiin maksuttomasti kolme (3) kertaa.",
             "loading": {
               "checkingEligibility": "Tarkastamme täyttyvätkö maksuttomuuden ehdot kohdallasi.",
               "pleaseWait": "Tietoja ladataan, ole hyvä ja odota hetki."

--- a/frontend/packages/yki/src/components/registration/steps/register/ExamFee.tsx
+++ b/frontend/packages/yki/src/components/registration/steps/register/ExamFee.tsx
@@ -1,4 +1,6 @@
+import InfoFilledIcon from '@mui/icons-material/Info';
 import {
+  Container,
   FormControl,
   FormControlLabel,
   Radio,
@@ -7,7 +9,7 @@ import {
 import { useEffect, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { H2, H3, Text } from 'shared/components';
-import { APIResponseStatus } from 'shared/enums';
+import { APIResponseStatus, Color } from 'shared/enums';
 
 import { usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
@@ -35,8 +37,10 @@ const UserEducationSelection = () => {
   });
   const dispatch = useAppDispatch();
   const { showErrors } = useAppSelector(registrationSelector);
-  const { isFree } = useAppSelector(publicFreeRegistrationSelector);
-
+  const { isFree, attemptsUsed } = useAppSelector(
+    publicFreeRegistrationSelector,
+  );
+  const attemptsLeft = 3 - (attemptsUsed || 0);
   const [countryOfEducation, setCountryOfEducation] = useState<
     CountryOfStudies | undefined
   >(undefined);
@@ -148,6 +152,17 @@ const UserEducationSelection = () => {
       )}
       {isFree === 'YES' && (
         <>
+          <Container className="public-registration__info-box columns gapped-sm">
+            <InfoFilledIcon color={Color.Secondary} />
+            <Text>
+              {t('freeAttemptsOfferedYKI')}
+              <Trans
+                t={t}
+                i18nKey="freeAttemptsLeft"
+                values={{ amount: attemptsLeft }}
+              />
+            </Text>
+          </Container>
           <H3>{t('userSelection.randomChecksPerformed.heading')}</H3>
           <Text>
             {t('userSelection.randomChecksPerformed.part1')}{' '}


### PR DESCRIPTION
Toteutettu #913 päälle

<img width="1135" height="520" alt="Screenshot 2025-11-26 at 10 46 52" src="https://github.com/user-attachments/assets/85c690db-6060-4c5a-8af3-448e10404c27" />
