### PR TITLE
YKI(Backend): OPHKIOS-186 API to search all customers

### DIFF
--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
@@ -13,10 +13,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 
 @RestController
 @RequestMapping(value = "/v2/api/clerk/customer", produces = APPLICATION_JSON_VALUE)

--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
@@ -7,12 +7,14 @@ import fi.oph.yki.api.dto.clerk.*;
 import fi.oph.yki.service.ClerkCustomerService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.annotation.Resource;
-import java.util.List;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping(value = "/v2/api/clerk/customer", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v2/api/clerk/customer", produces = APPLICATION_JSON_VALUE)
 @Profile("dev")
 public class ClerkCustomerDetailsController {
 
@@ -20,11 +22,27 @@ public class ClerkCustomerDetailsController {
   private ClerkCustomerService service;
 
   private static final String TAG_CUSTOMER = "Clerk customer API";
+  private static final int DEFAULT_PAGE_SIZE = 20;
+  private static final int MAX_PAGE_SIZE = 100;
 
   @PostMapping(path = "/search", consumes = ALL_VALUE)
-  @Operation(tags = TAG_CUSTOMER, summary = "Search customers")
-  public List<ClerkCustomerDetailsDTO> searchCustomers() throws Exception {
-    return service.searchClerkCustomers();
+  @Operation(
+    tags = TAG_CUSTOMER,
+    summary = "Search customers with pagination",
+    description = "Returns paginated customer details. Default page size is 20, max is 100."
+  )
+  public Page<ClerkCustomerDetailsDTO> searchCustomers(
+    @RequestParam(defaultValue = "0") int page,
+    @RequestParam(defaultValue = "20") int size
+  ) throws Exception {
+    // Validate and cap page size
+    final int validatedSize = Math.min(size, MAX_PAGE_SIZE);
+
+    // Create Pageable (no sorting for now)
+    final Pageable pageable = PageRequest.of(page, validatedSize);
+
+    var resp = service.searchClerkCustomers(pageable);
+    return resp;
   }
 
   @GetMapping(path = "/{oid}", consumes = ALL_VALUE)

--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
@@ -9,10 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.annotation.Resource;
 import java.util.List;
 import org.springframework.context.annotation.Profile;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(value = "/v2/api/clerk/customer", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
@@ -23,6 +20,12 @@ public class ClerkCustomerDetailsController {
   private ClerkCustomerService service;
 
   private static final String TAG_CUSTOMER = "Clerk customer API";
+
+  @PostMapping(path = "/search", consumes = ALL_VALUE)
+  @Operation(tags = TAG_CUSTOMER, summary = "Search customers")
+  public List<ClerkCustomerDetailsDTO> searchCustomers() throws Exception {
+    return service.searchClerkCustomers();
+  }
 
   @GetMapping(path = "/{oid}", consumes = ALL_VALUE)
   @Operation(tags = TAG_CUSTOMER, summary = "Get customer details")

--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
@@ -35,13 +35,9 @@ public class ClerkCustomerDetailsController {
     @RequestParam(defaultValue = "0") int page,
     @RequestParam(defaultValue = "20") int size
   ) throws Exception {
-    // Validate and cap page size
     final int validatedSize = Math.min(size, MAX_PAGE_SIZE);
 
-    // Create Pageable (no sorting for now)
-    final Pageable pageable = PageRequest.of(page, validatedSize);
-
-    return service.searchClerkCustomers(pageable);
+    return service.searchClerkCustomers(PageRequest.of(page, validatedSize));
   }
 
   @GetMapping(path = "/{oid}", consumes = ALL_VALUE)

--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
@@ -31,7 +31,7 @@ public class ClerkCustomerDetailsController {
     summary = "Search customers with pagination",
     description = "Returns paginated customer details. Default page size is 20, max is 100."
   )
-  public Page<ClerkCustomerDetailsDTO> searchCustomers(
+  public Page<ClerkCustomerSummaryDTO> searchCustomers(
     @RequestParam(defaultValue = "0") int page,
     @RequestParam(defaultValue = "20") int size
   ) throws Exception {
@@ -41,8 +41,7 @@ public class ClerkCustomerDetailsController {
     // Create Pageable (no sorting for now)
     final Pageable pageable = PageRequest.of(page, validatedSize);
 
-    var resp = service.searchClerkCustomers(pageable);
-    return resp;
+    return service.searchClerkCustomers(pageable);
   }
 
   @GetMapping(path = "/{oid}", consumes = ALL_VALUE)

--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
@@ -22,7 +22,6 @@ public class ClerkCustomerDetailsController {
   private ClerkCustomerService service;
 
   private static final String TAG_CUSTOMER = "Clerk customer API";
-  private static final int DEFAULT_PAGE_SIZE = 20;
   private static final int MAX_PAGE_SIZE = 100;
 
   @PostMapping(path = "/search", consumes = ALL_VALUE)

--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerDetailsController.java
@@ -3,15 +3,20 @@ package fi.oph.yki.api.clerk;
 import static org.springframework.http.MediaType.ALL_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import fi.oph.yki.api.dto.clerk.*;
+import fi.oph.yki.api.dto.clerk.ClerkCustomerDetailsDTO;
+import fi.oph.yki.api.dto.clerk.ClerkCustomerSummaryDTO;
 import fi.oph.yki.service.ClerkCustomerService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.annotation.Resource;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @RestController
 @RequestMapping(value = "/v2/api/clerk/customer", produces = APPLICATION_JSON_VALUE)
@@ -33,7 +38,7 @@ public class ClerkCustomerDetailsController {
   public Page<ClerkCustomerSummaryDTO> searchCustomers(
     @RequestParam(defaultValue = "0") int page,
     @RequestParam(defaultValue = "20") int size
-  ) throws Exception {
+  ) {
     final int validatedSize = Math.min(size, MAX_PAGE_SIZE);
 
     return service.searchClerkCustomers(PageRequest.of(page, validatedSize));

--- a/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkCustomerPersonDTO.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkCustomerPersonDTO.java
@@ -1,5 +1,8 @@
 package fi.oph.yki.api.dto.clerk;
 
+import lombok.Builder;
+
+@Builder
 public record ClerkCustomerPersonDTO(
   String firstName,
   String lastName,

--- a/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkCustomerRegistrationDTO.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkCustomerRegistrationDTO.java
@@ -6,11 +6,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import lombok.Builder;
 
 /**
  * @param examLocation Exam locations in different languages.
  * @param liftedFromQueueAt - Date, when the registration was lifted from the queue. Can be null.
  */
+@Builder
 public record ClerkCustomerRegistrationDTO(
   LocalDate examDate,
   ClerkExamDTO exam,

--- a/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkCustomerRegistrationDTO.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkCustomerRegistrationDTO.java
@@ -16,9 +16,9 @@ public record ClerkCustomerRegistrationDTO(
   ClerkExamDTO exam,
   List<ClerkExamLocationDTO> examLocation,
   RegistrationState registrationState,
-  Optional<LocalDate> examPaymentPaidAt,
-  Optional<LocalDate> registrationDate,
+  Optional<LocalDateTime> examPaymentPaidAt,
+  Optional<LocalDateTime> registrationDate,
   RegistrationKind kind,
-  Optional<LocalDate> liftedFromQueueAt,
-  Optional<LocalDate> expiresAt
+  Optional<LocalDateTime> liftedFromQueueAt,
+  Optional<LocalDateTime> expiresAt
 ) {}

--- a/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkCustomerSummaryDTO.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkCustomerSummaryDTO.java
@@ -1,0 +1,6 @@
+package fi.oph.yki.api.dto.clerk;
+
+import lombok.Builder;
+
+@Builder
+public record ClerkCustomerSummaryDTO(ClerkCustomerPersonDTO person, int registrationsCount) {}

--- a/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkExamDTO.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkExamDTO.java
@@ -1,3 +1,6 @@
 package fi.oph.yki.api.dto.clerk;
 
+import lombok.Builder;
+
+@Builder
 public record ClerkExamDTO(String language, String level) {}

--- a/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkExamLocationDTO.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkExamLocationDTO.java
@@ -1,3 +1,6 @@
 package fi.oph.yki.api.dto.clerk;
 
+import lombok.Builder;
+
+@Builder
 public record ClerkExamLocationDTO(String name, String municipality, String lang) {}

--- a/backend/yki/src/main/java/fi/oph/yki/model/Person.java
+++ b/backend/yki/src/main/java/fi/oph/yki/model/Person.java
@@ -25,9 +25,7 @@ public class Person {
 
   @Id
   @Size(max = 255)
-  @Column(name = "oid", unique = true)
-  @NonNull
-  @NotNull
+  @Column(name = "oid", unique = true, nullable = false)
   private String oid;
 
   @Size(max = 255)

--- a/backend/yki/src/main/java/fi/oph/yki/model/Person.java
+++ b/backend/yki/src/main/java/fi/oph/yki/model/Person.java
@@ -7,12 +7,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 
 @Getter
@@ -24,6 +26,8 @@ public class Person {
   @Id
   @Size(max = 255)
   @Column(name = "oid", unique = true)
+  @NonNull
+  @NotNull
   private String oid;
 
   @Size(max = 255)

--- a/backend/yki/src/main/java/fi/oph/yki/model/type/RegistrationKind.java
+++ b/backend/yki/src/main/java/fi/oph/yki/model/type/RegistrationKind.java
@@ -3,4 +3,5 @@ package fi.oph.yki.model.type;
 public enum RegistrationKind {
   ADMISSION,
   QUEUE,
+  POST_ADMISSION
 }

--- a/backend/yki/src/main/java/fi/oph/yki/model/type/RegistrationKind.java
+++ b/backend/yki/src/main/java/fi/oph/yki/model/type/RegistrationKind.java
@@ -3,5 +3,5 @@ package fi.oph.yki.model.type;
 public enum RegistrationKind {
   ADMISSION,
   QUEUE,
-  POST_ADMISSION
+  POST_ADMISSION,
 }

--- a/backend/yki/src/main/java/fi/oph/yki/onr/OnrService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/onr/OnrService.java
@@ -1,9 +1,11 @@
 package fi.oph.yki.onr;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.oph.yki.onr.dto.PersonalDataDTO;
 import fi.vm.sade.javautils.nio.cas.CasClient;
+import java.util.concurrent.ExecutionException;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
@@ -32,7 +34,8 @@ public class OnrService {
     this.onrServiceUrl = onrServiceUrl;
   }
 
-  public PersonalDataDTO getPersonalData(final String oidNumber) throws Exception {
+  public PersonalDataDTO getPersonalData(final String oidNumber)
+    throws RuntimeException, ExecutionException, InterruptedException, JsonProcessingException {
     final Request request = defaultRequestBuilder
       .setUrl(onrServiceUrl + "/henkilo/" + oidNumber)
       .setMethod(Methods.GET)
@@ -40,7 +43,7 @@ public class OnrService {
 
     final Response response = casClient.executeBlocking(request);
     if (response.getStatusCode() != HttpStatus.OK.value()) {
-      throw new RuntimeException(("Wrong status code: " + response.getStatusCode()));
+      throw new RuntimeException("Unexpected status code from ONR: " + response.getStatusCode());
     }
 
     final String json = response.getResponseBody();

--- a/backend/yki/src/main/java/fi/oph/yki/repository/RegistrationRepository.java
+++ b/backend/yki/src/main/java/fi/oph/yki/repository/RegistrationRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
   List<Registration> getByPersonOid(String personOid);
+
+  int countByPersonOid(String personOid);
 }

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -32,7 +32,7 @@ public class ClerkCustomerService {
   private final RegistrationRepository registrationRepository;
   private final OnrService onrService;
 
-  private ClerkCustomerPersonDTO PersonToDTO(Person person) throws RuntimeException {
+  private ClerkCustomerPersonDTO personToDTO(Person person) throws RuntimeException {
     final var oid = person.getOid();
 
     final PersonalDataDTO onrPerson;
@@ -55,7 +55,7 @@ public class ClerkCustomerService {
       .build();
   }
 
-  private ClerkCustomerRegistrationDTO RegistrationToDTO(Registration registration) {
+  private ClerkCustomerRegistrationDTO registrationToDTO(Registration registration) {
     final var session = registration.getExamSession();
 
     final var examDate = session.getExamDate().getExamDate();
@@ -94,9 +94,10 @@ public class ClerkCustomerService {
       .build();
   }
 
+  @Transactional(readOnly = true)
   public ClerkCustomerDetailsDTO getClerkCustomerDetails(String oid) {
-    var personDTO = PersonToDTO(personRepository.getByOid(oid));
-    var registrationsDTOs = registrationRepository.getByPersonOid(oid).stream().map(this::RegistrationToDTO).toList();
+    var personDTO = personToDTO(personRepository.getByOid(oid));
+    var registrationsDTOs = registrationRepository.getByPersonOid(oid).stream().map(this::registrationToDTO).toList();
     return ClerkCustomerDetailsDTO.builder().person(personDTO).registrations(registrationsDTOs).build();
   }
 
@@ -110,8 +111,8 @@ public class ClerkCustomerService {
       .map(person ->
         ClerkCustomerSummaryDTO
           .builder()
-          .person(PersonToDTO(person))
-          .registrationsCount(registrationRepository.getByPersonOid(person.getOid()).size())
+          .person(personToDTO(person))
+          .registrationsCount(registrationRepository.countByPersonOid(person.getOid()))
           .build()
       )
       .toList();

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -38,23 +38,24 @@ public class ClerkCustomerService {
       throw new RuntimeException("Unable to get personal data from ONR with oid '" + oid + "'.", e);
     }
 
-    return new ClerkCustomerPersonDTO(
-      person.getFirstName(),
-      person.getLastName(),
-      onrPerson.getIdentityNumber(),
-      person.getOid(),
-      person.getNationalityCode(),
-      person.getPhoneNumber(),
-      person.getAddress(),
-      person.getEmail()
-    );
+    return ClerkCustomerPersonDTO
+      .builder()
+      .firstName(person.getFirstName())
+      .lastName(person.getLastName())
+      .ssn(onrPerson.getIdentityNumber())
+      .oid(person.getOid())
+      .nationalityCode(person.getNationalityCode())
+      .phoneNumber(person.getPhoneNumber())
+      .streetAddress(person.getAddress())
+      .email(person.getEmail())
+      .build();
   }
 
   private ClerkCustomerRegistrationDTO RegistrationToDTO(Registration registration) {
     final var session = registration.getExamSession();
 
     final var examDate = session.getExamDate().getExamDate();
-    final var exam = new ClerkExamDTO(session.getLanguage(), session.getLevel());
+    final var exam = ClerkExamDTO.builder().language(session.getLanguage()).level(session.getLevel()).build();
 
     final var examLocation = session
       .getLocations()
@@ -68,29 +69,31 @@ public class ClerkCustomerService {
       .filter(p -> p.getPaidAt() != null)
       .max(Comparator.comparing(ExamPayment::getPaidAt));
 
-    final var freeRegistrationCreatedAt = Optional.ofNullable(registration.getFreeRegistration())
+    final var freeRegistrationCreatedAt = Optional
+      .ofNullable(registration.getFreeRegistration())
       .map(FreeRegistration::getCreatedAt);
 
     final var paidAt = latestExamPayment.map(ExamPayment::getPaidAt);
     final var registrationDate = paidAt.or(() -> freeRegistrationCreatedAt);
 
-    return new ClerkCustomerRegistrationDTO(
-      examDate,
-      exam,
-      examLocation,
-      registration.getState(),
-      paidAt,
-      registrationDate,
-      registration.getKind(),
-      Optional.ofNullable(registration.getLiftedFromQueueAt()),
-      Optional.ofNullable(registration.getExpiresAt())
-    );
+    return ClerkCustomerRegistrationDTO
+      .builder()
+      .examDate(examDate)
+      .exam(exam)
+      .examLocation(examLocation)
+      .registrationState(registration.getState())
+      .examPaymentPaidAt(paidAt)
+      .registrationDate(registrationDate)
+      .kind(registration.getKind())
+      .liftedFromQueueAt(Optional.ofNullable(registration.getLiftedFromQueueAt()))
+      .expiresAt(Optional.ofNullable(registration.getExpiresAt()))
+      .build();
   }
 
   public ClerkCustomerDetailsDTO getClerkCustomerDetails(String oid) {
     var personDTO = PersonToDTO(personRepository.getByOid(oid));
     var registrationsDTOs = registrationRepository.getByPersonOid(oid).stream().map(this::RegistrationToDTO).toList();
-    return new ClerkCustomerDetailsDTO(personDTO, registrationsDTOs);
+    return ClerkCustomerDetailsDTO.builder().person(personDTO).registrations(registrationsDTOs).build();
   }
 
   @Transactional(readOnly = true)

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -16,6 +16,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -113,7 +116,28 @@ public class ClerkCustomerService {
     return new ClerkCustomerDetailsDTO(getClerkCustomerPersonDTO(oid), getClerkCustomerRegistrationDTOs(oid));
   }
 
-  public List<ClerkCustomerDetailsDTO> searchClerkCustomers() throws Exception {
+  public Page<ClerkCustomerDetailsDTO> searchClerkCustomers(Pageable pageable) throws Exception {
+    // Get paginated persons
+    final Page<Person> personPage = personRepository.findAll(pageable);
+
+    // Transform persons to DTOs with their registrations
+    final List<ClerkCustomerDetailsDTO> content = personPage
+      .getContent()
+      .stream()
+      .map(person -> {
+        var registrations = registrationRepository.getByPersonOid(person.getOid());
+        return new ClerkCustomerDetailsDTO(
+          PersonToDTO(person),
+          registrations.stream().map(this::RegistrationToDTO).toList()
+        );
+      })
+      .toList();
+
+    // Return Page with transformed content
+    return new PageImpl<>(content, pageable, personPage.getTotalElements());
+  }
+
+  public List<ClerkCustomerDetailsDTO> searchClerkCustomer() throws Exception {
     final var persons = personRepository.findAll();
     return persons
       .stream()

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -1,6 +1,5 @@
 package fi.oph.yki.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import fi.oph.yki.api.dto.clerk.*;
 import fi.oph.yki.model.ExamPayment;
 import fi.oph.yki.model.Person;
@@ -9,14 +8,10 @@ import fi.oph.yki.onr.OnrService;
 import fi.oph.yki.onr.dto.PersonalDataDTO;
 import fi.oph.yki.repository.PersonRepository;
 import fi.oph.yki.repository.RegistrationRepository;
-import fi.oph.yki.util.exception.NotFoundException;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -72,20 +67,20 @@ public class ClerkCustomerService {
       .filter(p -> p.getPaidAt() != null)
       .max(Comparator.comparing(ExamPayment::getPaidAt));
 
-    final Optional<LocalDate> freeRegistrationCreatedAt = registration.getFreeRegistration() == null
+    final Optional<LocalDateTime> freeRegistrationCreatedAt = registration.getFreeRegistration() == null
       ? Optional.empty()
-      : Optional.of(registration.getFreeRegistration().getCreatedAt().toLocalDate());
+      : Optional.of(registration.getFreeRegistration().getCreatedAt());
 
-    final var paidAt = latestExamPayment.map(ExamPayment::getPaidAt).map(LocalDateTime::toLocalDate);
+    final var paidAt = latestExamPayment.map(ExamPayment::getPaidAt);
     final var registrationDate = paidAt.or(() -> freeRegistrationCreatedAt);
 
-    final Optional<LocalDate> liftedFromQueueAt = registration.getLiftedFromQueueAt() == null
+    final Optional<LocalDateTime> liftedFromQueueAt = registration.getLiftedFromQueueAt() == null
       ? Optional.empty()
-      : Optional.of(registration.getLiftedFromQueueAt().toLocalDate());
+      : Optional.of(registration.getLiftedFromQueueAt());
 
-    final Optional<LocalDate> expiresAt = registration.getExpiresAt() == null
+    final Optional<LocalDateTime> expiresAt = registration.getExpiresAt() == null
       ? Optional.empty()
-      : Optional.of(registration.getExpiresAt().toLocalDate());
+      : Optional.of(registration.getExpiresAt());
 
     return new ClerkCustomerRegistrationDTO(
       examDate,

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -1,6 +1,11 @@
 package fi.oph.yki.service;
 
-import fi.oph.yki.api.dto.clerk.*;
+import fi.oph.yki.api.dto.clerk.ClerkCustomerDetailsDTO;
+import fi.oph.yki.api.dto.clerk.ClerkCustomerPersonDTO;
+import fi.oph.yki.api.dto.clerk.ClerkCustomerRegistrationDTO;
+import fi.oph.yki.api.dto.clerk.ClerkCustomerSummaryDTO;
+import fi.oph.yki.api.dto.clerk.ClerkExamDTO;
+import fi.oph.yki.api.dto.clerk.ClerkExamLocationDTO;
 import fi.oph.yki.model.ExamPayment;
 import fi.oph.yki.model.FreeRegistration;
 import fi.oph.yki.model.Person;
@@ -9,7 +14,6 @@ import fi.oph.yki.onr.OnrService;
 import fi.oph.yki.onr.dto.PersonalDataDTO;
 import fi.oph.yki.repository.PersonRepository;
 import fi.oph.yki.repository.RegistrationRepository;
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -117,21 +117,17 @@ public class ClerkCustomerService {
     return new ClerkCustomerDetailsDTO(getClerkCustomerPersonDTO(oid), getClerkCustomerRegistrationDTOs(oid));
   }
 
-  public Page<ClerkCustomerDetailsDTO> searchClerkCustomers(Pageable pageable) throws Exception {
+  public Page<ClerkCustomerSummaryDTO> searchClerkCustomers(Pageable pageable) throws Exception {
     // Get paginated persons
     final Page<Person> personPage = personRepository.findAll(pageable);
 
     // Transform persons to DTOs with their registrations
-    final List<ClerkCustomerDetailsDTO> content = personPage
+    final List<ClerkCustomerSummaryDTO> content = personPage
       .getContent()
       .stream()
-      .map(person -> {
-        var registrations = registrationRepository.getByPersonOid(person.getOid());
-        return new ClerkCustomerDetailsDTO(
-          PersonToDTO(person),
-          registrations.stream().map(this::RegistrationToDTO).toList()
-        );
-      })
+      .map(person ->
+        new ClerkCustomerSummaryDTO(PersonToDTO(person), registrationRepository.getByPersonOid(person.getOid()).size())
+      )
       .toList();
 
     // Return Page with transformed content

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -64,7 +64,9 @@ public class ClerkCustomerService {
     final var examLocation = session
       .getLocations()
       .stream()
-      .map(l -> new ClerkExamLocationDTO(l.getName(), l.getPostOffice(), l.getLang()))
+      .map(l ->
+        ClerkExamLocationDTO.builder().name(l.getName()).municipality(l.getPostOffice()).lang(l.getLang()).build()
+      )
       .toList();
 
     final var latestExamPayment = registration

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -2,6 +2,7 @@ package fi.oph.yki.service;
 
 import fi.oph.yki.api.dto.clerk.*;
 import fi.oph.yki.model.ExamPayment;
+import fi.oph.yki.model.FreeRegistration;
 import fi.oph.yki.model.Person;
 import fi.oph.yki.model.Registration;
 import fi.oph.yki.onr.OnrService;
@@ -67,20 +68,11 @@ public class ClerkCustomerService {
       .filter(p -> p.getPaidAt() != null)
       .max(Comparator.comparing(ExamPayment::getPaidAt));
 
-    final Optional<LocalDateTime> freeRegistrationCreatedAt = registration.getFreeRegistration() == null
-      ? Optional.empty()
-      : Optional.of(registration.getFreeRegistration().getCreatedAt());
+    final var freeRegistrationCreatedAt = Optional.ofNullable(registration.getFreeRegistration())
+      .map(FreeRegistration::getCreatedAt);
 
     final var paidAt = latestExamPayment.map(ExamPayment::getPaidAt);
     final var registrationDate = paidAt.or(() -> freeRegistrationCreatedAt);
-
-    final Optional<LocalDateTime> liftedFromQueueAt = registration.getLiftedFromQueueAt() == null
-      ? Optional.empty()
-      : Optional.of(registration.getLiftedFromQueueAt());
-
-    final Optional<LocalDateTime> expiresAt = registration.getExpiresAt() == null
-      ? Optional.empty()
-      : Optional.of(registration.getExpiresAt());
 
     return new ClerkCustomerRegistrationDTO(
       examDate,
@@ -90,8 +82,8 @@ public class ClerkCustomerService {
       paidAt,
       registrationDate,
       registration.getKind(),
-      liftedFromQueueAt,
-      expiresAt
+      Optional.ofNullable(registration.getLiftedFromQueueAt()),
+      Optional.ofNullable(registration.getExpiresAt())
     );
   }
 

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -3,6 +3,7 @@ package fi.oph.yki.service;
 import fi.oph.yki.api.dto.clerk.*;
 import fi.oph.yki.model.ExamPayment;
 import fi.oph.yki.model.Person;
+import fi.oph.yki.model.Registration;
 import fi.oph.yki.onr.OnrService;
 import fi.oph.yki.onr.dto.PersonalDataDTO;
 import fi.oph.yki.repository.PersonRepository;
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,84 +26,104 @@ public class ClerkCustomerService {
   private final RegistrationRepository registrationRepository;
   private final OnrService onrService;
 
-  private ClerkCustomerPersonDTO getClerkCustomerPersonDTO(String oid) throws Exception {
-    Person person = personRepository.getByOid(oid);
-    if (person == null) {
-      // throw 404, because the whole data of getClerkCustomerDetails is tied to a specific user.
-      throw new NotFoundException(String.format("Person with oid '%s' not found from the person repository.", oid));
-    }
-
-    PersonalDataDTO onrPerson = onrService.getPersonalData(oid);
-    if (onrPerson == null) {
-      throw new RuntimeException(
+  private ClerkCustomerPersonDTO PersonToDTO(Person person) throws NotFoundException {
+    try {
+      final var oid = person.getOid();
+      final var onrPerson = Objects.requireNonNull(
+        onrService.getPersonalData(oid),
         String.format("Person with oid '%s' was found in the person repository, ", oid) +
         "but not found from the oppijanumerorekisteri-service."
       );
+
+      return new ClerkCustomerPersonDTO(
+        person.getFirstName(),
+        person.getLastName(),
+        onrPerson.getIdentityNumber(),
+        person.getOid(),
+        person.getNationalityCode(),
+        person.getPhoneNumber(),
+        person.getAddress(),
+        person.getEmail()
+      );
+    } catch (Exception e) {
+      throw new NotFoundException(e.getMessage());
     }
-    return new ClerkCustomerPersonDTO(
-      person.getFirstName(),
-      person.getLastName(),
-      onrPerson.getIdentityNumber(),
-      person.getOid(),
-      person.getNationalityCode(),
-      person.getPhoneNumber(),
-      person.getAddress(),
-      person.getEmail()
+  }
+
+  private ClerkCustomerRegistrationDTO RegistrationToDTO(Registration registration) {
+    final var session = registration.getExamSession();
+
+    final var examDate = session.getExamDate().getExamDate();
+    final var exam = new ClerkExamDTO(session.getLanguage(), session.getLevel());
+
+    final var examLocation = session
+      .getLocations()
+      .stream()
+      .map(l -> new ClerkExamLocationDTO(l.getName(), l.getPostOffice(), l.getLang()))
+      .toList();
+
+    final var latestExamPayment = registration
+      .getExamPayments()
+      .stream()
+      .max(Comparator.comparing(ExamPayment::getPaidAt));
+
+    final Optional<LocalDate> freeRegistrationCreatedAt = registration.getFreeRegistration() == null
+      ? Optional.empty()
+      : Optional.of(registration.getFreeRegistration().getCreatedAt().toLocalDate());
+
+    final var paidAt = latestExamPayment.map(ExamPayment::getPaidAt).map(LocalDateTime::toLocalDate);
+    final var registrationDate = paidAt.or(() -> freeRegistrationCreatedAt);
+
+    final Optional<LocalDate> liftedFromQueueAt = registration.getLiftedFromQueueAt() == null
+      ? Optional.empty()
+      : Optional.of(registration.getLiftedFromQueueAt().toLocalDate());
+
+    final Optional<LocalDate> expiresAt = registration.getExpiresAt() == null
+      ? Optional.empty()
+      : Optional.of(registration.getExpiresAt().toLocalDate());
+
+    return new ClerkCustomerRegistrationDTO(
+      examDate,
+      exam,
+      examLocation,
+      registration.getState(),
+      paidAt,
+      registrationDate,
+      registration.getKind(),
+      liftedFromQueueAt,
+      expiresAt
     );
   }
 
-  private List<ClerkCustomerRegistrationDTO> getClerkCustomerRegistrationDTOs(String oid) throws Exception {
-    return registrationRepository
-      .getByPersonOid(oid)
-      .stream()
-      .map(registration -> {
-        final var session = registration.getExamSession();
+  private ClerkCustomerPersonDTO getClerkCustomerPersonDTO(String oid) throws Exception {
+    return PersonToDTO(
+      Objects.requireNonNull(
+        personRepository.getByOid(oid),
+        // throw 404, because the whole data of getClerkCustomerDetails is tied to a specific user.
+        String.format("Person with oid '%s' not found from the person repository.", oid)
+      )
+    );
+  }
 
-        final var examDate = session.getExamDate().getExamDate();
-        final var exam = new ClerkExamDTO(session.getLanguage(), session.getLevel());
-
-        final var examLocation = session
-          .getLocations()
-          .stream()
-          .map(l -> new ClerkExamLocationDTO(l.getName(), l.getPostOffice(), l.getLang()))
-          .toList();
-
-        final var latestExamPayment = registration
-          .getExamPayments()
-          .stream()
-          .max(Comparator.comparing(ExamPayment::getPaidAt));
-
-        final Optional<LocalDate> freeRegistrationCreatedAt = registration.getFreeRegistration() == null
-          ? Optional.empty()
-          : Optional.of(registration.getFreeRegistration().getCreatedAt().toLocalDate());
-
-        final var paidAt = latestExamPayment.map(ExamPayment::getPaidAt).map(LocalDateTime::toLocalDate);
-        final var registrationDate = paidAt.or(() -> freeRegistrationCreatedAt);
-
-        final Optional<LocalDate> liftedFromQueueAt = registration.getLiftedFromQueueAt() == null
-          ? Optional.empty()
-          : Optional.of(registration.getLiftedFromQueueAt().toLocalDate());
-
-        final Optional<LocalDate> expiresAt = registration.getExpiresAt() == null
-          ? Optional.empty()
-          : Optional.of(registration.getExpiresAt().toLocalDate());
-
-        return new ClerkCustomerRegistrationDTO(
-          examDate,
-          exam,
-          examLocation,
-          registration.getState(),
-          paidAt,
-          registrationDate,
-          registration.getKind(),
-          liftedFromQueueAt,
-          expiresAt
-        );
-      })
-      .toList();
+  private List<ClerkCustomerRegistrationDTO> getClerkCustomerRegistrationDTOs(String oid) {
+    return registrationRepository.getByPersonOid(oid).stream().map(this::RegistrationToDTO).toList();
   }
 
   public ClerkCustomerDetailsDTO getClerkCustomerDetails(String oid) throws Exception {
     return new ClerkCustomerDetailsDTO(getClerkCustomerPersonDTO(oid), getClerkCustomerRegistrationDTOs(oid));
+  }
+
+  public List<ClerkCustomerDetailsDTO> searchClerkCustomers() throws Exception {
+    final var persons = personRepository.findAll();
+    return persons
+      .stream()
+      .map(person -> {
+        var registrations = registrationRepository.getByPersonOid(person.getOid());
+        return new ClerkCustomerDetailsDTO(
+          PersonToDTO(person),
+          registrations.stream().map(this::RegistrationToDTO).toList()
+        );
+      })
+      .toList();
   }
 }

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -33,9 +34,6 @@ public class ClerkCustomerService {
 
   private ClerkCustomerPersonDTO PersonToDTO(Person person) throws RuntimeException {
     final var oid = person.getOid();
-    if (oid == null) {
-      throw new NotFoundException("Person oid is null in the repository.");
-    }
 
     final PersonalDataDTO onrPerson;
     try {
@@ -102,32 +100,25 @@ public class ClerkCustomerService {
     );
   }
 
-  private ClerkCustomerPersonDTO getClerkCustomerPersonDTO(String oid) throws Exception {
-    return PersonToDTO(
-      Objects.requireNonNull(
-        personRepository.getByOid(oid),
-        // throw 404, because the whole data of getClerkCustomerDetails is tied to a specific user.
-        String.format("Person with oid '%s' not found from the person repository.", oid)
-      )
-    );
+  public ClerkCustomerDetailsDTO getClerkCustomerDetails(String oid) {
+    var personDTO = PersonToDTO(personRepository.getByOid(oid));
+    var registrationsDTOs = registrationRepository.getByPersonOid(oid).stream().map(this::RegistrationToDTO).toList();
+    return new ClerkCustomerDetailsDTO(personDTO, registrationsDTOs);
   }
 
-  private List<ClerkCustomerRegistrationDTO> getClerkCustomerRegistrationDTOs(String oid) {
-    return registrationRepository.getByPersonOid(oid).stream().map(this::RegistrationToDTO).toList();
-  }
-
-  public ClerkCustomerDetailsDTO getClerkCustomerDetails(String oid) throws Exception {
-    return new ClerkCustomerDetailsDTO(getClerkCustomerPersonDTO(oid), getClerkCustomerRegistrationDTOs(oid));
-  }
-
-  public Page<ClerkCustomerSummaryDTO> searchClerkCustomers(Pageable pageable) throws Exception {
+  @Transactional(readOnly = true)
+  public Page<ClerkCustomerSummaryDTO> searchClerkCustomers(Pageable pageable) {
     final Page<Person> personPage = personRepository.findAll(pageable);
 
     final List<ClerkCustomerSummaryDTO> content = personPage
       .getContent()
       .stream()
       .map(person ->
-        new ClerkCustomerSummaryDTO(PersonToDTO(person), registrationRepository.getByPersonOid(person.getOid()).size())
+        ClerkCustomerSummaryDTO
+          .builder()
+          .person(PersonToDTO(person))
+          .registrationsCount(registrationRepository.getByPersonOid(person.getOid()).size())
+          .build()
       )
       .toList();
 

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -1,5 +1,6 @@
 package fi.oph.yki.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import fi.oph.yki.api.dto.clerk.*;
 import fi.oph.yki.model.ExamPayment;
 import fi.oph.yki.model.Person;
@@ -15,6 +16,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -29,28 +31,29 @@ public class ClerkCustomerService {
   private final RegistrationRepository registrationRepository;
   private final OnrService onrService;
 
-  private ClerkCustomerPersonDTO PersonToDTO(Person person) throws NotFoundException {
-    try {
-      final var oid = person.getOid();
-      final var onrPerson = Objects.requireNonNull(
-        onrService.getPersonalData(oid),
-        String.format("Person with oid '%s' was found in the person repository, ", oid) +
-        "but not found from the oppijanumerorekisteri-service."
-      );
-
-      return new ClerkCustomerPersonDTO(
-        person.getFirstName(),
-        person.getLastName(),
-        onrPerson.getIdentityNumber(),
-        person.getOid(),
-        person.getNationalityCode(),
-        person.getPhoneNumber(),
-        person.getAddress(),
-        person.getEmail()
-      );
-    } catch (Exception e) {
-      throw new NotFoundException(e.getMessage());
+  private ClerkCustomerPersonDTO PersonToDTO(Person person) throws RuntimeException {
+    final var oid = person.getOid();
+    if (oid == null) {
+      throw new NotFoundException("Person oid is null in the repository.");
     }
+
+    final PersonalDataDTO onrPerson;
+    try {
+      onrPerson = onrService.getPersonalData(oid);
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to get personal data from ONR with oid '" + oid + "'.", e);
+    }
+
+    return new ClerkCustomerPersonDTO(
+      person.getFirstName(),
+      person.getLastName(),
+      onrPerson.getIdentityNumber(),
+      person.getOid(),
+      person.getNationalityCode(),
+      person.getPhoneNumber(),
+      person.getAddress(),
+      person.getEmail()
+    );
   }
 
   private ClerkCustomerRegistrationDTO RegistrationToDTO(Registration registration) {
@@ -118,10 +121,8 @@ public class ClerkCustomerService {
   }
 
   public Page<ClerkCustomerSummaryDTO> searchClerkCustomers(Pageable pageable) throws Exception {
-    // Get paginated persons
     final Page<Person> personPage = personRepository.findAll(pageable);
 
-    // Transform persons to DTOs with their registrations
     final List<ClerkCustomerSummaryDTO> content = personPage
       .getContent()
       .stream()
@@ -130,21 +131,6 @@ public class ClerkCustomerService {
       )
       .toList();
 
-    // Return Page with transformed content
     return new PageImpl<>(content, pageable, personPage.getTotalElements());
-  }
-
-  public List<ClerkCustomerDetailsDTO> searchClerkCustomer() throws Exception {
-    final var persons = personRepository.findAll();
-    return persons
-      .stream()
-      .map(person -> {
-        var registrations = registrationRepository.getByPersonOid(person.getOid());
-        return new ClerkCustomerDetailsDTO(
-          PersonToDTO(person),
-          registrations.stream().map(this::RegistrationToDTO).toList()
-        );
-      })
-      .toList();
   }
 }

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -68,6 +68,7 @@ public class ClerkCustomerService {
     final var latestExamPayment = registration
       .getExamPayments()
       .stream()
+      .filter(p -> p.getPaidAt() != null)
       .max(Comparator.comparing(ExamPayment::getPaidAt));
 
     final Optional<LocalDate> freeRegistrationCreatedAt = registration.getFreeRegistration() == null


### PR DESCRIPTION
## Yhteenveto

Rajapinta, joka palauttaa kaikki käyttäjät.

Seuraavaksi tuota rajapintaa pitää muokata niin, että dataa voidaan filtteröidä eri arvojen perusteella

## Lisätiedot

Testattu curlilla
```sh
 curl -s -X POST 'http://localhost:8083/yki/v2/api/clerk/customer/search?page=3&size=5' \
  |jq '.content[] | {oid: .person.oid, count: .registrationsCount}'
```



## Huomautukset

Tässä käytetään olemassaolevia rajapintoja, ja frontti ei itseasiassa tarvitse niin paljoa dataa. Speksin mukaan riittäisi, että palautetaan registrationsCount kaikkien ilmoittautumisten sijaan. Ajattelin, jatkaa sitä filosofiaa, että rajapinta antaa mitä kysytään ja frontti saa itse päättää mitä näytetään ja mitä ei. 


Vai olisiko järkevämpi tehdä kevyempi DTO? UI tarvitsee 
- ilmoittautumisten count

Sen lisäksi hakutehtävässä pitää pysytä hakeamaan seuraavilla tiedoilla
- nimi,hetu,syntymäaika, s-posti, oppijanumero
- järjestäjä
- tutkintopäivä
- kieli
- taso
- Onko henkilö yksilöimätön




## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
