### PR TITLE
feature: run-local-env.sh  - script and other run-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,45 @@ cd frontend
 yarn 
 yarn run yki:start:dev-server
 ```
- 
+
+## Local development with tmuxinator
+
+[tmux](https://github.com/tmux/tmux) and [tmuxinator](https://github.com/tmuxinator/tmuxinator) are required. Install them (e.g. with Homebrew):
+
+```sh
+brew install tmux
+gem install tmuxinator
+```
+
+Start the YKI clerk environment (uses MSW mock by default):
+
+```sh
+scripts/run-local-env.sh
+```
+
+To connect to a real backend instead of MSW:
+
+```sh
+scripts/run-local-env.sh --no-msw
+```
+
+When using `--no-msw`, start the backend separately:
+
+```sh
+cd backend/yki && ./mvnw spring-boot:run
+# or run fi.oph.yki.YkiApplication in IntelliJ debugger
+```
+
+To stop, run from within the tmux session:
+
+```sh
+scripts/stop-tmux.sh
+# or gracefully, waiting N seconds before killing:
+scripts/stop-tmux.sh --gracefully=3
+```
+
+&nbsp;
+
 ## Development setup initialisation with Docker
 
 1. Download Docker Desktop

--- a/scripts/kios-tmux.yml
+++ b/scripts/kios-tmux.yml
@@ -1,0 +1,38 @@
+name: kios
+root: <%= ENV["KIOS"] %>
+
+windows:
+
+  # Uusi - frontend
+  - frontend-clerk: |
+      code .
+      cd frontend/packages/yki/clerk
+      echo 'USE_MSW=true' > .env
+      echo "yarn run yki:start:dev-server"
+      yarn yki:clerk:start:msw
+
+  - frontend-public: |
+      cd frontend/packages/yki/public
+      echo 'USE_MSW=true' > .env
+      yki:start:msw"
+
+  - cypress-clerk: |
+      cd frontend/packages/yki/clerk
+      echo "yarn yki:clerk:test:cypress"
+      npx cypress open
+
+#   - cypress-clerk: |
+#       cd frontend/packages/yki/public
+#       echo "yarn yki:test:cypress"
+#       npx cypress open
+
+  - "backend (idea)": idea .
+
+  - database: scripts/run-database.sh
+
+  # Muut
+  - git: 
+      layout: even-horizontal
+      panes:
+        - git --no-pager status
+        - git --no-pager diff

--- a/scripts/kios-tmux.yml
+++ b/scripts/kios-tmux.yml
@@ -4,29 +4,18 @@ root: <%= ENV["KIOS"] %>
 windows:
 
   # Uusi - frontend
-  - frontend-clerk: |
-      code .
-      cd frontend/packages/yki/clerk
-      echo 'USE_MSW=true' > .env
-      echo "yarn run yki:start:dev-server"
-      yarn yki:clerk:start:msw
+  - frontend-clerk: scripts/run-frontend-clerk.sh
 
-  - frontend-public: |
-      cd frontend/packages/yki/public
-      echo 'USE_MSW=true' > .env
-      yki:start:msw"
+  - frontend-public: scripts/run-frontend-public.sh
 
-  - cypress-clerk: |
-      cd frontend/packages/yki/clerk
-      echo "yarn yki:clerk:test:cypress"
-      npx cypress open
+  - cypress-clerk: scripts/run-cypress-clerk.sh
 
 #   - cypress-clerk: |
 #       cd frontend/packages/yki/public
 #       echo "yarn yki:test:cypress"
 #       npx cypress open
 
-  - "backend (idea)": idea .
+  - "backend (idea)": code . && idea .
 
   - database: scripts/run-database.sh
 

--- a/scripts/kios-tmux.yml
+++ b/scripts/kios-tmux.yml
@@ -4,7 +4,7 @@ root: <%= ENV["KIOS"] %>
 windows:
 
   # Uusi - frontend
-  - frontend-clerk: scripts/run-frontend-clerk.sh
+  - frontend-clerk: '<%= ENV["USE_MSW"] == "false" ? "scripts/run-frontend-clerk-no-msw.sh" : "scripts/run-frontend-clerk.sh" %>'
 
   - frontend-public: scripts/run-frontend-public.sh
 

--- a/scripts/run-cypress-clerk.sh
+++ b/scripts/run-cypress-clerk.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cd "$KIOS/frontend/packages/yki/clerk" || {
+    echo "could not find frontend/packages/yki/clerk" >&2
+    exit 1
+}
+
+echo "yarn yki:clerk:test:cypress"
+npx cypress open

--- a/scripts/run-cypress-clerk.sh
+++ b/scripts/run-cypress-clerk.sh
@@ -6,4 +6,6 @@ cd "$KIOS/frontend/packages/yki/clerk" || {
 }
 
 echo "yarn yki:clerk:test:cypress"
+
+set -x
 npx cypress open

--- a/scripts/run-database.sh
+++ b/scripts/run-database.sh
@@ -15,8 +15,11 @@ if [[ $KERNEL == "Darwin" ]]; then
     sleep 5
 fi
 
-# start (and try running) posgres/database
-docker run --name postgres-yki -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -p 5432:5432 -d postgres:latest
+(
+    set -x
+    # start (and try running) posgres/database
+    docker run --name postgres-yki -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -p 5432:5432 -d postgres:latest
+)
 
 ### add data
 #psql -h localhost -p 5432 -U admin -d yki < *.sql
@@ -24,8 +27,11 @@ docker run --name postgres-yki -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin
 echo "when creating new db, run:" 
 printf "\tpsql -h localhost -U admin -c 'create database yki'\n\n"
 
-# start db
-docker start "$(docker ps -a | grep "postgres-yki" | awk '{ print $1 }')"
-
-# ensure running
-docker ps -a
+(
+    set -x
+    # start db
+    docker start "$(docker ps -a | grep "postgres-yki" | awk '{ print $1 }')"
+    
+    # ensure running
+    docker ps -a
+)

--- a/scripts/run-database.sh
+++ b/scripts/run-database.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# cd "$YKI" || { echo "could find '\$YKI'."; exit 1 }
+cd "$KIOS/backend/yki/db" || {
+    echo "could find backend/yki/db"
+    exit 1
+}
+
+# open Docker Desktop on Mac to ensure Docker daemon is running
+# on linux you can use your favorite service manager to run docker daemon
+KERNEL="$(uname -s)"
+if [[ $KERNEL == "Darwin" ]]; then
+    echo "Opening Docker Desktop to ensure daemon is running"
+    open -a "Docker" --background
+    sleep 5
+fi
+
+# start (and try running) posgres/database
+docker run --name postgres-yki -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -p 5432:5432 -d postgres:latest
+
+### add data
+#psql -h localhost -p 5432 -U admin -d yki < *.sql
+
+echo "when creating new db, run:" 
+printf "\tpsql -h localhost -U admin -c 'create database yki'\n\n"
+
+# start db
+docker start "$(docker ps -a | grep "postgres-yki" | awk '{ print $1 }')"
+
+# ensure running
+docker ps -a

--- a/scripts/run-database.sh
+++ b/scripts/run-database.sh
@@ -2,7 +2,7 @@
 
 # cd "$YKI" || { echo "could find '\$YKI'."; exit 1 }
 cd "$KIOS/backend/yki/db" || {
-    echo "could find backend/yki/db"
+    echo "could find backend/yki/db" >&2
     exit 1
 }
 

--- a/scripts/run-frontend-clerk-no-msw.sh
+++ b/scripts/run-frontend-clerk-no-msw.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+printf "Backend should be running. Start it with:\n"
+printf "  cd backend/yki && ./mvnw spring-boot:run\n"
+printf "  or run fi.oph.yki.YkiApplication in IntelliJ debugger\n\n"
+
+cd "$KIOS/frontend/packages/yki/clerk" || {
+    echo "could not find frontend/packages/yki/clerk" >&2
+    exit 1
+}
+
+echo 'USE_MSW=false' > .env
+yarn yki:clerk:start

--- a/scripts/run-frontend-clerk-no-msw.sh
+++ b/scripts/run-frontend-clerk-no-msw.sh
@@ -9,5 +9,6 @@ cd "$KIOS/frontend/packages/yki/clerk" || {
     exit 1
 }
 
+set -x
 echo 'USE_MSW=false' > .env
 yarn yki:clerk:start

--- a/scripts/run-frontend-clerk.sh
+++ b/scripts/run-frontend-clerk.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+cd "$KIOS/frontend/packages/yki/clerk" || {
+    echo "could not find frontend/packages/yki/clerk" >&2
+    exit 1
+}
+
+echo "yarn run yki:start:dev-server"
+echo "USE_MSW=true" > .env 
+yarn yki:clerk:start:msw

--- a/scripts/run-frontend-clerk.sh
+++ b/scripts/run-frontend-clerk.sh
@@ -6,5 +6,6 @@ cd "$KIOS/frontend/packages/yki/clerk" || {
 }
 
 echo "yarn run yki:start:dev-server"
+set -x
 echo "USE_MSW=true" > .env 
 yarn yki:clerk:start:msw

--- a/scripts/run-frontend-public.sh
+++ b/scripts/run-frontend-public.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cd "$KIOS/frontend/packages/yki/public" || {
+    echo "could not find frontend/packages/yki/public" >&2
+    exit 1
+}
+
+echo "USE_MSW=true" > .env 
+yarn yki:start:msw

--- a/scripts/run-frontend-public.sh
+++ b/scripts/run-frontend-public.sh
@@ -5,5 +5,6 @@ cd "$KIOS/frontend/packages/yki/public" || {
     exit 1
 }
 
+set -x
 echo "USE_MSW=true" > .env 
 yarn yki:start:msw

--- a/scripts/run-local-env.sh
+++ b/scripts/run-local-env.sh
@@ -10,4 +10,6 @@ if ! command -v tmuxinator &>/dev/null; then
   exit 1
 fi
 
-tmuxinator start -p $(dirname "${BASH_SOURCE[0]}")/kios-tmux.yml
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+KIOS="$(cd "$SCRIPT_DIR/.." && pwd)" tmuxinator start -p "$SCRIPT_DIR/kios-tmux.yml"

--- a/scripts/run-local-env.sh
+++ b/scripts/run-local-env.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+tmuxinator start -p $(dirname "${BASH_SOURCE[0]}")/kios-tmux.yml

--- a/scripts/run-local-env.sh
+++ b/scripts/run-local-env.sh
@@ -1,3 +1,13 @@
 #!/usr/bin/env bash
 
+if ! command -v tmux &>/dev/null; then
+  echo "tmux is not installed" >&2
+  exit 1
+fi
+
+if ! command -v tmuxinator &>/dev/null; then
+  echo "tmuxinator is not installed" >&2
+  exit 1
+fi
+
 tmuxinator start -p $(dirname "${BASH_SOURCE[0]}")/kios-tmux.yml

--- a/scripts/run-local-env.sh
+++ b/scripts/run-local-env.sh
@@ -10,6 +10,15 @@ if ! command -v tmuxinator &>/dev/null; then
   exit 1
 fi
 
+USE_MSW=true
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-msw) USE_MSW=false ;;
+    *) echo "Unknown flag: $arg" >&2; exit 1 ;;
+  esac
+done
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-KIOS="$(cd "$SCRIPT_DIR/.." && pwd)" tmuxinator start -p "$SCRIPT_DIR/kios-tmux.yml"
+KIOS="$(cd "$SCRIPT_DIR/.." && pwd)" USE_MSW="$USE_MSW" tmuxinator start -p "$SCRIPT_DIR/kios-tmux.yml"

--- a/scripts/stop-tmux.sh
+++ b/scripts/stop-tmux.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WAIT_UNTIL=3
+GRACEFUL_STOP=false
+for arg in "$@"; do
+  case $arg in
+    --gracefully=*)
+      GRACEFUL_STOP=true
+      WAIT_UNTIL="${arg#*=}"
+      if ! [[ "$WAIT_UNTIL" =~ ^[1-9]+$ ]]; then
+        echo "The format is '--gracefully={number 1-9 represent seconds} '" 1>&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+# Check if the script is running inside a tmux session
+if [[ -z "$TMUX" ]]; then
+  echo "Script not running inside a tmux session" >&2
+  exit 1
+fi
+
+# Iterate over current session windows and panes
+tmux list-windows -F '#{window_index}' | while read -r window; do
+  tmux list-panes -t "$window" -F '#{pane_index}' | while read -r pane; do
+    tmux send-keys -t "$window.$pane" C-c
+  done
+done
+
+if $GRACEFUL_STOP; then
+  echo "Waiting $WAIT_UNTIL seconds before killing the session"
+  sleep "$WAIT_UNTIL"
+fi
+
+tmux kill-session


### PR DESCRIPTION
## Yhteenveto

Mulla on ollut lokaalisti tällainen `run-local-env.sh` - skripti, jolla oon laittanut mun dev ympäristön pystyyn. Skripti käyttää `

Mun workflow on sen verran _opinionated_, että käytän [tmuxia](https://github.com/tmux/tmux) pyörittämään yhtä aikaa useita ikkunoita. Ja koska tmuxin pöyrittäminen sellaisenaan on hieman työlästä (esim. [kielitutkintorekisteri](https://github.com/Opetushallitus/kielitutkintorekisteri/blob/main/scripts/start_tmux.sh)), oon käyttänyt yml-pohjaista [tmuxinatoria](https://github.com/tmuxinator/tmuxinator) session konfigurointiin.

Parantelin samalla tuotta claudella ja lisäilin tuohon pieni ominaisuuksia. (kts joko commitit tai ## Lisätiedot)

## Ominaisuudet: `scripts/run-local.env.sh`
  - scripts/run-local-env.sh — käynnistää ympäristön tmuxilla / tmuxinatorilla. 
  - Ajaa ykin frontit yarnilla, clerk portissa 4004 ja public portissa 4003
  - Laittaa cypressin UI:n päälle, ja siinä clerkin UI-testit.
  - Laittaa tietokannan päälle
  - Käynnistää vscoden ja idean (sillä oletuksella, että `code` ja `idea` löytyy envistä)
  - näyttää mitä sulla on gitissä lisäämättä. Joskus oon käyttänyt interaktiivistä versiota eli
 ```sh
watch -n1 --color 'git -c color.ui=always status'
```

## Muut ominaisuudet
  - scripts/stop-tmux.sh — pysäyttää tmux-session. Tukee --gracefully=N-flagia, joka odottaa N sekuntia ennen tappamista

## Parannukset mun alkuperäiseen 
  - Lisätty `--no-msw` - flag `scripts/run-local-env.sh`, niin voi ajaa helpommin lokaalia bäkkäriä vasten.
  - Tmuxinator-konfiguraation ikkunakomennot eriytetty omiin shell-skripteihin
  - Virheviesti, jos tmux tai tmuxinator ei ole asennettu
  - jos tulee exit 1, niin messaget ohjataan `stderr`:iin
  - README lisätty käyttöohjeita.

## Huomautukset

Koska toi `.env`:n näkyminen gitin changedissa, niin ajan koneellani myöskin:
```sh
git update-index --no-assume-unchanged frontend/packages/yki/clerk/.env
```


## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
