### PR TITLE
CI: Upgrade and pin used versions of GH actions

### DIFF
--- a/.github/workflows/common-backend.yml
+++ b/.github/workflows/common-backend.yml
@@ -26,29 +26,32 @@ jobs:
     if: ${{ contains(github.event.head_commit.message, inputs.app-name) || contains(github.ref, 'snyk-io') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache/restore v5.0.3
         if: ${{ !inputs.yki-separate-frontend-builds }}
         with:
           path: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}/src/main/resources/static
           key: ${{ runner.os }}-${{ inputs.app-name }}-frontend-build-${{ github.sha }}
-      - uses: actions/cache@v3
+          fail-on-cache-miss: true
+      - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache/restore v5.0.3
         if: ${{ inputs.yki-separate-frontend-builds }}
         with:
           path: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}/src/main/resources/static/public
           key: ${{ runner.os }}-${{ inputs.app-name }}-public-frontend-build-${{ github.sha }}
-      - uses: actions/cache@v3
+          fail-on-cache-miss: true
+      - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache/restore v5.0.3
         if: ${{ inputs.yki-separate-frontend-builds }}
         with:
           path: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}/src/main/resources/static/v2/clerk
           key: ${{ runner.os }}-${{ inputs.app-name }}-clerk-frontend-build-${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
@@ -78,7 +81,7 @@ jobs:
         env:
           GITHUB_USERNAME: ${{ github.actor }}
           GITHUB_REGISTRY_TOKEN: ${{ github.token }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         with:
           path: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}/target/${{ inputs.app-name }}-*.jar
           key: ${{ runner.os }}-${{ inputs.app-name }}-backend-build-${{ github.sha }}

--- a/.github/workflows/common-deploy.yml
+++ b/.github/workflows/common-deploy.yml
@@ -34,11 +34,12 @@ jobs:
       }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
+      - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache/restore v5.0.3
         with:
           path: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}/target/${{ inputs.app-name }}-*.jar
           key: ${{ runner.os }}-${{ inputs.app-name }}-backend-build-${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Build Docker container
         if: ${{ !inputs.with-wkhtmltopdf }}
         working-directory: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}

--- a/.github/workflows/common-frontend.yml
+++ b/.github/workflows/common-frontend.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         node-version: [20.9.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
       - uses: szenius/set-timezone@v1.1
         with:
           timezoneLinux: "Europe/Helsinki"
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache Yarn modules
-        uses: actions/cache@v3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         id: yarn-cache
         with:
           path: "**/node_modules"
@@ -53,7 +53,7 @@ jobs:
         working-directory: ${{ env.FRONTEND_DIR }}
         run: yarn ${{ inputs.app-name }}:test:jest
       - name: Cache Cypress
-        uses: actions/cache@v3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         id: cypress-cache
         with:
           path: "~/.cache/Cypress"
@@ -83,7 +83,7 @@ jobs:
         working-directory: ${{ env.FRONTEND_DIR }}
         run: yarn ${{ inputs.app-name }}:build
       - name: Cache build
-        uses: actions/cache@v3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         with:
           path: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}/src/main/resources/static
           key: ${{ runner.os }}-${{ inputs.app-name }}-frontend-build-${{ github.sha }}

--- a/.github/workflows/shared_frontend.yml
+++ b/.github/workflows/shared_frontend.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         node-version: [20.9.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
       - uses: szenius/set-timezone@v1.1
         with:
           timezoneLinux: "Europe/Helsinki"
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         id: yarn-cache
         with:
           path: "**/node_modules"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -9,7 +9,7 @@ jobs:
   trivy-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
       - name: Scan vulnerabilities with Trivy
         uses: aquasecurity/trivy-action@0.29.0
         with:

--- a/.github/workflows/yki-clerk-frontend.yml
+++ b/.github/workflows/yki-clerk-frontend.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         node-version: [20.9.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
       - uses: szenius/set-timezone@v1.1
         with:
           timezoneLinux: "Europe/Helsinki"
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache Yarn modules
-        uses: actions/cache@v3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         id: yarn-cache
         with:
           path: "**/node_modules"
@@ -53,7 +53,7 @@ jobs:
         working-directory: ${{ env.FRONTEND_DIR }}
         run: yarn ${{ inputs.app-name }}:clerk:test:jest
       - name: Cache Cypress
-        uses: actions/cache@v3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         id: cypress-cache
         with:
           path: "~/.cache/Cypress"
@@ -83,7 +83,7 @@ jobs:
         working-directory: ${{ env.FRONTEND_DIR }}
         run: yarn ${{ inputs.app-name }}:clerk:build
       - name: Cache build
-        uses: actions/cache@v3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         with:
           path: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}/src/main/resources/static/v2/clerk
           key: ${{ runner.os }}-${{ inputs.app-name }}-clerk-frontend-build-${{ github.sha }}

--- a/.github/workflows/yki-public-frontend.yml
+++ b/.github/workflows/yki-public-frontend.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         node-version: [20.9.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
       - uses: szenius/set-timezone@v1.1
         with:
           timezoneLinux: "Europe/Helsinki"
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache Yarn modules
-        uses: actions/cache@v3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         id: yarn-cache
         with:
           path: "**/node_modules"
@@ -53,7 +53,7 @@ jobs:
         working-directory: ${{ env.FRONTEND_DIR }}
         run: yarn ${{ inputs.app-name }}:test:jest
       - name: Cache Cypress
-        uses: actions/cache@v3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         id: cypress-cache
         with:
           path: "~/.cache/Cypress"
@@ -83,7 +83,7 @@ jobs:
         working-directory: ${{ env.FRONTEND_DIR }}
         run: yarn ${{ inputs.app-name }}:build
       - name: Cache build
-        uses: actions/cache@v3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # actions/cache v5.0.3
         with:
           path: ${{ env.BACKEND_DIR }}/${{ inputs.app-name }}/src/main/resources/static/public
           key: ${{ runner.os }}-${{ inputs.app-name }}-public-frontend-build-${{ github.sha }}


### PR DESCRIPTION
- Bump actions/checkout to v6.0.2
- Bump actions/cache to v5.0.3
- Use actions/cache/restore instead of actions/cache where just a cache lookup will do
- Fail fast if cache is not found where expected
