### PR TITLE
YKI(Backend): OPHKIOS-318 - Get all hetus at once

### DIFF
--- a/backend/yki/src/main/java/fi/oph/yki/onr/OnrService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/onr/OnrService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.oph.yki.onr.dto.PersonalDataDTO;
 import fi.vm.sade.javautils.nio.cas.CasClient;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.asynchttpclient.Request;
@@ -49,6 +51,23 @@ public class OnrService {
 
     final String json = response.getResponseBody();
     return OBJECT_MAPPER.readValue(json, new TypeReference<>() {});
+  }
+
+  public List<PersonalDataDTO> listPersonDetails(final List<String> oids)
+    throws RuntimeException, ExecutionException, InterruptedException, JsonProcessingException {
+    final String body = OBJECT_MAPPER.writeValueAsString(Map.of("henkiloOids", oids));
+    final Request request = defaultRequestBuilder
+      .setUrl(onrServiceUrl + "/s2s/henkilo/perustiedotAsAdmin")
+      .setMethod(Methods.POST)
+      .setBody(body)
+      .build();
+
+    final Response response = casClient.executeBlocking(request);
+    if (response.getStatusCode() != HttpStatus.OK.value()) {
+      throw new RuntimeException("Unexpected status code from ONR: " + response.getStatusCode());
+    }
+
+    return OBJECT_MAPPER.readValue(response.getResponseBody(), new TypeReference<>() {});
   }
 
   public Optional<PersonalDataDTO> findPersonalDataByIdentityNumber(final String identityNumber)

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -166,6 +166,7 @@ public class ClerkCustomerService {
       return onrService
         .listPersonDetails(oids)
         .stream()
+        .filter(dto -> dto.getIdentityNumber() != null)
         .collect(Collectors.toMap(PersonalDataDTO::getOidHenkilo, PersonalDataDTO::getIdentityNumber));
     } catch (final Exception e) {
       LOG.error("Unable to get identity numbers from ONR", e);

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -20,8 +20,10 @@ import fi.oph.yki.repository.RegistrationRepository;
 import fi.oph.yki.util.HetuUtils;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -159,12 +161,15 @@ public class ClerkCustomerService {
     );
   }
 
-  private List<PersonalDataDTO> getPersonDetails(List<String> oids) {
+  private Map<String, String> getOidToHetuMap(List<String> oids) {
     try {
-      return onrService.listPersonDetails(oids);
+      return onrService
+        .listPersonDetails(oids)
+        .stream()
+        .collect(Collectors.toMap(PersonalDataDTO::getOidHenkilo, PersonalDataDTO::getIdentityNumber));
     } catch (final Exception e) {
       LOG.error("Unable to get identity numbers from ONR", e);
-      return List.of();
+      return Map.of();
     }
   }
 
@@ -175,7 +180,7 @@ public class ClerkCustomerService {
   ) throws ExecutionException, InterruptedException, JsonProcessingException, RuntimeException {
     final var personsPage = searchPersons(pageable, request);
     final var oids = personsPage.getContent().stream().map(PersonSearchProjection::oid).toList();
-    final var personDetails = getPersonDetails(oids);
+    final var hetuByOid = getOidToHetuMap(oids);
 
     return personsPage.map(person ->
       ClerkCustomerSummaryDTO
@@ -185,14 +190,7 @@ public class ClerkCustomerService {
             .builder()
             .firstName(person.firstName())
             .lastName(person.lastName())
-            .ssn(
-              personDetails
-                .stream()
-                .filter(personDetail -> person.oid().equals(personDetail.getOidHenkilo()))
-                .findFirst()
-                .map(PersonalDataDTO::getIdentityNumber)
-                .orElse(null)
-            )
+            .ssn(hetuByOid.get(person.oid()))
             .oid(person.oid())
             .nationalityCode(person.nationalityCode())
             .phoneNumber(person.phoneNumber())

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -10,8 +10,10 @@ import fi.oph.yki.api.dto.clerk.ClerkExamDTO;
 import fi.oph.yki.api.dto.clerk.ClerkExamLocationDTO;
 import fi.oph.yki.model.ExamPayment;
 import fi.oph.yki.model.FreeRegistration;
+import fi.oph.yki.model.Person;
 import fi.oph.yki.model.Registration;
 import fi.oph.yki.onr.OnrService;
+import fi.oph.yki.onr.dto.PersonalDataDTO;
 import fi.oph.yki.repository.PersonRepository;
 import fi.oph.yki.repository.PersonSearchProjection;
 import fi.oph.yki.repository.RegistrationRepository;
@@ -84,23 +86,24 @@ public class ClerkCustomerService {
       .build();
   }
 
+  private String getIdentityNumber(Person person) {
+    try {
+      return onrService.getPersonalData(person.getOid()).getIdentityNumber();
+    } catch (final Exception e) {
+      LOG.error("Unable to get identity number from ONR for oid: {}", person.getOid(), e);
+      return null;
+    }
+  }
+
   @Transactional(readOnly = true)
   public ClerkCustomerDetailsDTO getClerkCustomerDetails(final String oid) {
     final var person = personRepository.getByOid(oid);
-
-    String identityNumber;
-    try {
-      identityNumber = onrService.getPersonalData(person.getOid()).getIdentityNumber();
-    } catch (final Exception e) {
-      identityNumber = null;
-      LOG.error("Unable to get identity number from ONR for oid: {}", person.getOid(), e);
-    }
 
     final var personDTO = ClerkCustomerPersonDTO
       .builder()
       .firstName(person.getFirstName())
       .lastName(person.getLastName())
-      .ssn(identityNumber)
+      .ssn(getIdentityNumber(person))
       .oid(person.getOid())
       .nationalityCode(person.getNationalityCode())
       .phoneNumber(person.getPhoneNumber())
@@ -156,38 +159,49 @@ public class ClerkCustomerService {
     );
   }
 
+  private List<PersonalDataDTO> getPersonDetails(List<String> oids) {
+    try {
+      return onrService.listPersonDetails(oids);
+    } catch (final Exception e) {
+      LOG.error("Unable to get identity numbers from ONR", e);
+      return List.of();
+    }
+  }
+
   @Transactional(readOnly = true)
   public Page<ClerkCustomerSummaryDTO> searchClerkCustomers(
     final Pageable pageable,
     final ClerkCustomerSearchRequestDTO request
   ) throws ExecutionException, InterruptedException, JsonProcessingException, RuntimeException {
-    return searchPersons(pageable, request)
-      .map(person -> {
-        String identityNumber;
-        try {
-          identityNumber = onrService.getPersonalData(person.oid()).getIdentityNumber();
-        } catch (final Exception e) {
-          identityNumber = null;
-          LOG.error("Unable to get identity number from ONR for oid: {}", person.oid(), e);
-        }
+    final var personsPage = searchPersons(pageable, request);
+    final var oids = personsPage.getContent().stream().map(PersonSearchProjection::oid).toList();
+    final var personDetails = getPersonDetails(oids);
 
-        return ClerkCustomerSummaryDTO
-          .builder()
-          .person(
-            ClerkCustomerPersonDTO
-              .builder()
-              .firstName(person.firstName())
-              .lastName(person.lastName())
-              .ssn(identityNumber)
-              .oid(person.oid())
-              .nationalityCode(person.nationalityCode())
-              .phoneNumber(person.phoneNumber())
-              .streetAddress(person.streetAddress())
-              .email(person.email())
-              .build()
-          )
-          .registrationsCount(person.registrationsCount() == null ? 0 : person.registrationsCount())
-          .build();
-      });
+    return personsPage.map(person ->
+      ClerkCustomerSummaryDTO
+        .builder()
+        .person(
+          ClerkCustomerPersonDTO
+            .builder()
+            .firstName(person.firstName())
+            .lastName(person.lastName())
+            .ssn(
+              personDetails
+                .stream()
+                .filter(personDetail -> person.oid().equals(personDetail.getOidHenkilo()))
+                .findFirst()
+                .map(PersonalDataDTO::getIdentityNumber)
+                .orElse(null)
+            )
+            .oid(person.oid())
+            .nationalityCode(person.nationalityCode())
+            .phoneNumber(person.phoneNumber())
+            .streetAddress(person.streetAddress())
+            .email(person.email())
+            .build()
+        )
+        .registrationsCount(person.registrationsCount() == null ? 0 : person.registrationsCount())
+        .build()
+    );
   }
 }


### PR DESCRIPTION
## Yhteenveto

Hetut haetaan kaikki yhdessä requestissa ONR:stä, niin ei tule montaa hakua. 

## Lisätiedot

_Tehdyt muutokset..._

## Huomautukset
Pohdiskelin samassa vielä tuota, että indeksoi tietokantakyselyä, mutta sillä sais ehkä millisekunnin parannuksen.

Ehkä toinen optimointikeino voisi olla cachettaa meidän [controlleriin](https://github.com/Opetushallitus/kieli-ja-kaantajatutkinnot/blob/f44576869923c48820472574b6c9595fd047efa4/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkCustomerController.java#L38-L56) tulevat requestit.


## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
