### PR TITLE
YKI: Sort ClerkCustomersListing

### DIFF
--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerController.java
@@ -11,6 +11,7 @@ import fi.oph.yki.config.ClerkEnabledCondition;
 import fi.oph.yki.service.ClerkCustomerService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.annotation.Resource;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
@@ -44,6 +45,8 @@ public class ClerkCustomerController {
   public Page<ClerkCustomerSummaryDTO> searchCustomers(
     @RequestParam(defaultValue = "0") final int page,
     @RequestParam(defaultValue = "20") final int size,
+    @RequestParam(defaultValue = "lastName") final String sortColumn,
+    @RequestParam(defaultValue = "ASC") final String sortDirection,
     @RequestBody final ClerkCustomerSearchRequestDTO request
   ) throws IllegalArgumentException, ExecutionException, InterruptedException, JsonProcessingException {
     final int validatedSize = Math.min(size, MAX_PAGE_SIZE);
@@ -55,7 +58,15 @@ public class ClerkCustomerController {
       }
     }
 
-    return service.searchClerkCustomers(PageRequest.of(page, validatedSize), request);
+    if (!Objects.equals(sortColumn, "lastName") && !Objects.equals(sortColumn, "registrationCount")) {
+      throw new IllegalArgumentException(String.format("Invalid sort column %s", sortColumn));
+    }
+
+    if (!Objects.equals(sortDirection, "ASC") && !Objects.equals(sortDirection, "DESC")) {
+      throw new IllegalArgumentException(String.format("Invalid sort direction %s", sortDirection));
+    }
+
+    return service.searchClerkCustomers(PageRequest.of(page, validatedSize), request, sortColumn, sortDirection);
   }
 
   @GetMapping(path = "/{oid}", consumes = ALL_VALUE)

--- a/backend/yki/src/main/java/fi/oph/yki/repository/PersonRepository.java
+++ b/backend/yki/src/main/java/fi/oph/yki/repository/PersonRepository.java
@@ -54,7 +54,12 @@ WHERE (:personQuery IS NULL OR :personQuery = '' OR
               AND (:levelCode IS NULL OR :levelCode = '' OR es.level_code = :levelCode)
         )
     )
-ORDER BY p.created DESC, p.oid
+ORDER BY
+    CASE WHEN :sortColumn = 'lastName' AND :sortDirection = 'ASC' THEN p.last_name END ASC,
+    CASE WHEN :sortColumn = 'lastName' AND :sortDirection = 'DESC' THEN p.last_name END DESC,
+    CASE WHEN :sortColumn = 'registrationsCount' AND :sortDirection = 'ASC' THEN (SELECT COUNT(*) FROM registration r2 WHERE r2.person_oid = p.oid) END ASC,
+    CASE WHEN :sortColumn = 'registrationsCount' AND :sortDirection = 'DESC' THEN (SELECT COUNT(*) FROM registration r2 WHERE r2.person_oid = p.oid) END DESC,
+    p.created DESC, p.oid
 """,
     countQuery = """
 SELECT COUNT(*) FROM person p
@@ -88,6 +93,8 @@ WHERE (:personQuery IS NULL OR :personQuery = '' OR
     @Param("organizerId") Long organizerId,
     @Param("examDateId") Long examDateId,
     @Param("languageCode") String languageCode,
-    @Param("levelCode") String levelCode
+    @Param("levelCode") String levelCode,
+    @Param("sortColumn") String sortColumn,
+    @Param("sortDirection") String sortDirection
   );
 }

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -20,6 +20,7 @@ import fi.oph.yki.util.HetuUtils;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -119,7 +120,9 @@ public class ClerkCustomerService {
 
   private Page<PersonSearchProjection> searchPersons(
     final Pageable pageable,
-    final ClerkCustomerSearchRequestDTO request
+    final ClerkCustomerSearchRequestDTO request,
+    final String sortColumn,
+    final String sortDirection
   ) throws ExecutionException, InterruptedException, JsonProcessingException, RuntimeException {
     final var personQuery = request.personQuery() == null ? "" : request.personQuery();
     final var queries = personQuery.split(" ");
@@ -139,7 +142,9 @@ public class ClerkCustomerService {
         request.organizerId(),
         request.examDateId(),
         request.languageCode(),
-        request.levelCode()
+        request.levelCode(),
+        sortColumn,
+        sortDirection
       );
     }
 
@@ -150,16 +155,20 @@ public class ClerkCustomerService {
       request.organizerId(),
       request.examDateId(),
       request.languageCode(),
-      request.levelCode()
+      request.levelCode(),
+      sortColumn,
+      sortDirection
     );
   }
 
   @Transactional(readOnly = true)
   public Page<ClerkCustomerSummaryDTO> searchClerkCustomers(
     final Pageable pageable,
-    final ClerkCustomerSearchRequestDTO request
+    final ClerkCustomerSearchRequestDTO request,
+    final String sortColumn,
+    final String sortDirection
   ) throws ExecutionException, InterruptedException, JsonProcessingException, RuntimeException {
-    return searchPersons(pageable, request)
+    return searchPersons(pageable, request, sortColumn, sortDirection)
       .map(person -> {
         String identityNumber;
         try {

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerListingFilter.tsx
@@ -46,6 +46,7 @@ export const ClerkCustomerListingFilter = () => {
     languageCodeFilter,
     levelCodeFilter,
     size,
+    sort,
   } = useAppSelector(clerkCustomersSearchSelector);
 
   useEffect(() => {
@@ -89,6 +90,7 @@ export const ClerkCustomerListingFilter = () => {
                       },
                       page: 0, // Reset to first page when filters change
                       size,
+                      sort,
                     }),
                   );
                 }}
@@ -178,6 +180,7 @@ export const ClerkCustomerListingFilter = () => {
                 },
                 page: 0, // Reset to first page when filters change
                 size,
+                sort,
               }),
             )
           }

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomerSearch.tsx
@@ -6,7 +6,10 @@ import { ClerkCustomersListing } from 'components/clerkCustomer/ClerkCustomersLi
 import { usePublicTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { H2 } from 'ophTheme/Text';
-import { loadCustomersSearch } from 'redux/reducers/clerkCustomersSearch';
+import {
+  loadCustomersSearch,
+  setCustomersSort,
+} from 'redux/reducers/clerkCustomersSearch';
 import { clerkCustomersSearchSelector } from 'redux/selectors/clerkCustomersSearchSelector';
 
 const InfoText = ({ status }: { status: APIResponseStatus }) => {
@@ -38,6 +41,7 @@ export const ClerkCustomerSearch = () => {
     page,
     size,
     totalElements,
+    sort,
   } = useAppSelector(clerkCustomersSearchSelector);
 
   const dispatch = useAppDispatch();
@@ -53,6 +57,24 @@ export const ClerkCustomerSearch = () => {
             page={page}
             pageSize={size}
             totalCount={totalElements}
+            sort={sort}
+            onSortChange={(newSort) => {
+              dispatch(setCustomersSort(newSort));
+              dispatch(
+                loadCustomersSearch({
+                  request: {
+                    personQuery: searchQueryFilter,
+                    organizerId: organizerIdFilter,
+                    examDateId: examDateIdFilter,
+                    languageCode: languageCodeFilter,
+                    levelCode: levelCodeFilter,
+                  },
+                  page: 0,
+                  size,
+                  sort: newSort,
+                }),
+              );
+            }}
             onPageChange={(newPage) =>
               dispatch(
                 loadCustomersSearch({
@@ -65,6 +87,7 @@ export const ClerkCustomerSearch = () => {
                   },
                   page: newPage,
                   size,
+                  sort,
                 }),
               )
             }

--- a/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomersListing.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkCustomer/ClerkCustomersListing.tsx
@@ -16,12 +16,16 @@ export const ClerkCustomersListing = ({
   pageSize,
   totalCount,
   onPageChange,
+  sort,
+  onSortChange,
 }: {
   customers: ClerkCustomerSummary[] | undefined;
   page: number;
   pageSize: number;
   totalCount: number;
   onPageChange: (page: number) => void;
+  sort: string;
+  onSortChange: (sort: string) => void;
 }) => {
   const { t } = usePublicTranslation({
     keyPrefix: 'yki.component.clerkCustomer.search',
@@ -35,6 +39,7 @@ export const ClerkCustomersListing = ({
     {
       key: 'name',
       title: t('listing.columns.name'),
+      sortable: true,
       render: ({ person }) => (
         <div>
           <Link
@@ -57,6 +62,7 @@ export const ClerkCustomersListing = ({
     {
       key: 'registrationsCount',
       title: t('listing.columns.registrations'),
+      sortable: true,
       render: ({ registrationsCount }) => registrationsCount,
     },
   ];
@@ -84,6 +90,8 @@ export const ClerkCustomersListing = ({
             totalCount,
             serverSide: true,
           }}
+          sort={sort}
+          setSort={onSortChange}
         />
       )}
     </Stack>

--- a/frontend/packages/yki/clerk/src/enums/api.ts
+++ b/frontend/packages/yki/clerk/src/enums/api.ts
@@ -6,7 +6,7 @@ export enum APIEndpoints {
   ClerkFreeRegistrationSupplementRequest = '/yki/v2/api/clerk/registration/approval/:id/supplement-request',
   ClerkFreeRegistrationDetailsMessages = '/yki/v2/api/clerk/registration/approval/:id/comment',
   ClerkCustomerDetails = '/yki/v2/api/clerk/customer/:oid',
-  ClerkCustomersSearch = '/yki/v2/api/clerk/customer/search?page=:page&size=:size',
+  ClerkCustomersSearch = '/yki/v2/api/clerk/customer/search?page=:page&size=:size&sortColumn=:sortColumn&sortDirection=:sortDirection',
   ExamDate = '/yki/v2/api/clerk/examDate',
   User = '/yki/api/user/identity',
 }

--- a/frontend/packages/yki/clerk/src/interfaces/clerkCustomer.ts
+++ b/frontend/packages/yki/clerk/src/interfaces/clerkCustomer.ts
@@ -103,6 +103,7 @@ export type ClerkCustomerSearchParams = {
   };
   page: number;
   size: number;
+  sort?: string;
 };
 
 export interface ClerkCustomerSummary {

--- a/frontend/packages/yki/clerk/src/redux/reducers/clerkCustomersSearch.ts
+++ b/frontend/packages/yki/clerk/src/redux/reducers/clerkCustomersSearch.ts
@@ -21,6 +21,9 @@ interface ClerkCustomersSearchState {
   page: number;
   size: number;
   totalElements: number;
+
+  // sort
+  sort: string;
 }
 
 const initialState: ClerkCustomersSearchState = {
@@ -29,6 +32,7 @@ const initialState: ClerkCustomersSearchState = {
   page: 0,
   size: 20,
   totalElements: 0,
+  sort: '',
 };
 
 const clerkCustomersSearchSlice = createSlice({
@@ -42,6 +46,9 @@ const clerkCustomersSearchSlice = createSlice({
       state.status = APIResponseStatus.InProgress;
       state.page = action.payload.page;
       state.size = action.payload.size;
+      if (action.payload.sort !== undefined) {
+        state.sort = action.payload.sort;
+      }
     },
     rejectCustomersSearch(state) {
       state.status = APIResponseStatus.Error;
@@ -81,6 +88,9 @@ const clerkCustomersSearchSlice = createSlice({
       state.levelCodeFilter =
         action.payload === '' ? undefined : action.payload;
     },
+    setCustomersSort(state, action: PayloadAction<string>) {
+      state.sort = action.payload;
+    },
   },
 });
 
@@ -95,4 +105,5 @@ export const {
   setExamDateFilter,
   setLanguageFilter,
   setLevelFilter,
+  setCustomersSort,
 } = clerkCustomersSearchSlice.actions;

--- a/frontend/packages/yki/clerk/src/redux/sagas/clerkCustomersSearch.ts
+++ b/frontend/packages/yki/clerk/src/redux/sagas/clerkCustomersSearch.ts
@@ -21,14 +21,16 @@ function* loadCustomersSearchSaga(
   action: PayloadAction<ClerkCustomerSearchParams>,
 ) {
   try {
-    const { page, size, request } = action.payload;
+    const { page, size, request, sort } = action.payload;
+    const { sortColumn, sortDirection } =
+      SerializationUtils.serializeCustomerSearchSort(sort);
     const response: AxiosResponse<PageResponse<ClerkCustomerSummaryResponse>> =
       yield call(
         axiosInstance.post,
-        APIEndpoints.ClerkCustomersSearch.replace(':page', `${page}`).replace(
-          ':size',
-          `${size}`,
-        ),
+        APIEndpoints.ClerkCustomersSearch.replace(':page', `${page}`)
+          .replace(':size', `${size}`)
+          .replace(':sortColumn', sortColumn)
+          .replace(':sortDirection', sortDirection),
         request,
       );
     const customers: ClerkCustomerSummary[] = response.data.content.map(

--- a/frontend/packages/yki/clerk/src/utils/serialization.ts
+++ b/frontend/packages/yki/clerk/src/utils/serialization.ts
@@ -406,6 +406,24 @@ export class SerializationUtils {
     }));
   }
 
+  static serializeCustomerSearchSort(sort?: string): {
+    sortColumn: string;
+    sortDirection: string;
+  } {
+    if (!sort) {
+      return { sortColumn: '', sortDirection: '' };
+    }
+    const [key, direction] = sort.split(':');
+    if (!key || !direction) {
+      return { sortColumn: '', sortDirection: '' };
+    }
+    const columnMap: Record<string, string> = { name: 'lastName' };
+    const sortColumn = columnMap[key] ?? key;
+    const sortDirection = direction.toUpperCase();
+
+    return { sortColumn, sortDirection };
+  }
+
   static deserializeFindByOidsOrganizationResponse(
     organizationResponse: FindByOidsOrganizationResponse,
   ) {


### PR DESCRIPTION
## Yhteenveto

Asiakashaku - kentän - sorttaus. Nimi - kenttä sorttaa sukunimen mukaan. Sorttaukset tehdään bäkkärissä - personRepositoryControllerin sql-kyselyssä. Sorttauksen klikkaus vaihtaa kolmen arvon välillä:
1. ASC
2. DESC
3. Tyhjä -> ei sorttausta, pitäisikö defaulttaa esim. ASC:iin

<img width="1134" height="622" alt="image" src="https://github.com/user-attachments/assets/752ae383-7e62-4a16-8d62-2fffd176b99b" />


## Lisätiedot

_Tehdyt muutokset..._

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
