### PR TITLE
OPHKIOS-186: bugfixes

### DIFF
--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerController.java
@@ -50,7 +50,7 @@ public class ClerkCustomerController {
 
     if (request.personQuery() != null) {
       final var personQuery = request.personQuery().trim();
-      if (personQuery.length() <= 2) {
+      if (!personQuery.isEmpty() && personQuery.length() <= 2) {
         throw new IllegalArgumentException("When given the person query, it must have atleast three characters");
       }
     }

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -35,6 +37,7 @@ public class ClerkCustomerService {
   private final PersonRepository personRepository;
   private final RegistrationRepository registrationRepository;
   private final OnrService onrService;
+  private static final Logger LOG = LoggerFactory.getLogger(ClerkCustomerService.class);
 
   private PersonalDataDTO getPersonalData(final String oid) throws RuntimeException {
     try {
@@ -163,6 +166,7 @@ public class ClerkCustomerService {
           identityNumber = onrService.getPersonalData(person.oid()).getIdentityNumber();
         } catch (final Exception e) {
           identityNumber = null;
+          LOG.error("Unable to get identity number from ONR for oid: {}", person.oid(), e);
         }
 
         return ClerkCustomerSummaryDTO

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -157,15 +157,22 @@ public class ClerkCustomerService {
     final ClerkCustomerSearchRequestDTO request
   ) throws ExecutionException, InterruptedException, JsonProcessingException, RuntimeException {
     return searchPersons(pageable, request)
-      .map(person ->
-        ClerkCustomerSummaryDTO
+      .map(person -> {
+        String identityNumber;
+        try {
+          identityNumber = onrService.getPersonalData(person.oid()).getIdentityNumber();
+        } catch (final Exception e) {
+          identityNumber = null;
+        }
+
+        return ClerkCustomerSummaryDTO
           .builder()
           .person(
             ClerkCustomerPersonDTO
               .builder()
               .firstName(person.firstName())
               .lastName(person.lastName())
-              .ssn(getPersonalData(person.oid()).getIdentityNumber())
+              .ssn(identityNumber)
               .oid(person.oid())
               .nationalityCode(person.nationalityCode())
               .phoneNumber(person.phoneNumber())
@@ -174,7 +181,7 @@ public class ClerkCustomerService {
               .build()
           )
           .registrationsCount(person.registrationsCount() == null ? 0 : person.registrationsCount())
-          .build()
-      );
+          .build();
+      });
   }
 }

--- a/frontend/packages/yki/clerk/CLAUDE.md
+++ b/frontend/packages/yki/clerk/CLAUDE.md
@@ -1,0 +1,102 @@
+# YKI Clerk Frontend
+
+This is the clerk (virkailija) UI for YKI (Yleiset kielitutkinnot). 
+
+## Local Development
+
+```bash
+# With MSW mocks (preferred for frontend-only development)
+yarn yki:clerk:start:msw
+
+# With real backend at localhost:8083
+yarn yki:clerk:start
+```
+
+Uses webpack with hot reload.
+
+## Code Style
+
+Follow existing code patterns. When creating new components, copy similar existing components to maintain consistency.
+
+- Prettier: 2-space indent, single quotes, 80 char line width
+- ESLint: absolute imports only (no relative `./` imports), alphabetized imports
+- Import order: external packages first, then internal modules (separated by blank line)
+- Blank line before return statements
+
+## Project Structure
+
+```
+src/
+├── components/          # React components grouped by feature
+├── configs/             # axios, i18n, redux configuration
+├── enums/               # TypeScript enums (api.ts has endpoints)
+├── hooks/               # Custom React hooks
+├── interfaces/          # TypeScript interfaces
+├── pages/               # Page components (routed views)
+├── redux/
+│   ├── reducers/        # Redux Toolkit slices
+│   ├── sagas/           # Redux-saga side effects
+│   └── selectors/       # Reselect selectors
+├── routers/             # React Router configuration
+├── styles/              # SCSS files (components have own .scss)
+└── tests/
+    ├── cypress/         # Integration tests
+    ├── jest/            # Unit tests (minimal)
+    └── msw/
+        ├── fixtures/    # Mock data
+        └── handlers.ts  # MSW request handlers
+public/
+└── i18n/                # Translation files (fi-FI, sv-SE, en-GB)
+```
+
+## State Management
+
+Redux Toolkit with redux-saga:
+
+1. **Reducer** (`redux/reducers/`) - createSlice with actions
+2. **Saga** (`redux/sagas/`) - handles API calls, dispatches store/reject actions
+3. **Selector** (`redux/selectors/`) - derives data from state
+
+Pattern: `load*` action triggers saga → saga calls API → deserialize → `store*` or `reject*` action updates state.
+
+API responses are deserialized in [src/utils/serialization.ts](src/utils/serialization.ts) before storing in Redux (e.g., date strings → dayjs objects).
+
+## API Endpoints
+
+- Defined in [src/enums/api.ts](src/enums/api.ts)
+- Path params use `:param` syntax (e.g., `/customer/:oid`)
+- Replace params in sagas: `APIEndpoints.X.replace(/:param$/, value)`
+- Old API uses snake_case, new API (v2) uses camelCase
+
+## MSW Mocks
+
+When developing, endpoints are mocked in [src/tests/msw/handlers.ts](src/tests/msw/handlers.ts):
+- Add fixture data in `src/tests/msw/fixtures/`
+- Import and use in handlers.ts
+
+## i18n Translations
+
+- Files: `public/i18n/{fi-FI,sv-SE,en-GB}/{common,public}.json`
+- During development: write Finnish text, copy same value to Swedish and English
+- Use `useCommonTranslation()` hook with `keyPrefix: 'yki.common'`
+- Translators will translate later
+
+## Styling
+
+- SCSS files in `src/styles/`
+- Components have their own `.scss` files in corresponding folders
+- Global styles and variables in `styles/base/` and `styles/colors/`
+
+## Testing
+
+- Cypress integration tests in `src/tests/cypress/`
+- Run: `yarn yki:clerk:test:cypress` or `yarn yki:clerk:test:cypress:open`
+- Fixtures (`tests/msw/fixtures/`) contain hardcoded values used by both MSW handlers and tests
+- Tests can assert against fixture values directly (import from fixtures)
+
+## Shared Package
+
+The `shared` package provides common utilities, enums, and types:
+- `APIResponseStatus` enum for loading states
+- `DateUtils` for date formatting
+- `AppLanguage`, `I18nNamespace` enums


### PR DESCRIPTION
## Virhe 1
 * Kuvaus: Joskus koko kysely aiheuttaa `Tietojen haku epäonnistui`.
 * Syy: ONR-haku aiheuttaa virheen
 * Korjaus: catchataan virhe -> laitetaan hetun arvoksi null, kun tämä haku epäonnistuu


## Virhe 2:
* Kuvaus: Jos hakee laittamalla jotain `Hae osallistujaa` - kenttään, filtteröinti toimii oikein. Sen jälkeen, jos poistaa arvon ja hakee uudestaan, tulee `Tietojen haku epäonnistui`

### Syy
Jos ei täytä kenttiä UI:ssä, niin UI lähettää bäkkärille personQuery = null. Mutta jos täyttää ensin arvon ja sen poistaa, niin UI/frontend lähettää personQuery = "". 

Bäkkärissä taas tarkistetaan onko arvo tyhjä tai vähintään 3 merkkiä
```java
    if (request.personQuery() != null) {
      final var personQuery = request.personQuery().trim();
      if (personQuery.length() <= 2) {
        throw new IllegalArgumentException("When given the person query, it must have atleast three characters");
      }
    }
```
Jos bäkkäri vastaanottaa personQuery = "", niin se ei ole null ja personQuery.length == 0. Eli se heittää tuon IllegalArgumentExceptionin.

### Korjaus
Heitetään IllegalArgumentException vain jos personQuery ei ole null tyhjä, eikä tyhjä, ja on enintään 2 merkkiä. Tietokanta-haku käsittelee jo valmiiksi null ja tyhjän arvon identtisesti.



## Lisätiedot

_Tehdyt muutokset..._

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
