### PR TITLE
feature: OPHKIOS-186  Asiakashaku - hakukentät

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ dist
 !**/.yarn/sdks
 !**/.yarn/versions
 
+cypress/
+
 backend/vkt/src/main/resources/application-dev.yaml
 backend/yki/src/main/resources/application-dev.yaml
 backend/yki/src/main/resources/static/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# Code style
+
+- Don't make self-explanatory comments. Comment only code, that is violates best practises in order to the business domain logic work. 
+- Prefer code style of the existing code base. Do not alter from the existing code style. When there are conflicting coding styles use this preference order:
+  * current domain in the stack (stack = frontend or backend)
+  * current category / sub domain
+  * stack (frontend or backend)
+
+# Structure
+- Code base is split by frontend and backend. Inside of them the code is split by domains. For example the backend logic for yki domain is at @backend/yki folder, and the frontend logic is at @frontend/packages/yki
+
+# Database
+- The database for yki - domain is older than our backend. The old backend is remotely at https://github.com/Opetushallitus/yki, and locally potentially at `../yki` 
+
+# Context examples
+
+## yki clerk customer details
+- The code flow from front to back
+- frontend can use maven backend, but for local development there is also MSW mock available.
+- when using locally real backend: yarn run yki:start:dev-server
+- It is safe to assume, when you are making changes on frontend, the programmer is manually running the frontend, so you don't need to run it.
+
+#### frontend context
+1. @frontend/packages/yki/src/enums/app.ts/AppRoutes - defines frontend routes
+2. @frontend/packages/yki/src/routers/AppRouter.tsx - frontend router logic
+3. @frontend/packages/yki/src/pages/clerk/ClerkCustomerDetailsPage.tsx - the frontend page
+4. @frontend/packages/yki/src/components/clerk/ClerkCustomerDetails.tsx - the main component
+5. @frontend/packages/yki/src/redux/selector/clerkCustomerDetails.ts - the selector of the main component.
+6. @frontend/packages/yki/src/redux/reducers/clerkCustomerDetails.ts - the reducer
+8. @frontend/packages/yki/src/redux/sagas/clerkCustomerDetails.ts/loadClerkCustomerDetailsSaga - calls backend API/MSW
+7. @frontend/packages/yki/src/utils/serialization.ts/deserializeClerkCustomerDetailsResponse - deserialize the response for frontend
+9. @frontend/packages/yki/src/enums/api.ts/APIEndpoints - defined the API endpoints
+
+#### MSW
+- Running frontend with MSW mock: yarn yki:clerk:start:msw
+- The test data: @frontend/packages/yki/src/test/msw/fixtures/customerDetails.ts
+- MSW handlers: @frontend/packages/yki/src/test/msw/handlers.ts
+
+### backend
+ 1. @backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerController.java - backend controllers
+ 2. @backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java - backend business logic.
+ 3. @backend/yki/src/main/java/fi/oph/yki/repository - folder, JPA entrypoints to database
+ 4.  @backend/yki/db - folder: local database initialization scripts
+ 5. @backend/yki/src/main/resources/db/changelog - liquibase migrations
+
+## Liquibase
+* If you are assigned to update migration, do not create new migration file, but update the existing one.
+

--- a/backend/yki/CLAUDE.md
+++ b/backend/yki/CLAUDE.md
@@ -1,0 +1,11 @@
+# Database
+- The database older than our backend. The old backend is remotely at https://github.com/Opetushallitus/yki, and locally potentially at `../../../yki`. The old database contain the data already, so when our code is missing tables or columns, that is very domain specific, that it should be reviewed manually by the programmer.
+
+- We have sql scripts at `db` - folder to set up the database locally, with `db/create_db_sql.sh`
+- We also use liquibase to add new migrations.
+
+
+# Maven
+We use maven, not gradle, and this is a shared project. Parent pom is at `../`. 
+
+./mvnw clean install build etc

--- a/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkCustomerSearchRequestDTO.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkCustomerSearchRequestDTO.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 public record ClerkCustomerSearchRequestDTO(
   @Nullable String personQuery,
   @Nullable Long organizerId,
-  @Nullable Long examDateId,
+  @Nullable Long examSessionId,
   @Nullable String languageCode,
   @Nullable String levelCode
 ) {}

--- a/backend/yki/src/main/java/fi/oph/yki/repository/PersonRepository.java
+++ b/backend/yki/src/main/java/fi/oph/yki/repository/PersonRepository.java
@@ -42,14 +42,14 @@ WHERE (:personQuery IS NULL OR :personQuery = '' OR
         ) @@ plainto_tsquery('simple', :personQuery)
     )
     AND (
-        (:organizerId IS NULL AND :examDateId IS NULL AND (:languageCode IS NULL OR :languageCode = '') AND (:levelCode IS NULL OR :levelCode = ''))
+        (:organizerId IS NULL AND :examSessionId IS NULL AND (:languageCode IS NULL OR :languageCode = '') AND (:levelCode IS NULL OR :levelCode = ''))
         OR EXISTS (
             SELECT 1
             FROM registration r
             JOIN exam_session es ON r.exam_session_id = es.id
             WHERE r.person_oid = p.oid
               AND (:organizerId IS NULL OR es.organizer_id = :organizerId)
-              AND (:examDateId IS NULL OR es.exam_date_id = :examDateId)
+              AND (:examSessionId IS NULL OR es.id = :examSessionId)
               AND (:languageCode IS NULL OR :languageCode = '' OR es.language_code = :languageCode)
               AND (:levelCode IS NULL OR :levelCode = '' OR es.level_code = :levelCode)
         )
@@ -67,14 +67,14 @@ WHERE (:personQuery IS NULL OR :personQuery = '' OR
         ) @@ plainto_tsquery('simple', :personQuery)
     )
     AND (
-        (:organizerId IS NULL AND :examDateId IS NULL AND (:languageCode IS NULL OR :languageCode = '') AND (:levelCode IS NULL OR :levelCode = ''))
+        (:organizerId IS NULL AND :examSessionId IS NULL AND (:languageCode IS NULL OR :languageCode = '') AND (:levelCode IS NULL OR :levelCode = ''))
         OR EXISTS (
             SELECT 1
             FROM registration r
             JOIN exam_session es ON r.exam_session_id = es.id
             WHERE r.person_oid = p.oid
               AND (:organizerId IS NULL OR es.organizer_id = :organizerId)
-              AND (:examDateId IS NULL OR es.exam_date_id = :examDateId)
+              AND (:examSessionId IS NULL OR es.id = :examSessionId)
               AND (:languageCode IS NULL OR :languageCode = '' OR es.language_code = :languageCode)
               AND (:levelCode IS NULL OR :levelCode = '' OR es.level_code = :levelCode)
         )
@@ -86,7 +86,7 @@ WHERE (:personQuery IS NULL OR :personQuery = '' OR
     Pageable pageable,
     @Param("personQuery") String personQuery,
     @Param("organizerId") Long organizerId,
-    @Param("examDateId") Long examDateId,
+    @Param("examSessionId") Long examSessionId,
     @Param("languageCode") String languageCode,
     @Param("levelCode") String levelCode
   );

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -134,7 +134,7 @@ public class ClerkCustomerService {
         pageable,
         onrDtoOptional.get().getOidHenkilo(),
         request.organizerId(),
-        request.examDateId(),
+        request.examSessionId(),
         request.languageCode(),
         request.levelCode()
       );
@@ -145,7 +145,7 @@ public class ClerkCustomerService {
       pageable,
       request.personQuery(),
       request.organizerId(),
-      request.examDateId(),
+      request.examSessionId(),
       request.languageCode(),
       request.levelCode()
     );

--- a/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
@@ -265,8 +265,10 @@
           "header": "{{amount}} osallistujaa",
           "listing": {
             "apiResponseStatus": {
-              "inProgress": "Ladataan tietoja",
-              "error": "Tietojen lataaminen epäonnistui"
+              "NOT_STARTED": "Tietojen lataaminen epäonnistui",
+              "IN_PROGRESS": "Ladataan tietoja",
+              "ERROR": "Tietojen lataaminen epäonnistui",
+              "CANCELLED": "Tietojen lataaminen epäonnistui"
             },
             "columns": {
               "name": "Nimi",

--- a/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
@@ -263,6 +263,7 @@
         },
         "search": {
           "header": "{{amount}} osallistujaa",
+          "submit": "Hae osallistujia",
           "labels": {
             "participant": "Hae osallistujaa",
             "organizer": "Järjestäjä",

--- a/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
@@ -263,7 +263,15 @@
         },
         "search": {
           "header": "{{amount}} osallistujaa",
+          "labels": {
+            "participant": "Hae osallistujaa",
+            "organizer": "Järjestäjä",
+            "examDate": "Tutkintopäivä",
+            "language": "Kieli",
+            "level": "Taso"
+          },
           "listing": {
+            "all": "Kaikki",
             "apiResponseStatus": {
               "NOT_STARTED": "Tietojen lataaminen epäonnistui",
               "IN_PROGRESS": "Ladataan tietoja",

--- a/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
@@ -265,8 +265,10 @@
           "header": "{{amount}} osallistujaa",
           "listing": {
             "apiResponseStatus": {
-              "inProgress": "Ladataan tietoja",
-              "error": "Tietojen lataaminen epäonnistui"
+              "NOT_STARTED": "Tietojen lataaminen epäonnistui",
+              "IN_PROGRESS": "Ladataan tietoja",
+              "ERROR": "Tietojen lataaminen epäonnistui",
+              "CANCELLED": "Tietojen lataaminen epäonnistui"
             },
             "columns": {
               "name": "Nimi",

--- a/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
@@ -263,6 +263,7 @@
         },
         "search": {
           "header": "{{amount}} osallistujaa",
+          "submit": "Hae osallistujia",
           "labels": {
             "participant": "Hae osallistujaa",
             "organizer": "Järjestäjä",

--- a/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
@@ -263,7 +263,15 @@
         },
         "search": {
           "header": "{{amount}} osallistujaa",
+          "labels": {
+            "participant": "Hae osallistujaa",
+            "organizer": "Järjestäjä",
+            "examDate": "Tutkintopäivä",
+            "language": "Kieli",
+            "level": "Taso"
+          },
           "listing": {
+            "all": "Kaikki",
             "apiResponseStatus": {
               "NOT_STARTED": "Tietojen lataaminen epäonnistui",
               "IN_PROGRESS": "Ladataan tietoja",

--- a/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
@@ -265,8 +265,10 @@
           "header": "{{amount}} osallistujaa",
           "listing": {
             "apiResponseStatus": {
-              "inProgress": "Ladataan tietoja",
-              "error": "Tietojen lataaminen epäonnistui"
+              "NOT_STARTED": "Tietojen lataaminen epäonnistui",
+              "IN_PROGRESS": "Ladataan tietoja",
+              "ERROR": "Tietojen lataaminen epäonnistui",
+              "CANCELLED": "Tietojen lataaminen epäonnistui"
             },
             "columns": {
               "name": "Nimi",

--- a/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
@@ -263,6 +263,7 @@
         },
         "search": {
           "header": "{{amount}} osallistujaa",
+          "submit": "Hae osallistujia",
           "labels": {
             "participant": "Hae osallistujaa",
             "organizer": "Järjestäjä",

--- a/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
@@ -263,7 +263,15 @@
         },
         "search": {
           "header": "{{amount}} osallistujaa",
+          "labels": {
+            "participant": "Hae osallistujaa",
+            "organizer": "Järjestäjä",
+            "examDate": "Tutkintopäivä",
+            "language": "Kieli",
+            "level": "Taso"
+          },
           "listing": {
+            "all": "Kaikki",
             "apiResponseStatus": {
               "NOT_STARTED": "Tietojen lataaminen epäonnistui",
               "IN_PROGRESS": "Ladataan tietoja",

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
@@ -22,7 +22,7 @@ import { loadClerkOrganizerRegistry } from 'redux/reducers/clerkOrganizer';
 import { loadExamSessions } from 'redux/reducers/examSessions';
 import { clerkCustomersSearchSelector } from 'redux/selectors/clerkCustomersSearchSelector';
 import { clerkOrganizersSelector } from 'redux/selectors/clerkOrganizers';
-import { examSessionsSelector } from 'redux/selectors/examSessions';
+import { examSessionsSelector } from 'redux/selectors/examSession';
 import { filteredClerkOrganizersSelector } from 'redux/selectors/filteredClerkOrganizers';
 import { LANGUAGES, levelDescription } from 'utils/clerk';
 

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
@@ -1,0 +1,116 @@
+import { TextField } from '@mui/material';
+import { OphSelectFormField } from '@opetushallitus/oph-design-system';
+import { useEffect } from 'react';
+import { APIResponseStatus } from 'shared/enums';
+
+import { usePublicTranslation } from 'configs/i18n';
+import { useAppDispatch, useAppSelector } from 'configs/redux';
+import { Label } from 'ophTheme/Text';
+import {
+  setExamDateFilter,
+  setLanguageFilter,
+  setLevelFilter,
+  setOrganizerFilter,
+} from 'redux/reducers/clerkCustomersSearch';
+import { loadClerkOrganizerRegistry } from 'redux/reducers/clerkOrganizer';
+import { loadExamSessions } from 'redux/reducers/examSessions';
+import { clerkOrganizersSelector } from 'redux/selectors/clerkOrganizers';
+import { examSessionsSelector } from 'redux/selectors/examSessions';
+import { filteredClerkOrganizersSelector } from 'redux/selectors/filteredClerkOrganizers';
+import { LANGUAGES, levelDescription } from 'utils/clerk';
+
+type LevelCode = 'PERUS' | 'KESKI' | 'YLIN';
+
+export const ClerkCustomerListingFilter = () => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.clerkCustomer.search',
+  });
+
+  const levels: LevelCode[] = ['PERUS', 'KESKI', 'YLIN'];
+  const dispatch = useAppDispatch();
+  const { organizerRegistryStatus } = useAppSelector(clerkOrganizersSelector);
+  const organizers = useAppSelector(filteredClerkOrganizersSelector);
+  const { status: examSessionsStatus, exam_sessions } =
+    useAppSelector(examSessionsSelector);
+
+  useEffect(() => {
+    if (organizerRegistryStatus === APIResponseStatus.NotStarted) {
+      dispatch(loadClerkOrganizerRegistry());
+    }
+    if (examSessionsStatus === APIResponseStatus.NotStarted) {
+      dispatch(loadExamSessions());
+    }
+  }, [dispatch, organizerRegistryStatus, examSessionsStatus]);
+
+  return (
+    <div
+      className="columns gapped"
+      style={{ marginBottom: '2rem', alignItems: 'flex-start' }}
+    >
+      <div style={{ flex: 1, maxWidth: '300px' }}>
+        <Label>{t('labels.participant')}</Label>
+        <TextField sx={{ width: '100%' }} />
+      </div>
+      <div style={{ flex: 1, maxWidth: '300px' }}>
+        <OphSelectFormField
+          sx={{ width: '100%' }}
+          label={t('labels.organizer')}
+          inputProps={{ 'aria-label': t('labels.organizer') }}
+          options={[
+            { label: t('listing.all'), value: '' },
+            ...organizers.map((org) => ({
+              label: org.name,
+              value: String(org.id),
+            })),
+          ]}
+          onChange={(e) => dispatch(setOrganizerFilter(e.target.value))}
+        />
+      </div>
+      <div style={{ minWidth: '150px' }}>
+        <OphSelectFormField
+          sx={{ width: '100%' }}
+          label={t('labels.examDate')}
+          inputProps={{ 'aria-label': t('labels.examDate') }}
+          options={[
+            { label: t('listing.all'), value: '' },
+            ...exam_sessions.map((es) => ({
+              label: es.session_date.format('D.M.YYYY'),
+              value: String(es.id),
+            })),
+          ]}
+          onChange={(e) => dispatch(setExamDateFilter(e.target.value))}
+        />
+      </div>
+      <div style={{ minWidth: '150px' }}>
+        <OphSelectFormField
+          sx={{ width: '100%' }}
+          label={t('labels.language')}
+          inputProps={{ 'aria-label': t('labels.language') }}
+          options={[
+            { label: t('listing.all'), value: '' },
+            ...LANGUAGES.map((lang) => ({
+              label: lang.name,
+              value: lang.code,
+            })),
+          ]}
+          onChange={(e) => dispatch(setLanguageFilter(e.target.value))}
+        />
+      </div>
+      <div style={{ minWidth: '150px' }}>
+        <OphSelectFormField
+          sx={{ width: '100%' }}
+          label={t('labels.level')}
+          inputProps={{ 'aria-label': t('labels.level') }}
+          options={[
+            { label: t('listing.all'), value: '' },
+            ...levels.map((level) => ({
+              label: levelDescription(level),
+              value: level,
+            })),
+          ]}
+          onChange={(e) => dispatch(setLevelFilter(e.target.value))}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
@@ -1,19 +1,26 @@
-import { TextField } from '@mui/material';
-import { OphSelectFormField } from '@opetushallitus/oph-design-system';
+import { Search } from '@mui/icons-material';
+import { IconButton, InputAdornment } from '@mui/material';
+import {
+  OphButton,
+  OphInputFormField,
+  OphSelectFormField,
+} from '@opetushallitus/oph-design-system';
 import { useEffect } from 'react';
-import { APIResponseStatus } from 'shared/enums';
+import { APIResponseStatus, Variant } from 'shared/enums';
 
 import { usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
-import { Label } from 'ophTheme/Text';
 import {
-  setExamDateFilter,
+  loadCustomersSearch,
+  setExamSessionFilter,
   setLanguageFilter,
   setLevelFilter,
   setOrganizerFilter,
+  setSearchQueryFilter,
 } from 'redux/reducers/clerkCustomersSearch';
 import { loadClerkOrganizerRegistry } from 'redux/reducers/clerkOrganizer';
 import { loadExamSessions } from 'redux/reducers/examSessions';
+import { clerkCustomersSearchSelector } from 'redux/selectors/clerkCustomersSearchSelector';
 import { clerkOrganizersSelector } from 'redux/selectors/clerkOrganizers';
 import { examSessionsSelector } from 'redux/selectors/examSessions';
 import { filteredClerkOrganizersSelector } from 'redux/selectors/filteredClerkOrganizers';
@@ -32,6 +39,15 @@ export const ClerkCustomerListingFilter = () => {
   const organizers = useAppSelector(filteredClerkOrganizersSelector);
   const { status: examSessionsStatus, exam_sessions } =
     useAppSelector(examSessionsSelector);
+  const {
+    searchQueryFilter,
+    organizerIdFilter,
+    examSessionIdFilter,
+    languageCodeFilter,
+    levelCodeFilter,
+    size,
+    page,
+  } = useAppSelector(clerkCustomersSearchSelector);
 
   useEffect(() => {
     if (organizerRegistryStatus === APIResponseStatus.NotStarted) {
@@ -45,11 +61,44 @@ export const ClerkCustomerListingFilter = () => {
   return (
     <div
       className="columns gapped"
-      style={{ marginBottom: '2rem', alignItems: 'flex-start' }}
+      style={{ marginBottom: '2rem', alignItems: 'flex-end' }}
     >
       <div style={{ flex: 1, maxWidth: '300px' }}>
-        <Label>{t('labels.participant')}</Label>
-        <TextField sx={{ width: '100%' }} />
+        <OphInputFormField
+          sx={{ width: '100%' }}
+          label={t('labels.participant')}
+          value={searchQueryFilter}
+          onChange={(e) => dispatch(setSearchQueryFilter(e.target.value))}
+          endAdornment={
+            <InputAdornment position="end">
+              <IconButton
+                sx={{ padding: 0, margin: '0 4px' }}
+                aria-label={t('listing.filters.searchLabel')}
+                onClick={() => {
+                  dispatch(setSearchQueryFilter(searchQueryFilter ?? ''));
+                  dispatch(
+                    loadCustomersSearch({
+                      request: {
+                        personQuery: searchQueryFilter,
+                        organizerId: organizerIdFilter,
+                        examDateId: examSessionIdFilter,
+                        languageCode: languageCodeFilter,
+                        levelCode: levelCodeFilter,
+                      },
+                      page,
+                      size,
+                    }),
+                  );
+                }}
+                onMouseDown={(e) => e.preventDefault()}
+                onMouseUp={(e) => e.preventDefault()}
+                edge="end"
+              >
+                <Search color="disabled" fontSize="large" />
+              </IconButton>
+            </InputAdornment>
+          }
+        />
       </div>
       <div style={{ flex: 1, maxWidth: '300px' }}>
         <OphSelectFormField
@@ -63,7 +112,7 @@ export const ClerkCustomerListingFilter = () => {
               value: String(org.id),
             })),
           ]}
-          onChange={(e) => dispatch(setOrganizerFilter(e.target.value))}
+          onChange={(e) => dispatch(setOrganizerFilter(+e.target.value))}
         />
       </div>
       <div style={{ minWidth: '150px' }}>
@@ -78,7 +127,7 @@ export const ClerkCustomerListingFilter = () => {
               value: String(es.id),
             })),
           ]}
-          onChange={(e) => dispatch(setExamDateFilter(e.target.value))}
+          onChange={(e) => dispatch(setExamSessionFilter(+e.target.value))}
         />
       </div>
       <div style={{ minWidth: '150px' }}>
@@ -110,6 +159,29 @@ export const ClerkCustomerListingFilter = () => {
           ]}
           onChange={(e) => dispatch(setLevelFilter(e.target.value))}
         />
+      </div>
+      <div style={{ minWidth: '150px' }}>
+        <OphButton
+          variant={Variant.Contained}
+          sx={{ width: '100%' }}
+          onClick={() =>
+            dispatch(
+              loadCustomersSearch({
+                request: {
+                  personQuery: searchQueryFilter,
+                  organizerId: organizerIdFilter,
+                  examDateId: examSessionIdFilter,
+                  languageCode: languageCodeFilter,
+                  levelCode: levelCodeFilter,
+                },
+                page,
+                size,
+              }),
+            )
+          }
+        >
+          {t('submit')}
+        </OphButton>
       </div>
     </div>
   );

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
@@ -81,7 +81,7 @@ export const ClerkCustomerListingFilter = () => {
                       request: {
                         personQuery: searchQueryFilter,
                         organizerId: organizerIdFilter,
-                        examDateId: examSessionIdFilter,
+                        examSessionId: examSessionIdFilter,
                         languageCode: languageCodeFilter,
                         levelCode: levelCodeFilter,
                       },
@@ -170,7 +170,7 @@ export const ClerkCustomerListingFilter = () => {
                 request: {
                   personQuery: searchQueryFilter,
                   organizerId: organizerIdFilter,
-                  examDateId: examSessionIdFilter,
+                  examSessionId: examSessionIdFilter,
                   languageCode: languageCodeFilter,
                   levelCode: levelCodeFilter,
                 },

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
@@ -75,7 +75,7 @@ export const ClerkCustomerListingFilter = () => {
                 sx={{ padding: 0, margin: '0 4px' }}
                 aria-label={t('listing.filters.searchLabel')}
                 onClick={() => {
-                  dispatch(setSearchQueryFilter(searchQueryFilter ?? ''));
+                  dispatch(setSearchQueryFilter(searchQueryFilter));
                   dispatch(
                     loadCustomersSearch({
                       request: {

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
@@ -49,7 +49,7 @@ export const ClerkCustomerSearch = () => {
           request: {
             personQuery: searchQueryFilter,
             organizerId: organizerIdFilter,
-            examDateId: examSessionIdFilter,
+            examSessionId: examSessionIdFilter,
             languageCode: languageCodeFilter,
             levelCode: levelCodeFilter,
           },
@@ -88,7 +88,7 @@ export const ClerkCustomerSearch = () => {
                 request: {
                   personQuery: searchQueryFilter,
                   organizerId: organizerIdFilter,
-                  examDateId: examSessionIdFilter,
+                  examSessionId: examSessionIdFilter,
                   languageCode: languageCodeFilter,
                   levelCode: levelCodeFilter,
                 },

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
@@ -9,14 +9,28 @@ import { H2 } from 'ophTheme/Text';
 import { loadCustomersSearch } from 'redux/reducers/clerkCustomersSearch';
 import { clerkCustomersSearchSelector } from 'redux/selectors/clerkCustomersSearchSelector';
 
+const InfoText = ({ status }: { status: APIResponseStatus }) => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.clerkCustomer.search',
+  });
+
+  return (
+    <Box
+      minHeight="10vh"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <H2>{t(`listing.apiResponseStatus.${status}`)}</H2>
+    </Box>
+  );
+};
+
 export const ClerkCustomerSearch = () => {
   const { status, customers, page, size, totalElements } = useAppSelector(
     clerkCustomersSearchSelector,
   );
 
-  const { t } = usePublicTranslation({
-    keyPrefix: 'yki.component.clerkCustomer.search',
-  });
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -33,52 +47,29 @@ export const ClerkCustomerSearch = () => {
     }
   }, [dispatch, page, size, status]);
 
-  switch (status) {
-    case APIResponseStatus.NotStarted:
-    case APIResponseStatus.InProgress:
-      return (
-        <Box
-          minHeight="10vh"
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-        >
-          <H2>{t('listing.apiResponseStatus.inProgress')}</H2>
-        </Box>
-      );
-    case APIResponseStatus.Error:
-      return (
-        <Box
-          minHeight="10vh"
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-        >
-          <H2>{t('listing.apiResponseStatus.error')}</H2>
-        </Box>
-      );
-
-    case APIResponseStatus.Success:
-      return (
-        <>
-          <ClerkCustomersListing
-            customers={customers}
-            page={page}
-            pageSize={size}
-            totalCount={totalElements}
-            onPageChange={(newPage) =>
-              dispatch(
-                loadCustomersSearch({
-                  request: {
-                    personQuery: '',
-                  },
-                  page: newPage,
-                  size,
-                }),
-              )
-            }
-          />
-        </>
-      );
-  }
+  return (
+    <>
+      {status !== APIResponseStatus.Success ? (
+        <InfoText status={status} />
+      ) : (
+        <ClerkCustomersListing
+          customers={customers}
+          page={page}
+          pageSize={size}
+          totalCount={totalElements}
+          onPageChange={(newPage) =>
+            dispatch(
+              loadCustomersSearch({
+                request: {
+                  personQuery: '',
+                },
+                page: newPage,
+                size,
+              }),
+            )
+          }
+        />
+      )}
+    </>
+  );
 };

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
@@ -28,25 +28,47 @@ const InfoText = ({ status }: { status: APIResponseStatus }) => {
 };
 
 export const ClerkCustomerSearch = () => {
-  const { status, customers, page, size, totalElements } = useAppSelector(
-    clerkCustomersSearchSelector,
-  );
+  const {
+    status,
+    customers,
+    searchQueryFilter,
+    organizerIdFilter,
+    examSessionIdFilter,
+    languageCodeFilter,
+    levelCodeFilter,
+    page,
+    size,
+    totalElements,
+  } = useAppSelector(clerkCustomersSearchSelector);
 
   const dispatch = useAppDispatch();
-
   useEffect(() => {
     if (status === APIResponseStatus.NotStarted) {
       dispatch(
         loadCustomersSearch({
           request: {
-            personQuery: '',
+            personQuery: searchQueryFilter,
+            organizerId: organizerIdFilter,
+            examDateId: examSessionIdFilter,
+            languageCode: languageCodeFilter,
+            levelCode: levelCodeFilter,
           },
           page,
           size,
         }),
       );
     }
-  }, [dispatch, page, size, status]);
+  }, [
+    dispatch,
+    examSessionIdFilter,
+    languageCodeFilter,
+    levelCodeFilter,
+    organizerIdFilter,
+    page,
+    searchQueryFilter,
+    size,
+    status,
+  ]);
 
   return (
     <>
@@ -64,7 +86,11 @@ export const ClerkCustomerSearch = () => {
             dispatch(
               loadCustomersSearch({
                 request: {
-                  personQuery: '',
+                  personQuery: searchQueryFilter,
+                  organizerId: organizerIdFilter,
+                  examDateId: examSessionIdFilter,
+                  languageCode: languageCodeFilter,
+                  levelCode: levelCodeFilter,
                 },
                 page: newPage,
                 size,

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material';
-import { useEffect } from 'react';
 import { APIResponseStatus } from 'shared/enums';
 
 import { ClerkCustomerListingFilter } from 'components/clerkCustomer/ClerkCustomerListingFilter';
@@ -42,63 +41,44 @@ export const ClerkCustomerSearch = () => {
   } = useAppSelector(clerkCustomersSearchSelector);
 
   const dispatch = useAppDispatch();
-  useEffect(() => {
-    if (status === APIResponseStatus.NotStarted) {
-      dispatch(
-        loadCustomersSearch({
-          request: {
-            personQuery: searchQueryFilter,
-            organizerId: organizerIdFilter,
-            examSessionId: examSessionIdFilter,
-            languageCode: languageCodeFilter,
-            levelCode: levelCodeFilter,
-          },
-          page,
-          size,
-        }),
-      );
+
+  const renderClerkCustomersListing = () => {
+    switch (status) {
+      case APIResponseStatus.NotStarted:
+        return null;
+      case APIResponseStatus.Success:
+        return (
+          <ClerkCustomersListing
+            customers={customers}
+            page={page}
+            pageSize={size}
+            totalCount={totalElements}
+            onPageChange={(newPage) =>
+              dispatch(
+                loadCustomersSearch({
+                  request: {
+                    personQuery: searchQueryFilter,
+                    organizerId: organizerIdFilter,
+                    examSessionId: examSessionIdFilter,
+                    languageCode: languageCodeFilter,
+                    levelCode: levelCodeFilter,
+                  },
+                  page: newPage,
+                  size,
+                }),
+              )
+            }
+          />
+        );
+      default:
+        return <InfoText status={status} />;
     }
-  }, [
-    dispatch,
-    examSessionIdFilter,
-    languageCodeFilter,
-    levelCodeFilter,
-    organizerIdFilter,
-    page,
-    searchQueryFilter,
-    size,
-    status,
-  ]);
+  };
 
   return (
     <>
       <ClerkCustomerListingFilter />
-
-      {status !== APIResponseStatus.Success ? (
-        <InfoText status={status} />
-      ) : (
-        <ClerkCustomersListing
-          customers={customers}
-          page={page}
-          pageSize={size}
-          totalCount={totalElements}
-          onPageChange={(newPage) =>
-            dispatch(
-              loadCustomersSearch({
-                request: {
-                  personQuery: searchQueryFilter,
-                  organizerId: organizerIdFilter,
-                  examSessionId: examSessionIdFilter,
-                  languageCode: languageCodeFilter,
-                  levelCode: levelCodeFilter,
-                },
-                page: newPage,
-                size,
-              }),
-            )
-          }
-        />
-      )}
+      {renderClerkCustomersListing()}
     </>
   );
 };

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/material';
 import { useEffect } from 'react';
 import { APIResponseStatus } from 'shared/enums';
 
+import { ClerkCustomerListingFilter } from 'components/clerkCustomer/ClerkCustomerListingFilter';
 import { ClerkCustomersListing } from 'components/clerkCustomer/ClerkCustomersListing';
 import { usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
@@ -49,6 +50,8 @@ export const ClerkCustomerSearch = () => {
 
   return (
     <>
+      <ClerkCustomerListingFilter />
+
       {status !== APIResponseStatus.Success ? (
         <InfoText status={status} />
       ) : (

--- a/frontend/packages/yki/clerk/src/enums/api.ts
+++ b/frontend/packages/yki/clerk/src/enums/api.ts
@@ -7,5 +7,7 @@ export enum APIEndpoints {
   ClerkFreeRegistrationDetailsMessages = '/yki/v2/api/clerk/registration/approval/:id/comment',
   ClerkCustomerDetails = '/yki/v2/api/clerk/customer/:oid',
   ClerkCustomersSearch = '/yki/v2/api/clerk/customer/search?page=:page&size=:size',
+  ExamSession = '/yki/api/exam-session/:examSessionId',
+  ExamSessions = '/yki/api/exam-session',
   User = '/yki/api/user/identity',
 }

--- a/frontend/packages/yki/clerk/src/interfaces/clerkCustomer.ts
+++ b/frontend/packages/yki/clerk/src/interfaces/clerkCustomer.ts
@@ -97,7 +97,7 @@ export type ClerkCustomerSearchParams = {
   request: {
     personQuery?: string;
     organizerId?: number;
-    examDateId?: number;
+    examSessionId?: number;
     languageCode?: string;
     levelCode?: string;
   };

--- a/frontend/packages/yki/clerk/src/interfaces/examSessions.ts
+++ b/frontend/packages/yki/clerk/src/interfaces/examSessions.ts
@@ -7,6 +7,14 @@ export interface ExamSessionsResponse {
   exam_sessions: Array<ExamSessionResponse>;
 }
 
+export interface ExamSessionFilters {
+  language?: ExamLanguage;
+  level?: ExamLevel;
+  municipality?: string;
+  excludeFullSessions: boolean;
+  excludeNonOpenSessions: boolean;
+}
+
 export interface ExamSessions {
   exam_sessions: Array<ExamSession>;
 }
@@ -21,7 +29,7 @@ export interface ExamSessionResponse
   registration_end_date?: string;
 }
 
-interface ExamSessionLocation {
+export interface ExamSessionLocation {
   name: string;
   post_office: string;
   zip: string;

--- a/frontend/packages/yki/clerk/src/interfaces/session.ts
+++ b/frontend/packages/yki/clerk/src/interfaces/session.ts
@@ -1,5 +1,5 @@
-interface AuthenticatedSession {
-  'auth-method': 'CAS';
+export interface AuthenticatedSession {
+  'auth-method': 'CAS' | 'EMAIL' | 'SUOMIFI';
 }
 
 export interface CasAuthenticatedClerkSession extends AuthenticatedSession {

--- a/frontend/packages/yki/clerk/src/redux/reducers/APIError.ts
+++ b/frontend/packages/yki/clerk/src/redux/reducers/APIError.ts
@@ -18,4 +18,4 @@ const APIErrorSlice = createSlice({
 });
 
 export const APIErrorReducer = APIErrorSlice.reducer;
-export const { resetAPIError } = APIErrorSlice.actions;
+export const { setAPIError, resetAPIError } = APIErrorSlice.actions;

--- a/frontend/packages/yki/clerk/src/redux/reducers/clerkCustomersSearch.ts
+++ b/frontend/packages/yki/clerk/src/redux/reducers/clerkCustomersSearch.ts
@@ -9,6 +9,15 @@ import {
 interface ClerkCustomersSearchState {
   customers: ClerkCustomerSummary[];
   status: APIResponseStatus;
+
+  // filter
+  searchQueryFilter?: string;
+  organizerIdFilter?: number;
+  examSessionIdFilter?: number;
+  languageCodeFilter?: string;
+  levelCodeFilter?: 'PERUS' | 'KESKI' | 'YLIN';
+
+  // pagination
   page: number;
   size: number;
   totalElements: number;
@@ -53,17 +62,24 @@ const clerkCustomersSearchSlice = createSlice({
       state.totalElements = action.payload.totalElements;
     },
 
-    setOrganizerFilter(_state, _action: PayloadAction<string>) {
-      // TODO: Save filter to query parameters. Note to claude: Don't implement this unless user wants so.
+    setSearchQueryFilter(state, action: PayloadAction<string>) {
+      state.searchQueryFilter = action.payload;
     },
-    setExamDateFilter(_state, _action: PayloadAction<string>) {
-      // TODO: Save filter to query parameters. Note to claude: Don't implement this unless user wants so.
+    setOrganizerFilter(state, action: PayloadAction<number>) {
+      state.organizerIdFilter = action.payload;
     },
-    setLanguageFilter(_state, _action: PayloadAction<string>) {
-      // TODO: Save filter to query parameters. Note to claude: Don't implement this unless user wants so.
+    setExamSessionFilter(state, action: PayloadAction<number>) {
+      state.examSessionIdFilter = action.payload;
     },
-    setLevelFilter(_state, _action: PayloadAction<string>) {
-      // TODO: Save filter to query parameters. Note to claude: Don't implement this unless user wants so.
+    setLanguageFilter(state, action: PayloadAction<string>) {
+      state.languageCodeFilter = action.payload;
+    },
+    setLevelFilter(
+      state,
+      action: PayloadAction<'' | 'PERUS' | 'KESKI' | 'YLIN'>,
+    ) {
+      state.levelCodeFilter =
+        action.payload === '' ? undefined : action.payload;
     },
   },
 });
@@ -74,8 +90,9 @@ export const {
   loadCustomersSearch,
   rejectCustomersSearch,
   storeCustomersSearch,
+  setSearchQueryFilter,
   setOrganizerFilter,
-  setExamDateFilter,
+  setExamSessionFilter,
   setLanguageFilter,
   setLevelFilter,
 } = clerkCustomersSearchSlice.actions;

--- a/frontend/packages/yki/clerk/src/redux/reducers/clerkCustomersSearch.ts
+++ b/frontend/packages/yki/clerk/src/redux/reducers/clerkCustomersSearch.ts
@@ -62,21 +62,21 @@ const clerkCustomersSearchSlice = createSlice({
       state.totalElements = action.payload.totalElements;
     },
 
-    setSearchQueryFilter(state, action: PayloadAction<string>) {
+    setSearchQueryFilter(state, action: PayloadAction<string | undefined>) {
       state.searchQueryFilter = action.payload;
     },
-    setOrganizerFilter(state, action: PayloadAction<number>) {
+    setOrganizerFilter(state, action: PayloadAction<number | undefined>) {
       state.organizerIdFilter = action.payload;
     },
-    setExamSessionFilter(state, action: PayloadAction<number>) {
+    setExamSessionFilter(state, action: PayloadAction<number | undefined>) {
       state.examSessionIdFilter = action.payload;
     },
-    setLanguageFilter(state, action: PayloadAction<string>) {
+    setLanguageFilter(state, action: PayloadAction<string | undefined>) {
       state.languageCodeFilter = action.payload;
     },
     setLevelFilter(
       state,
-      action: PayloadAction<'' | 'PERUS' | 'KESKI' | 'YLIN'>,
+      action: PayloadAction<'' | 'PERUS' | 'KESKI' | 'YLIN' | undefined>,
     ) {
       state.levelCodeFilter =
         action.payload === '' ? undefined : action.payload;

--- a/frontend/packages/yki/clerk/src/redux/reducers/clerkCustomersSearch.ts
+++ b/frontend/packages/yki/clerk/src/redux/reducers/clerkCustomersSearch.ts
@@ -52,6 +52,19 @@ const clerkCustomersSearchSlice = createSlice({
       state.size = action.payload.size;
       state.totalElements = action.payload.totalElements;
     },
+
+    setOrganizerFilter(_state, _action: PayloadAction<string>) {
+      // TODO: Save filter to query parameters. Note to claude: Don't implement this unless user wants so.
+    },
+    setExamDateFilter(_state, _action: PayloadAction<string>) {
+      // TODO: Save filter to query parameters. Note to claude: Don't implement this unless user wants so.
+    },
+    setLanguageFilter(_state, _action: PayloadAction<string>) {
+      // TODO: Save filter to query parameters. Note to claude: Don't implement this unless user wants so.
+    },
+    setLevelFilter(_state, _action: PayloadAction<string>) {
+      // TODO: Save filter to query parameters. Note to claude: Don't implement this unless user wants so.
+    },
   },
 });
 
@@ -61,4 +74,8 @@ export const {
   loadCustomersSearch,
   rejectCustomersSearch,
   storeCustomersSearch,
+  setOrganizerFilter,
+  setExamDateFilter,
+  setLanguageFilter,
+  setLevelFilter,
 } = clerkCustomersSearchSlice.actions;

--- a/frontend/packages/yki/clerk/src/redux/reducers/examSession.ts
+++ b/frontend/packages/yki/clerk/src/redux/reducers/examSession.ts
@@ -1,0 +1,34 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { APIResponseStatus } from 'shared/enums';
+
+import { ExamSession } from 'interfaces/examSessions';
+
+interface ExamSessionState {
+  status: APIResponseStatus;
+  examSession?: ExamSession;
+}
+
+const initialState: ExamSessionState = {
+  status: APIResponseStatus.NotStarted,
+};
+
+const examSessionSlice = createSlice({
+  name: 'examSession',
+  initialState,
+  reducers: {
+    loadExamSession(state, _action: PayloadAction<number>) {
+      state.status = APIResponseStatus.InProgress;
+    },
+    rejectExamSession(state) {
+      state.status = APIResponseStatus.Error;
+    },
+    storeExamSession(state, action: PayloadAction<ExamSession>) {
+      state.status = APIResponseStatus.Success;
+      state.examSession = action.payload;
+    },
+  },
+});
+
+export const examSessionReducer = examSessionSlice.reducer;
+export const { loadExamSession, rejectExamSession, storeExamSession } =
+  examSessionSlice.actions;

--- a/frontend/packages/yki/clerk/src/redux/reducers/examSessions.ts
+++ b/frontend/packages/yki/clerk/src/redux/reducers/examSessions.ts
@@ -1,0 +1,57 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { APIResponseStatus } from 'shared/enums';
+
+import { ExamSessionFilters, ExamSessions } from 'interfaces/examSessions';
+import { ExamSessionUtils } from 'utils/examSession';
+
+interface ExamSessionsState extends ExamSessions {
+  status: APIResponseStatus;
+  filters: ExamSessionFilters;
+  municipalities: Array<string>;
+}
+
+const initialState: ExamSessionsState = {
+  exam_sessions: [],
+  municipalities: [],
+  status: APIResponseStatus.NotStarted,
+  filters: {
+    language: undefined,
+    level: undefined,
+    municipality: undefined,
+    excludeFullSessions: false,
+    excludeNonOpenSessions: false,
+  },
+};
+
+const examSessionsSlice = createSlice({
+  name: 'examSessions',
+  initialState,
+  reducers: {
+    loadExamSessions(state) {
+      state.status = APIResponseStatus.InProgress;
+    },
+    rejectExamSessions(state) {
+      state.status = APIResponseStatus.Error;
+    },
+    storeExamSessions(state, action: PayloadAction<ExamSessions>) {
+      const examSessions = action.payload.exam_sessions.sort((es1, es2) =>
+        ExamSessionUtils.compareExamSessions(es1, es2),
+      );
+      const uniqueMunicipalities = new Set(
+        examSessions.map((es) =>
+          ExamSessionUtils.getMunicipality(es.location[0]),
+        ),
+      );
+
+      state.status = APIResponseStatus.Success;
+      state.exam_sessions = examSessions;
+      state.municipalities = Array.from(uniqueMunicipalities).sort(
+        new Intl.Collator('fi').compare,
+      );
+    },
+  },
+});
+
+export const examSessionsReducer = examSessionsSlice.reducer;
+export const { loadExamSessions, rejectExamSessions, storeExamSessions } =
+  examSessionsSlice.actions;

--- a/frontend/packages/yki/clerk/src/redux/sagas/examSession.ts
+++ b/frontend/packages/yki/clerk/src/redux/sagas/examSession.ts
@@ -1,0 +1,66 @@
+import { call, put, takeLatest } from '@redux-saga/core/effects';
+import { PayloadAction } from '@reduxjs/toolkit';
+import { AxiosResponse } from 'axios';
+
+import axiosInstance from 'configs/axios';
+import { translateOutsideComponent } from 'configs/i18n';
+import { APIEndpoints } from 'enums/api';
+import {
+  ExamSessionResponse,
+  ExamSessionsResponse,
+} from 'interfaces/examSessions';
+import { setAPIError } from 'redux/reducers/APIError';
+import {
+  loadExamSession,
+  rejectExamSession,
+  storeExamSession,
+} from 'redux/reducers/examSession';
+import {
+  loadExamSessions,
+  rejectExamSessions,
+  storeExamSessions,
+} from 'redux/reducers/examSessions';
+import { SerializationUtils } from 'utils/serialization';
+
+function* loadExamSessionsSaga() {
+  const t = translateOutsideComponent();
+  try {
+    const response: AxiosResponse<ExamSessionsResponse> = yield call(
+      axiosInstance.get,
+      APIEndpoints.ExamSessions,
+    );
+
+    yield put(
+      storeExamSessions(
+        SerializationUtils.deserializeExamSessionsResponse(response.data),
+      ),
+    );
+  } catch (error) {
+    yield put(rejectExamSessions());
+    yield put(setAPIError(t('yki.common.error')));
+  }
+}
+
+function* loadExamSessionSaga(action: PayloadAction<number>) {
+  const t = translateOutsideComponent();
+  try {
+    const response: AxiosResponse<ExamSessionResponse> = yield call(
+      axiosInstance.get,
+      APIEndpoints.ExamSession.replace(/:examSessionId$/, `${action.payload}`),
+    );
+
+    yield put(
+      storeExamSession(
+        SerializationUtils.deserializeExamSessionResponse(response.data),
+      ),
+    );
+  } catch (error) {
+    yield put(rejectExamSession());
+    yield put(setAPIError(t('yki.common.error')));
+  }
+}
+
+export function* watchExamSessions() {
+  yield takeLatest(loadExamSessions.type, loadExamSessionsSaga);
+  yield takeLatest(loadExamSession.type, loadExamSessionSaga);
+}

--- a/frontend/packages/yki/clerk/src/redux/sagas/index.ts
+++ b/frontend/packages/yki/clerk/src/redux/sagas/index.ts
@@ -5,6 +5,7 @@ import { watchClerkCustomersSearch } from 'redux/sagas/clerkCustomersSearch';
 import { watchClerkFreeRegistrations } from 'redux/sagas/clerkFreeRegistration';
 import { watchClerkFreeRegistrationDetails } from 'redux/sagas/clerkFreeRegistrationDetails';
 import { watchClerkOrganizers } from 'redux/sagas/clerkOrganizer';
+import { watchExamSessions } from 'redux/sagas/examSession';
 import { watchNationalities } from 'redux/sagas/nationalities';
 import { watchSession } from 'redux/sagas/session';
 
@@ -15,6 +16,7 @@ export default function* rootSaga() {
     watchClerkFreeRegistrationDetails(),
     watchClerkCustomerDetails(),
     watchClerkCustomersSearch(),
+    watchExamSessions(),
     watchNationalities(),
     watchSession(),
   ]);

--- a/frontend/packages/yki/clerk/src/redux/selectors/examSession.ts
+++ b/frontend/packages/yki/clerk/src/redux/selectors/examSession.ts
@@ -1,0 +1,3 @@
+import { RootState } from 'configs/redux';
+
+export const examSessionsSelector = (state: RootState) => state.examSessions;

--- a/frontend/packages/yki/clerk/src/redux/store/index.ts
+++ b/frontend/packages/yki/clerk/src/redux/store/index.ts
@@ -8,6 +8,8 @@ import { clerkCustomersSearchReducer } from 'redux/reducers/clerkCustomersSearch
 import { clerkFreeRegistrationReducer } from 'redux/reducers/clerkFreeRegistration';
 import { clerkFreeRegistrationDetailsReducer } from 'redux/reducers/clerkFreeRegistrationDetails';
 import { clerkOrganizersReducer } from 'redux/reducers/clerkOrganizer';
+import { examSessionReducer } from 'redux/reducers/examSession';
+import { examSessionsReducer } from 'redux/reducers/examSessions';
 import { nationalitiesReducer } from 'redux/reducers/nationalities';
 import { sessionReducer } from 'redux/reducers/session';
 import rootSaga from 'redux/sagas/index';
@@ -21,6 +23,8 @@ export const rootReducer = combineReducers({
   clerkFreeRegistrationDetails: clerkFreeRegistrationDetailsReducer,
   clerkCustomerDetails: clerkCustomerDetailsReducer,
   clerkCustomersSearch: clerkCustomersSearchReducer,
+  examSession: examSessionReducer,
+  examSessions: examSessionsReducer,
   nationalities: nationalitiesReducer,
   session: sessionReducer,
 });

--- a/frontend/packages/yki/clerk/src/tests/cypress/integration/clerk/customerSearch/customer_search_page.spec.ts
+++ b/frontend/packages/yki/clerk/src/tests/cypress/integration/clerk/customerSearch/customer_search_page.spec.ts
@@ -6,36 +6,39 @@ describe('CustomerSearchPage', () => {
     cy.openCustomerSearchPage();
   });
 
-  it('is visible', () => {
-    cy.openClerkCustomersSearchPage();
+  it('shows empty state before search', () => {
     cy.findByRole('heading', { name: 'Asiakashaku' }).should('be.visible');
+    onClerkCustomersSearchPage.expectNoTable();
+  });
 
-    // "header"
-    cy.findAllByText('103 osallistujaa').should('be.visible');
+  it('search with query filters results', () => {
+    onClerkCustomersSearchPage.search('Salla');
 
-    const personsTable = onClerkCustomersSearchPage.elements.table;
-
-    // Assert headers
-    personsTable().find('thead tr th').first().should('have.text', 'Nimi');
-    personsTable()
-      .find('thead tr th')
-      .eq(1)
-      .should('have.text', 'Ilmoittautumiset');
-
-    // Assert first row
-    personsTable()
-      .find('tbody tr td')
+    onClerkCustomersSearchPage.elements.table().should('be.visible');
+    onClerkCustomersSearchPage.elements
+      .table()
+      .find('tbody tr')
       .first()
-      .should('contain.text', 'Jori Testi Häkkinen-Testi')
-      .and('contain.text', '280105A911J')
-      .and('contain.text', '1.2.246.562.24.82364099322');
+      .should('contain.text', 'Salla');
+  });
 
-    personsTable().find('tbody tr td').eq(1).should('have.text', '11');
+  it('pagination navigates between pages', () => {
+    onClerkCustomersSearchPage.search('');
+
+    cy.findByText('103 osallistujaa').should('be.visible');
+    onClerkCustomersSearchPage.expectTableRowCount(20);
+
+    cy.findByRole('button', { name: /mene sivulle 2/i }).click();
+    onClerkCustomersSearchPage.expectTableRowCount(20);
+
+    cy.findByRole('button', { name: /mene sivulle 6/i }).click();
+    onClerkCustomersSearchPage.expectTableRowCount(3);
   });
 
   it('navigates to customer details page when clicking a row', () => {
-    const oid = '1.2.246.562.24.82364099322';
+    onClerkCustomersSearchPage.search('');
 
+    const oid = '1.2.246.562.24.82364099322';
     cy.findByRole('link', { name: 'Jori Testi Häkkinen-Testi' }).click();
     cy.url().should('include', oid);
     onClerkCustomerDetailsPage.isVisible(oid);

--- a/frontend/packages/yki/clerk/src/tests/cypress/support/page-objects/clerkCustomersSearchPage.ts
+++ b/frontend/packages/yki/clerk/src/tests/cypress/support/page-objects/clerkCustomersSearchPage.ts
@@ -1,9 +1,27 @@
 class ClerkCustomersSearchPage {
   elements = {
-    title: () => cy.findByText('Asiaskashaku'),
-
+    title: () => cy.findByText('Asiakashaku'),
     table: () => cy.get('table'),
+    searchInput: () => cy.findByLabelText(/hae osallistujaa/i),
+    searchButton: () => cy.findByRole('button', { name: /hae osallistujia/i }),
+    totalCountHeader: () => cy.findByText(/\d+ osallistujaa/),
   };
+
+  search(query: string) {
+    if (query) {
+      this.elements.searchInput().clear();
+      this.elements.searchInput().type(query);
+    }
+    this.elements.searchButton().click();
+  }
+
+  expectTableRowCount(count: number) {
+    this.elements.table().find('tbody tr').should('have.length', count);
+  }
+
+  expectNoTable() {
+    cy.get('table').should('not.exist');
+  }
 }
 
 export const onClerkCustomersSearchPage = new ClerkCustomersSearchPage();

--- a/frontend/packages/yki/clerk/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/clerk/src/tests/msw/handlers.ts
@@ -1,9 +1,11 @@
+import dayjs from 'dayjs';
 import { http, HttpResponse } from 'msw';
 
 import { APIEndpoints } from 'enums/api';
 import { customerDetails } from 'tests/msw/fixtures/customerDetails';
 import { allCustomers } from 'tests/msw/fixtures/customersSearch';
 import { examSessions } from 'tests/msw/fixtures/examSession';
+import { findByOidsResponse } from 'tests/msw/fixtures/findByOids';
 import { maatJaValtiot2Response } from 'tests/msw/fixtures/maatjavaltiot2';
 import { organizers } from 'tests/msw/fixtures/organizers';
 
@@ -164,5 +166,24 @@ export const handlers = [
     } else {
       return notFound();
     }
+  }),
+  http.post('/organisaatio-service/rest/organisaatio/v3/findbyoids', () => {
+    return HttpResponse.json(findByOidsResponse);
+  }),
+  http.get('/yki/api/clerk/organizer/:oid/exam-session', ({ params }) => {
+    const { from } = params;
+
+    const filteredExamSessions = from
+      ? examSessions.exam_sessions.filter((e) => {
+          return (
+            dayjs().isSame(dayjs(e.session_date), 'day') ||
+            dayjs().isAfter(dayjs(e.session_date), 'day')
+          );
+        })
+      : examSessions.exam_sessions;
+
+    return HttpResponse.json({ exam_sessions: filteredExamSessions });
+    // all exam dates
+    // return HttpResponse.json({ dates: examDates.dates });
   }),
 ];

--- a/frontend/packages/yki/clerk/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/clerk/src/tests/msw/handlers.ts
@@ -75,9 +75,16 @@ export const handlers = [
       return notFound();
     }
   }),
-
   http.post(APIEndpoints.ClerkCustomersSearch, async ({ request }) => {
     const url = new URL(request.url);
+    const body = (await request.json()) as {
+      personQuery?: string;
+      organizerId?: number;
+      examSessionId?: number;
+      languageCode?: string;
+      levelCode?: string;
+    };
+
     const getNumberParam = (urlParam: string, fallback: number) => {
       const param = Number(url.searchParams.get(urlParam));
 
@@ -87,8 +94,37 @@ export const handlers = [
     const page = getNumberParam('page', 0);
     const size = getNumberParam('size', 20);
 
-    // Emulating pagination
-    const filtered = allCustomers; // return every customer, for testing
+    const personQuery = body.personQuery?.trim() ?? '';
+    if (personQuery.length > 0 && personQuery.length <= 2) {
+      return HttpResponse.json(
+        {
+          error:
+            'When given the person query, it must have atleast three characters',
+        },
+        { status: 400 },
+      );
+    }
+
+    const searchTerms = personQuery.toLowerCase().split(/\s+/).filter(Boolean);
+
+    const matchesSearchTerms = (customer: (typeof allCustomers)[0]) => {
+      if (searchTerms.length === 0) {
+        return true;
+      }
+
+      const searchableText = [
+        customer.person.oid,
+        customer.person.firstName,
+        customer.person.lastName,
+        customer.person.email ?? '',
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      return searchTerms.every((term) => searchableText.includes(term));
+    };
+
+    const filtered = allCustomers.filter(matchesSearchTerms);
     const start = page * size;
     const paged = filtered.slice(start, start + size);
     const totalElements = filtered.length;
@@ -115,25 +151,5 @@ export const handlers = [
       numberOfElements: paged.length,
       empty: paged.length === 0,
     });
-  }),
-  http.post('/organisaatio-service/rest/organisaatio/v3/findbyoids', () => {
-    return HttpResponse.json(findByOidsResponse);
-  }),
-
-  http.get('/yki/api/clerk/organizer/:oid/exam-session', ({ params }) => {
-    const { from } = params;
-
-    const filteredExamSessions = from
-      ? examSessions.exam_sessions.filter((e) => {
-          return (
-            dayjs().isSame(dayjs(e.session_date), 'day') ||
-            dayjs().isAfter(dayjs(e.session_date), 'day')
-          );
-        })
-      : examSessions.exam_sessions;
-
-    return HttpResponse.json({ exam_sessions: filteredExamSessions });
-    // all exam dates
-    // return HttpResponse.json({ dates: examDates.dates });
   }),
 ];

--- a/frontend/packages/yki/clerk/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/clerk/src/tests/msw/handlers.ts
@@ -1,11 +1,9 @@
-import dayjs from 'dayjs';
 import { http, HttpResponse } from 'msw';
 
 import { APIEndpoints } from 'enums/api';
 import { customerDetails } from 'tests/msw/fixtures/customerDetails';
 import { allCustomers } from 'tests/msw/fixtures/customersSearch';
 import { examSessions } from 'tests/msw/fixtures/examSession';
-import { findByOidsResponse } from 'tests/msw/fixtures/findByOids';
 import { maatJaValtiot2Response } from 'tests/msw/fixtures/maatjavaltiot2';
 import { organizers } from 'tests/msw/fixtures/organizers';
 
@@ -151,5 +149,20 @@ export const handlers = [
       numberOfElements: paged.length,
       empty: paged.length === 0,
     });
+  }),
+  http.get(
+    APIEndpoints.ExamSessions,
+    () => new Response(JSON.stringify(examSessions), { status: 200 }),
+  ),
+  http.get(APIEndpoints.ExamSession, ({ params }) => {
+    const { examSessionId } = params;
+    const examSession = examSessions.exam_sessions.find(
+      (es) => es.id === Number(examSessionId),
+    );
+    if (examSession) {
+      return HttpResponse.json(examSession);
+    } else {
+      return notFound();
+    }
   }),
 ];

--- a/frontend/packages/yki/clerk/src/utils/examSession.ts
+++ b/frontend/packages/yki/clerk/src/utils/examSession.ts
@@ -1,0 +1,163 @@
+import { AppLanguage } from 'shared/enums';
+import { StringUtils } from 'shared/utils';
+
+import { translateOutsideComponent } from 'configs/i18n';
+import { ExamLanguage, ExamLevel } from 'enums/app';
+import { ExamSession, ExamSessionLocation } from 'interfaces/examSessions';
+import { AuthenticatedSession } from 'interfaces/session';
+
+export class ExamSessionUtils {
+  private static getRegistrationAvailablePlaces(examSession: ExamSession) {
+    return Math.max(examSession.max_participants - examSession.participants, 0);
+  }
+
+  static getAvailablePlaces(examSession: ExamSession) {
+    if (!examSession.upcoming_admission || examSession.queue) {
+      return 0;
+    } else {
+      return ExamSessionUtils.getRegistrationAvailablePlaces(examSession);
+    }
+  }
+
+  static hasRoom(examSession: ExamSession) {
+    return ExamSessionUtils.getAvailablePlaces(examSession) > 0;
+  }
+
+  private static compareExamSessionsByAdmissionAvailability(
+    es1: ExamSession,
+    es2: ExamSession,
+  ) {
+    if (es1.open && !es2.open) {
+      return -1;
+    } else if (!es1.open && es2.open) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  private static compareExamSessionsByLang(es1: ExamSession, es2: ExamSession) {
+    // Note: this is a silly comparison of language codes.
+    // Use when the actual order between exam languages is not a major concern,
+    // but exam sessions should just be grouped by language.
+    if (es1.language_code < es2.language_code) {
+      return -1;
+    } else if (es1.language_code > es2.language_code) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  private static compareExamSessionsByRoom(es1: ExamSession, es2: ExamSession) {
+    const hasRoom1 = ExamSessionUtils.hasRoom(es1);
+    const hasRoom2 = ExamSessionUtils.hasRoom(es2);
+
+    if (hasRoom1 && !hasRoom2) {
+      return -1;
+    } else if (!hasRoom1 && hasRoom2) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  private static compareExamSessionsByDate(es1: ExamSession, es2: ExamSession) {
+    if (es1.session_date.isBefore(es2.session_date)) {
+      return -1;
+    } else if (es1.session_date.isAfter(es2.session_date)) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  static compareExamSessions(es1: ExamSession, es2: ExamSession) {
+    // Prioritised ordering of comparators
+    const comparatorFns = [
+      ExamSessionUtils.compareExamSessionsByAdmissionAvailability,
+      ExamSessionUtils.compareExamSessionsByRoom,
+      ExamSessionUtils.compareExamSessionsByDate,
+      ExamSessionUtils.compareExamSessionsByLang,
+    ];
+
+    for (let i = 0; i < comparatorFns.length; i++) {
+      const order = comparatorFns[i](es1, es2);
+
+      if (order !== 0) {
+        return order;
+      }
+    }
+
+    return 0;
+  }
+
+  static languageAndLevelText({
+    language_code,
+    level_code,
+  }: {
+    language_code: ExamLanguage;
+    level_code: ExamLevel;
+  }) {
+    const t = translateOutsideComponent();
+
+    return `${t('yki.common.languages.' + language_code)}, ${t(
+      'yki.common.languageLevel.' + level_code,
+    )}`;
+  }
+
+  static getLocationInfo(es: Pick<ExamSession, 'location'>, lang: AppLanguage) {
+    const locationData = es.location.find(
+      (esl) =>
+        (lang === AppLanguage.Finnish && esl.lang === 'fi') ||
+        (lang === AppLanguage.Swedish && esl.lang === 'sv') ||
+        (lang === AppLanguage.English && esl.lang === 'en'),
+    );
+
+    return locationData as ExamSessionLocation;
+  }
+
+  static getEffectiveRegistrationPeriodDetails(examSession: ExamSession) {
+    return {
+      kind: examSession.available_registration_kind,
+      start: examSession.registration_start_date,
+      end: examSession.registration_end_date,
+      participants: examSession.participants,
+      quota: examSession.max_participants,
+      availablePlaces: ExamSessionUtils.getAvailablePlaces(examSession),
+      open: examSession.open,
+      queue: examSession.queue,
+    };
+  }
+
+  static getMunicipality(location: ExamSessionLocation) {
+    return StringUtils.capitalize(
+      StringUtils.trimAndLowerCase(location.post_office),
+    );
+  }
+
+  static freeRegistrationPossible(
+    { level_code, language_code }: ExamSession,
+    authenticatedSession?: AuthenticatedSession,
+  ) {
+    if (
+      authenticatedSession &&
+      authenticatedSession['auth-method'] !== 'SUOMIFI'
+    ) {
+      return false;
+    }
+
+    if (level_code !== ExamLevel.YLIN) {
+      return false;
+    }
+
+    if (
+      language_code !== ExamLanguage.FIN &&
+      language_code !== ExamLanguage.SWE
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
## Yhteenveto

<img width="1256" height="700" alt="image" src="https://github.com/user-attachments/assets/341903a5-25b4-4101-b8cd-888d7a72ba77" />

## Testausohjeet bäkkärin kanssa
```sh
# Käynnistä bäkkäri IDEA:ssa tai jotenkin muuten

# ota MSW pois päältä
echo "USE_MSW=false" > frontend/packages/yki/.env

# käynnistä frontti
cd frontend/packages/yki
yarn run yki:start:dev-server  
```

## Lisätiedot
* Ei näytetä tuloksia ensimmäisessä sivun latauksessa. Vasta kun käyttäjä hakee tietoja
* Kopioitu vahvasti `ClerkRegisterListingFilters.tsx` - kompoentistä,  mukaan lukien tyylit
* Jos kentän on Kaikki == tyhjä arvo, bäkkäri tulkitsee sen kaikki-valinnaksi.
Tyhjä arvo hakee myös haikki `Hae osallistujaa` - kentällä.
* Hakukentän suurennuslasi-ikoni toimii identtisesti `Hae osallistujia` - näppäimen kanssa
* Puuttuu `vain yksilöimättömät osallistujat`, koska en oo varma, että miten sen pitäisi toimia. Voisiko tämän toteuttaa myöhemmin?
* Taulukosta puuttuu paginoinnin sivun koon määritys. (Bäkkärillähän on jo tää toteutetttu). En tehnyt tässä, koska tää pullar i keskittyy enemmän noihin filtteröinteihin. Se pitänee varmaan joka tapauksessa toteuttaa

## Huomautukset

* Lisätty ohjeistus claudelle. Tuo on varmaan vielä aika sotkuinen, sen vois varmaan syöttää claudelle itselleen ja pyytää sitä kirjoittamaan järkevämmät ohjeet

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
