### PR TITLE
YKI: Small fixes

### DIFF
--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkExamDateController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkExamDateController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(value = "/v2/api/clerk/examDate", produces = MediaType.APPLICATION_JSON_VALUE)
 @Conditional(ClerkEnabledCondition.class)
-public class ExamDateController {
+public class ClerkExamDateController {
 
   @Resource
   private ExamDateService examDateService;

--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ExamDateController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ExamDateController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(value = "/v2/api/clerk/exam-date", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v2/api/clerk/examDate", produces = MediaType.APPLICATION_JSON_VALUE)
 @Conditional(ClerkEnabledCondition.class)
 public class ExamDateController {
 

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
@@ -46,7 +46,6 @@ export const ClerkCustomerListingFilter = () => {
     languageCodeFilter,
     levelCodeFilter,
     size,
-    page,
   } = useAppSelector(clerkCustomersSearchSelector);
 
   useEffect(() => {
@@ -88,7 +87,7 @@ export const ClerkCustomerListingFilter = () => {
                         languageCode: languageCodeFilter,
                         levelCode: levelCodeFilter,
                       },
-                      page,
+                      page: 0, // Reset to first page when filters change
                       size,
                     }),
                   );
@@ -177,7 +176,7 @@ export const ClerkCustomerListingFilter = () => {
                   languageCode: languageCodeFilter,
                   levelCode: levelCodeFilter,
                 },
-                page,
+                page: 0, // Reset to first page when filters change
                 size,
               }),
             )

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomersListing.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomersListing.tsx
@@ -40,9 +40,11 @@ export const ClerkCustomersListing = ({
           <Link
             to={AppRoutes.ClerkCustomerDetails.replace(/:oid$/, person.oid)}
           >{`${person.firstName} ${person.lastName}`}</Link>
-          <p>{person.ssn}</p>
           {person.ssn ? (
-            <p>{person.oid}</p>
+            <>
+              <p>{person.ssn}</p>
+              <p>{person.oid}</p>
+            </>
           ) : (
             <div className="columns" style={{ gap: '0.25rem' }}>
               <Error color="error" fontSize="large" />

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomersListing.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomersListing.tsx
@@ -1,3 +1,4 @@
+import { Error } from '@mui/icons-material';
 import { Stack } from '@mui/material';
 import { Link } from 'react-router-dom';
 
@@ -40,7 +41,14 @@ export const ClerkCustomersListing = ({
             to={AppRoutes.ClerkCustomerDetails.replace(/:oid$/, person.oid)}
           >{`${person.firstName} ${person.lastName}`}</Link>
           <p>{person.ssn}</p>
-          <p>{person.oid}</p>
+          {person.ssn ? (
+            <p>{person.oid}</p>
+          ) : (
+            <div className="columns" style={{ gap: '0.25rem' }}>
+              <Error color="error" fontSize="large" />
+              {person.oid}
+            </div>
+          )}
         </div>
       ),
     },

--- a/frontend/packages/yki/clerk/src/enums/api.ts
+++ b/frontend/packages/yki/clerk/src/enums/api.ts
@@ -7,6 +7,6 @@ export enum APIEndpoints {
   ClerkFreeRegistrationDetailsMessages = '/yki/v2/api/clerk/registration/approval/:id/comment',
   ClerkCustomerDetails = '/yki/v2/api/clerk/customer/:oid',
   ClerkCustomersSearch = '/yki/v2/api/clerk/customer/search?page=:page&size=:size',
-  ExamDate = '/yki/v2/api/clerk/exam-date',
+  ExamDate = '/yki/v2/api/clerk/examDate',
   User = '/yki/api/user/identity',
 }


### PR DESCRIPTION
## Yhteenveto

1. Käytetään camelCasea examDate endpointissa (liittyy #964)
2. examDatelle Clerk prefix (liittyy #964)
3. Näytetään error-icon jos hetu-haussa tulee virhe. Virhe päätellään implisiittisesti siitä, että ssn-kenttä on null (katso bäkkäritoteutus [pullarissa #962](https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/pull/962/changes#diff-9d5f2dfe229ad738cf48d440021abdf71bb13f23550792de14bbb7797ee46f21R168))
4. Bugikorjaus. Kun hakuparameterit muuttuu, se ei ennen resetoinut vanhan kutsun sivutusta.

<img width="1066" height="698" alt="image" src="https://github.com/user-attachments/assets/795eacfe-3c80-4159-83a9-712e3eed18f2" />


## Testausohjeet

```sh
cd frontend/packages/yki/clerk
echo 'USE_MSW=true' > .env
yarn && yarn yki:clerk:start:msw

```

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
