### PR TITLE
OPHKIOS-166: Clerk register part 2

### DIFF
--- a/frontend/packages/yki/public/i18n/en-GB/common.json
+++ b/frontend/packages/yki/public/i18n/en-GB/common.json
@@ -1,6 +1,7 @@
 {
   "yki": {
     "common": {
+      "and": "and",
       "actions": "Actions",
       "address": "Address",
       "appNameAbbreviation": "YKI",

--- a/frontend/packages/yki/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/public/i18n/en-GB/public.json
@@ -27,6 +27,12 @@
           "agreementExpired": "Sopimus vanhentunut",
           "errors": {
             "loadingFailed": "Järjestäjien hakeminen epäonnistui"
+          },
+          "contentLabels": {
+            "organizerAgreement": "Järjestäjäsopimus",
+            "languageProficiencies": "Kielitutkinnot",
+            "contactInfo": "Yhteystiedot",
+            "extraInfo": "Lisätiedot"
           }
         }
       },

--- a/frontend/packages/yki/public/i18n/fi-FI/common.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/common.json
@@ -1,6 +1,7 @@
 {
   "yki": {
     "common": {
+      "and": "ja",
       "actions": "Toiminnot",
       "address": "Osoite",
       "appNameAbbreviation": "YKI",

--- a/frontend/packages/yki/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/public/i18n/fi-FI/public.json
@@ -27,6 +27,12 @@
           "agreementExpired": "Sopimus vanhentunut",
           "errors": {
             "loadingFailed": "Järjestäjien hakeminen epäonnistui"
+          },
+          "contentLabels": {
+            "organizerAgreement": "Järjestäjäsopimus",
+            "languageProficiencies": "Kielitutkinnot",
+            "contactInfo": "Yhteystiedot",
+            "extraInfo": "Lisätiedot"
           }
         }
       },

--- a/frontend/packages/yki/public/i18n/sv-SE/common.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/common.json
@@ -1,6 +1,7 @@
 {
   "yki": {
     "common": {
+      "and": "och",
       "actions": "Funktioner",
       "address": "Adress",
       "appNameAbbreviation": "YKI",

--- a/frontend/packages/yki/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/public/i18n/sv-SE/public.json
@@ -27,6 +27,12 @@
           "agreementExpired": "Sopimus vanhentunut",
           "errors": {
             "loadingFailed": "Järjestäjien hakeminen epäonnistui"
+          },
+          "contentLabels": {
+            "organizerAgreement": "Järjestäjäsopimus",
+            "languageProficiencies": "Kielitutkinnot",
+            "contactInfo": "Yhteystiedot",
+            "extraInfo": "Lisätiedot"
           }
         }
       },

--- a/frontend/packages/yki/src/components/clerkRegister/listing/ClerkRegisterListing.tsx
+++ b/frontend/packages/yki/src/components/clerkRegister/listing/ClerkRegisterListing.tsx
@@ -1,3 +1,4 @@
+import { Error } from '@mui/icons-material';
 import { Collapse, TableCell, TableRow, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { Dayjs } from 'dayjs';
@@ -73,13 +74,14 @@ export const ClerkRegisterListing = ({
   ): ListTableColumn<ClerkOrganizerType> => ({
     key: 'agreements',
     title: t('header.agreements'),
-    render: (rowProps) => (
-      <span>
-        {rowProps.languages
-          ? languagesToString(rowProps.languages)
-          : t('agreementExpired')}
-      </span>
-    ),
+    render: (rowProps) =>
+      rowProps.languages ? (
+        <span>{languagesToString(rowProps.languages)}</span>
+      ) : (
+        <div className="columns" style={{ gap: '0.25rem' }}>
+          <Error color="error" fontSize="large" /> {t('agreementExpired')}
+        </div>
+      ),
   });
 
   const createMunicipalityColumn = (

--- a/frontend/packages/yki/src/components/clerkRegister/listing/ClerkRegisterListing.tsx
+++ b/frontend/packages/yki/src/components/clerkRegister/listing/ClerkRegisterListing.tsx
@@ -13,18 +13,23 @@ import i18next from 'i18next';
 import { useEffect } from 'react';
 import { CustomCircularProgress } from 'shared/components';
 import { APIResponseStatus, Color } from 'shared/enums';
+import { DateUtils } from 'shared/utils';
 
 import { ListTable } from 'components/oph-design/table/list-table';
 import { ListTableColumn } from 'components/oph-design/table/table-types';
 import { usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { OrganizerLanguage } from 'interfaces/clerkOrganizer';
+import { Label, Text } from 'ophTheme/Text';
 import { loadClerkOrganizers } from 'redux/reducers/clerkOrganizer';
 import {
   clerkOrganizersSelector,
   selectFilteredClerkOrganizers,
 } from 'redux/selectors/clerkOrganizers';
-import { languagesToString } from 'utils/clerk';
+import {
+  getLanguagesWithLevelDescriptions,
+  languagesToString,
+} from 'utils/clerk';
 
 type ClerkRegisterListingProps = {
   page: number;
@@ -158,20 +163,37 @@ const ClerkRegisterCollapsibleRow = ({
               display: 'flex',
               flexDirection: 'row',
               gap: '0.5rem',
+              justifyContent: 'space-between',
             }}
           >
-            <div className="columns">
-              <strong>Järjestäjäsopimus</strong>
-              {row.contact_name}
+            <div className="rows">
+              <Label>Järjestäjäsopimus</Label>
+              <Text>
+                {`${DateUtils.formatOptionalDate(
+                  row.agreement_start_date,
+                )} - ${DateUtils.formatOptionalDate(row.agreement_end_date)}`}
+              </Text>{' '}
             </div>
-            <div>
-              <strong>Kielitutkinnot:</strong> {row.contact_name}
+
+            <div className="rows">
+              <Label>Kielitutkinnot</Label>
+              {getLanguagesWithLevelDescriptions(row.languages || []).map(
+                (lang) => (
+                  <Text key={lang}>{lang}</Text>
+                ),
+              )}
             </div>
-            <div>
-              <strong>Yhteystiedot:</strong> {row.contact_phone_number}
+            <div className="rows">
+              <Label>Yhteystiedot</Label>
+              <Text>{row.contact_name}</Text>
+              <Text>{row.contact_phone_number}</Text>
+              <Text>
+                <a href={`mailto:${row.contact_email}`}>{row.contact_email}</a>
+              </Text>
             </div>
-            <div>
-              <strong>Lisätiedot:</strong> {row.extra}
+            <div className="rows">
+              <Label>Lisätiedot</Label>
+              <Text>{row.extra}</Text>
             </div>
           </div>
           <Table size="small" aria-label="purchases">

--- a/frontend/packages/yki/src/components/clerkRegister/listing/ClerkRegisterListing.tsx
+++ b/frontend/packages/yki/src/components/clerkRegister/listing/ClerkRegisterListing.tsx
@@ -1,12 +1,4 @@
-import {
-  Collapse,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  Typography,
-} from '@mui/material';
+import { Collapse, TableCell, TableRow, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { Dayjs } from 'dayjs';
 import i18next from 'i18next';
@@ -135,8 +127,8 @@ export const ClerkRegisterListing = ({
           columns={columns}
           translateHeader={false}
           pagination={pagination}
-          renderCollapsibleRow={(row, open) => (
-            <ClerkRegisterCollapsibleRow row={row} open={open} />
+          renderCollapsibleRow={(row, open, t) => (
+            <ClerkRegisterCollapsibleRow row={row} open={open} t={t} />
           )}
           collapsibleRows={true}
         />
@@ -147,9 +139,11 @@ export const ClerkRegisterListing = ({
 const ClerkRegisterCollapsibleRow = ({
   row,
   open,
+  t,
 }: {
   row: ClerkOrganizerType;
   open: boolean;
+  t: typeof i18next.t;
 }) => (
   <TableRow>
     <TableCell
@@ -167,7 +161,7 @@ const ClerkRegisterCollapsibleRow = ({
             }}
           >
             <div className="rows">
-              <Label>Järjestäjäsopimus</Label>
+              <Label>{t('organizerAgreement')}</Label>
               <Text>
                 {`${DateUtils.formatOptionalDate(
                   row.agreement_start_date,
@@ -176,7 +170,7 @@ const ClerkRegisterCollapsibleRow = ({
             </div>
 
             <div className="rows">
-              <Label>Kielitutkinnot</Label>
+              <Label>{t('languageProficiencies')}</Label>
               {getLanguagesWithLevelDescriptions(row.languages || []).map(
                 (lang) => (
                   <Text key={lang}>{lang}</Text>
@@ -184,7 +178,7 @@ const ClerkRegisterCollapsibleRow = ({
               )}
             </div>
             <div className="rows">
-              <Label>Yhteystiedot</Label>
+              <Label>{t('contactInfo')}</Label>
               <Text>{row.contact_name}</Text>
               <Text>{row.contact_phone_number}</Text>
               <Text>
@@ -192,30 +186,10 @@ const ClerkRegisterCollapsibleRow = ({
               </Text>
             </div>
             <div className="rows">
-              <Label>Lisätiedot</Label>
+              <Label>{t('extraInfo')}</Label>
               <Text>{row.extra}</Text>
             </div>
           </div>
-          <Table size="small" aria-label="purchases">
-            <TableHead>
-              <TableRow>
-                <TableCell>Date</TableCell>
-                <TableCell>Customer</TableCell>
-                <TableCell align="right">Amount</TableCell>
-                <TableCell align="right">Total price ($)</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              <TableRow key={row.oid}>
-                <TableCell component="th" scope="row">
-                  Hello
-                </TableCell>
-                <TableCell>Hullo</TableCell>
-                <TableCell align="right">12345</TableCell>
-                <TableCell align="right">100</TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
         </Box>
       </Collapse>
     </TableCell>

--- a/frontend/packages/yki/src/components/clerkRegister/listing/ClerkRegisterListing.tsx
+++ b/frontend/packages/yki/src/components/clerkRegister/listing/ClerkRegisterListing.tsx
@@ -31,6 +31,11 @@ export const ClerkRegisterListing = ({
   const filteredOrganizers = useAppSelector(selectFilteredClerkOrganizers);
   const rows = filteredOrganizers.map((organizer) => ({
     ...organizer,
+    collapsibleContent: {
+      name: organizer.contact_name,
+      email: organizer.contact_email,
+      phone: organizer.contact_phone_numner,
+    },
   }));
 
   const pagination = {

--- a/frontend/packages/yki/src/components/clerkRegister/listing/ClerkRegisterListing.tsx
+++ b/frontend/packages/yki/src/components/clerkRegister/listing/ClerkRegisterListing.tsx
@@ -1,4 +1,12 @@
-import { Typography } from '@mui/material';
+import {
+  Collapse,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
 import { Box } from '@mui/system';
 import { Dayjs } from 'dayjs';
 import i18next from 'i18next';
@@ -23,6 +31,18 @@ type ClerkRegisterListingProps = {
   setPage: (page: number) => void;
 };
 
+type ClerkOrganizerType = {
+  id: number;
+  oid: string;
+  agreement_start_date?: Dayjs;
+  agreement_end_date?: Dayjs;
+  contact_name?: string;
+  contact_email?: string;
+  contact_phone_number?: string;
+  languages: Array<OrganizerLanguage> | null;
+  extra: string;
+};
+
 export const ClerkRegisterListing = ({
   page,
   setPage,
@@ -31,11 +51,6 @@ export const ClerkRegisterListing = ({
   const filteredOrganizers = useAppSelector(selectFilteredClerkOrganizers);
   const rows = filteredOrganizers.map((organizer) => ({
     ...organizer,
-    collapsibleContent: {
-      name: organizer.contact_name,
-      email: organizer.contact_email,
-      phone: organizer.contact_phone_numner,
-    },
   }));
 
   const pagination = {
@@ -47,18 +62,6 @@ export const ClerkRegisterListing = ({
   const { t } = usePublicTranslation({
     keyPrefix: 'yki.component.clerkRegister.listing',
   });
-
-  type ClerkOrganizerType = {
-    id: number;
-    oid: string;
-    agreement_start_date?: Dayjs;
-    agreement_end_date?: Dayjs;
-    contact_name?: string;
-    contact_email?: string;
-    contact_phone_numner?: string;
-    languages: Array<OrganizerLanguage> | null;
-    extra: string;
-  };
 
   const createOrganizerColumn = (
     t: typeof i18next.t,
@@ -127,7 +130,72 @@ export const ClerkRegisterListing = ({
           columns={columns}
           translateHeader={false}
           pagination={pagination}
+          renderCollapsibleRow={(row, open) => (
+            <ClerkRegisterCollapsibleRow row={row} open={open} />
+          )}
+          collapsibleRows={true}
         />
       );
   }
 };
+
+const ClerkRegisterCollapsibleRow = ({
+  row,
+  open,
+}: {
+  row: ClerkOrganizerType;
+  open: boolean;
+}) => (
+  <TableRow>
+    <TableCell
+      style={{ height: 'unset', paddingTop: 0, paddingBottom: 0 }}
+      colSpan={3}
+    >
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <Box sx={{ margin: '1rem 4rem' }}>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              gap: '0.5rem',
+            }}
+          >
+            <div className="columns">
+              <strong>Järjestäjäsopimus</strong>
+              {row.contact_name}
+            </div>
+            <div>
+              <strong>Kielitutkinnot:</strong> {row.contact_name}
+            </div>
+            <div>
+              <strong>Yhteystiedot:</strong> {row.contact_phone_number}
+            </div>
+            <div>
+              <strong>Lisätiedot:</strong> {row.extra}
+            </div>
+          </div>
+          <Table size="small" aria-label="purchases">
+            <TableHead>
+              <TableRow>
+                <TableCell>Date</TableCell>
+                <TableCell>Customer</TableCell>
+                <TableCell align="right">Amount</TableCell>
+                <TableCell align="right">Total price ($)</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow key={row.oid}>
+                <TableCell component="th" scope="row">
+                  Hello
+                </TableCell>
+                <TableCell>Hullo</TableCell>
+                <TableCell align="right">12345</TableCell>
+                <TableCell align="right">100</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </Box>
+      </Collapse>
+    </TableCell>
+  </TableRow>
+);

--- a/frontend/packages/yki/src/components/oph-design/table/list-table-row.tsx
+++ b/frontend/packages/yki/src/components/oph-design/table/list-table-row.tsx
@@ -46,7 +46,7 @@ export const ListTableRow = <T extends Row>({
                 <ChevronLeft
                   fontSize="large"
                   style={{
-                    transform: open ? 'rotate(90deg)' : 'rotate(-90deg)',
+                    transform: open ? 'rotate(90deg)' : 'rotate(270deg)',
                     transition: 'transform 0.2s',
                     verticalAlign: 'middle',
                     marginRight: '0.5em',

--- a/frontend/packages/yki/src/components/oph-design/table/list-table-row.tsx
+++ b/frontend/packages/yki/src/components/oph-design/table/list-table-row.tsx
@@ -1,0 +1,63 @@
+import { ChevronLeft } from '@mui/icons-material';
+import { Collapse, TableCell, TableRow } from '@mui/material';
+import { PropsWithChildren, useState } from 'react';
+
+import { ListTableColumn, Row } from 'components/oph-design/table/table-types';
+
+type TableRowsProps<T extends Row> = PropsWithChildren<{
+  rowKeyProp: keyof T;
+  row: T;
+  columns: ListTableColumn<T>[];
+}>;
+
+export const ListTableRow = <T extends Row>({
+  rowKeyProp,
+  row,
+  columns,
+}: TableRowsProps<T>) => {
+  const [open, setOpen] = useState(false);
+
+  const rowId = row?.[rowKeyProp] as string;
+
+  return (
+    <>
+      <TableRow key={rowId}>
+        {columns.map(({ key: columnKey, render, style }, i) => {
+          return (
+            <TableCell
+              key={columnKey.toString()}
+              sx={style}
+              onClick={() => setOpen((prev) => !prev)}
+            >
+              {i === 0 && (
+                <ChevronLeft
+                  fontSize="large"
+                  style={{
+                    transform: open ? 'rotate(90deg)' : 'rotate(-90deg)',
+                    transition: 'transform 0.2s',
+                    verticalAlign: 'middle',
+                    marginRight: '0.5em',
+                  }}
+                />
+              )}
+              {render(row)}
+            </TableCell>
+          );
+        })}
+      </TableRow>
+      {row.collapsibleContent && (
+        <Collapse in={open} timeout="auto" unmountOnExit>
+          <TableRow key={`${rowId}-collapse`}>
+            {columns.map(({ key: columnKey, render, style }) => {
+              return (
+                <TableCell key={columnKey.toString()} sx={style}>
+                  {render(row)}
+                </TableCell>
+              );
+            })}
+          </TableRow>
+        </Collapse>
+      )}
+    </>
+  );
+};

--- a/frontend/packages/yki/src/components/oph-design/table/list-table-row.tsx
+++ b/frontend/packages/yki/src/components/oph-design/table/list-table-row.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft } from '@mui/icons-material';
-import { Collapse, TableCell, TableRow } from '@mui/material';
+import { TableCell, TableRow } from '@mui/material';
 import { PropsWithChildren, useState } from 'react';
 
 import { ListTableColumn, Row } from 'components/oph-design/table/table-types';
@@ -8,12 +8,16 @@ type TableRowsProps<T extends Row> = PropsWithChildren<{
   rowKeyProp: keyof T;
   row: T;
   columns: ListTableColumn<T>[];
+  collapsibleRows: boolean;
+  renderCollapsibleRow?: (row: T, open: boolean) => React.ReactNode;
 }>;
 
 export const ListTableRow = <T extends Row>({
   rowKeyProp,
   row,
   columns,
+  collapsibleRows,
+  renderCollapsibleRow,
 }: TableRowsProps<T>) => {
   const [open, setOpen] = useState(false);
 
@@ -29,7 +33,7 @@ export const ListTableRow = <T extends Row>({
               sx={style}
               onClick={() => setOpen((prev) => !prev)}
             >
-              {i === 0 && (
+              {collapsibleRows && i === 0 && (
                 <ChevronLeft
                   fontSize="large"
                   style={{
@@ -45,19 +49,9 @@ export const ListTableRow = <T extends Row>({
           );
         })}
       </TableRow>
-      {row.collapsibleContent && (
-        <Collapse in={open} timeout="auto" unmountOnExit>
-          <TableRow key={`${rowId}-collapse`}>
-            {columns.map(({ key: columnKey, render, style }) => {
-              return (
-                <TableCell key={columnKey.toString()} sx={style}>
-                  {render(row)}
-                </TableCell>
-              );
-            })}
-          </TableRow>
-        </Collapse>
-      )}
+      {collapsibleRows &&
+        renderCollapsibleRow &&
+        renderCollapsibleRow(row, open)}
     </>
   );
 };

--- a/frontend/packages/yki/src/components/oph-design/table/list-table-row.tsx
+++ b/frontend/packages/yki/src/components/oph-design/table/list-table-row.tsx
@@ -1,15 +1,21 @@
 import { ChevronLeft } from '@mui/icons-material';
 import { TableCell, TableRow } from '@mui/material';
+import i18next from 'i18next';
 import { PropsWithChildren, useState } from 'react';
 
 import { ListTableColumn, Row } from 'components/oph-design/table/table-types';
+import { usePublicTranslation } from 'configs/i18n';
 
 type TableRowsProps<T extends Row> = PropsWithChildren<{
   rowKeyProp: keyof T;
   row: T;
   columns: ListTableColumn<T>[];
   collapsibleRows: boolean;
-  renderCollapsibleRow?: (row: T, open: boolean) => React.ReactNode;
+  renderCollapsibleRow?: (
+    row: T,
+    open: boolean,
+    t: typeof i18next.t,
+  ) => React.ReactNode;
 }>;
 
 export const ListTableRow = <T extends Row>({
@@ -19,6 +25,9 @@ export const ListTableRow = <T extends Row>({
   collapsibleRows,
   renderCollapsibleRow,
 }: TableRowsProps<T>) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.clerkRegister.listing.contentLabels',
+  });
   const [open, setOpen] = useState(false);
 
   const rowId = row?.[rowKeyProp] as string;
@@ -51,7 +60,7 @@ export const ListTableRow = <T extends Row>({
       </TableRow>
       {collapsibleRows &&
         renderCollapsibleRow &&
-        renderCollapsibleRow(row, open)}
+        renderCollapsibleRow(row, open, t)}
     </>
   );
 };

--- a/frontend/packages/yki/src/components/oph-design/table/list-table.tsx
+++ b/frontend/packages/yki/src/components/oph-design/table/list-table.tsx
@@ -11,6 +11,7 @@ import {
 import { styled as muiStyled } from '@mui/material/styles';
 import { shouldForwardProp } from '@mui/system/createStyled';
 import { ophColors } from '@opetushallitus/oph-design-system';
+import i18next from 'i18next';
 import React, { useMemo } from 'react';
 
 import { OphPagination } from './oph-pagination';
@@ -123,7 +124,11 @@ interface ListTableProps<T extends Row>
   selection?: SelectionProps['selection'];
   setSelection?: SelectionProps['setSelection'];
   collapsibleRows?: boolean;
-  renderCollapsibleRow?: (row: T, open: boolean) => React.ReactNode;
+  renderCollapsibleRow?: (
+    row: T,
+    open: boolean,
+    t: typeof i18next.t,
+  ) => React.ReactNode;
 }
 
 const TableWrapper = styled(Box)(({ theme }) => ({

--- a/frontend/packages/yki/src/components/oph-design/table/list-table.tsx
+++ b/frontend/packages/yki/src/components/oph-design/table/list-table.tsx
@@ -51,32 +51,57 @@ const StyledTable = styled(Table)({
   },
 });
 
-const StyledTableBody = styled(TableBody)(({ theme }) => ({
-  '& .MuiTableCell-root': {
-    padding: theme.spacing(1, 0, 1, 2),
-    textAlign: 'left',
-    whiteSpace: 'pre-wrap',
-    height: '64px',
-    borderWidth: 0,
-  },
-  '& .MuiTableRow-root': {
-    '&:nth-of-type(even)': {
-      '.MuiTableCell-root': {
-        backgroundColor: ophColors.grey50,
-      },
+const StyledTableBody = styled(TableBody)<{ collapsibleRows?: boolean }>(
+  ({ theme, collapsibleRows }) => ({
+    '& .MuiTableCell-root': {
+      padding: theme.spacing(1, 0, 1, 2),
+      textAlign: 'left',
+      whiteSpace: 'pre-wrap',
+      height: '64px',
+      borderWidth: 0,
     },
-    '&:nth-of-type(odd)': {
-      '.MuiTableCell-root': {
-        backgroundColor: ophColors.white,
-      },
+    '& .MuiTableRow-root': {
+      ...(collapsibleRows
+        ? {
+            '&:nth-of-type(4n - 1)': {
+              '.MuiTableCell-root': {
+                backgroundColor: ophColors.grey50,
+              },
+            },
+            '&:nth-of-type(even)': {
+              '.MuiTableCell-root': {
+                backgroundColor: ophColors.white,
+              },
+            },
+            '&:nth-of-type(odd)': {
+              '&:hover': {
+                '.MuiTableCell-root': {
+                  backgroundColor: ophColors.lightBlue2,
+                },
+              },
+            },
+          }
+        : {
+            '&:nth-of-type(even)': {
+              '.MuiTableCell-root': {
+                backgroundColor: ophColors.grey50,
+              },
+            },
+            '&:nth-of-type(odd)': {
+              '.MuiTableCell-root': {
+                backgroundColor: ophColors.white,
+              },
+            },
+            '&:hover': {
+              '.MuiTableCell-root': {
+                backgroundColor: ophColors.lightBlue2,
+              },
+            },
+          }),
     },
-    '&:hover': {
-      '.MuiTableCell-root': {
-        backgroundColor: ophColors.lightBlue2,
-      },
-    },
-  },
-}));
+  }),
+);
+
 type ListTablePaginationProps = {
   page: number;
   setPage: (page: number) => void;
@@ -97,6 +122,8 @@ interface ListTableProps<T extends Row>
   checkboxSelection?: boolean;
   selection?: SelectionProps['selection'];
   setSelection?: SelectionProps['setSelection'];
+  collapsibleRows?: boolean;
+  renderCollapsibleRow?: (row: T, open: boolean) => React.ReactNode;
 }
 
 const TableWrapper = styled(Box)(({ theme }) => ({
@@ -145,6 +172,8 @@ export const ListTable = <T extends Row>({
   rowKeyProp,
   translateHeader = true,
   pagination,
+  collapsibleRows = false,
+  renderCollapsibleRow,
   ...props
 }: ListTableProps<T>) => {
   const translateCommon = useCommonTranslation();
@@ -184,7 +213,7 @@ export const ListTable = <T extends Row>({
               })}
             </TableRow>
           </TableHead>
-          <StyledTableBody>
+          <StyledTableBody collapsibleRows={collapsibleRows}>
             {pageRows.map((rowProps) => {
               const rowId = rowProps?.[rowKeyProp] as string;
 
@@ -194,6 +223,8 @@ export const ListTable = <T extends Row>({
                   key={rowId}
                   row={rowProps}
                   columns={columns}
+                  collapsibleRows={collapsibleRows}
+                  renderCollapsibleRow={renderCollapsibleRow}
                 />
               );
             })}

--- a/frontend/packages/yki/src/components/oph-design/table/list-table.tsx
+++ b/frontend/packages/yki/src/components/oph-design/table/list-table.tsx
@@ -5,7 +5,6 @@ import {
   Stack,
   Table,
   TableBody,
-  TableCell,
   TableHead,
   TableRow,
 } from '@mui/material';
@@ -18,6 +17,7 @@ import { OphPagination } from './oph-pagination';
 import { SelectionProps } from './table-checkboxes';
 import { TableHeaderCell } from './table-header-cell';
 import { ListTableColumn, Row } from './table-types';
+import { ListTableRow } from 'components/oph-design/table/list-table-row';
 import { useCommonTranslation } from 'configs/i18n';
 
 const DEFAULT_BOX_BORDER = `2px solid ${ophColors.grey100}`;
@@ -189,15 +189,12 @@ export const ListTable = <T extends Row>({
               const rowId = rowProps?.[rowKeyProp] as string;
 
               return (
-                <TableRow key={rowId}>
-                  {columns.map(({ key: columnKey, render, style }) => {
-                    return (
-                      <TableCell key={columnKey.toString()} sx={style}>
-                        {render(rowProps)}
-                      </TableCell>
-                    );
-                  })}
-                </TableRow>
+                <ListTableRow
+                  rowKeyProp={rowKeyProp}
+                  key={rowId}
+                  row={rowProps}
+                  columns={columns}
+                />
               );
             })}
           </StyledTableBody>

--- a/frontend/packages/yki/src/utils/clerk.ts
+++ b/frontend/packages/yki/src/utils/clerk.ts
@@ -3,9 +3,9 @@ import { t } from 'i18next';
 import { OrganizerLanguage } from 'interfaces/clerkOrganizer';
 
 const LEVEL_TRANSLATIONS = {
-  PERUS: 'common.level.basic',
-  KESKI: 'common.level.middle',
-  YLIN: 'common.level.high',
+  PERUS: 'yki.common.languageLevel.PERUS',
+  KESKI: 'yki.common.languageLevel.KESKI',
+  YLIN: 'yki.common.languageLevel.YLIN',
 };
 
 const LANGUAGES = [
@@ -71,7 +71,10 @@ export const languagesToString = (array: OrganizerLanguage[]) => {
 
   return list.map((lang) => lang.split(' ')[0].toLowerCase()).join(', ');
 };
-const getLanguagesWithLevelDescriptions = (array: OrganizerLanguage[]) => {
+
+export const getLanguagesWithLevelDescriptions = (
+  array: OrganizerLanguage[],
+) => {
   const list = [];
   for (const lang in LANGUAGES) {
     const language = LANGUAGES[lang];
@@ -87,8 +90,10 @@ const getLanguagesWithLevelDescriptions = (array: OrganizerLanguage[]) => {
     if (levels.length > 0) {
       const description =
         levels.length === language.levels.length
-          ? t('common.level.all')
-          : levels.map((l) => levelDescription(l)).join(` ${t('common.and')} `);
+          ? t('yki.common.languageLevel.ALL')
+          : levels
+              .map((l) => levelDescription(l))
+              .join(` ${t('yki.common.and')} `);
       list.push(`${language.name} - ${capitalize(description)}`);
     }
   }


### PR DESCRIPTION
## Yhteenveto

Table komponentti voi nyt rendata sekä tavallisia, että piilotettuja rivejä.

Data perustuu edelleen ensimmäiseen draftiin eli tästä puuttuu vanhan ykin "findByOids" tiedot, tulee jatko-PR:ssä.

Kiinni:

<img width="1478" height="267" alt="image" src="https://github.com/user-attachments/assets/0e8141f8-e0c4-4fe7-9445-77081c72f077" />

Auki:

<img width="1478" height="374" alt="image" src="https://github.com/user-attachments/assets/583771e6-40f5-4e00-9bb6-7e67651e012e" />




