### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/common-backend.yml
+++ b/.github/workflows/common-backend.yml
@@ -53,11 +53,11 @@ jobs:
           key: ${{ runner.os }}-${{ inputs.app-name }}-clerk-frontend-build-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # actions/setup-java v3
         with:
           java-version: "21"
           distribution: "temurin"
-      - uses: szenius/set-timezone@v1.1
+      - uses: szenius/set-timezone@d1416e74a9a643cbf6c711905741e73e3a0c26b8 # szenius/set-timezone v1.1
         with:
           timezoneLinux: "Europe/Helsinki"
       - name: Install wkhtmltopdf
@@ -72,7 +72,7 @@ jobs:
           echo 'Installation of wkhtmltopdf completed'
         shell: bash
       - name: Prepare maven settings
-        uses: s4u/maven-settings-action@v2
+        uses: s4u/maven-settings-action@6fd54e315175e01fffb0b988c0254feb388869f8 # s4u/maven-settings-action v2
         with:
           servers: '[{"id": "oph-github-packages", "username": "${GITHUB_USERNAME}", "password": "${GITHUB_REGISTRY_TOKEN}"}]'
       - name: Build with Maven

--- a/.github/workflows/common-frontend.yml
+++ b/.github/workflows/common-frontend.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: [20.9.0]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
-      - uses: szenius/set-timezone@v1.1
+      - uses: szenius/set-timezone@d1416e74a9a643cbf6c711905741e73e3a0c26b8 # szenius/set-timezone v1.1
         with:
           timezoneLinux: "Europe/Helsinki"
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/shared_frontend.yml
+++ b/.github/workflows/shared_frontend.yml
@@ -27,7 +27,7 @@ jobs:
         node-version: [20.9.0]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
-      - uses: szenius/set-timezone@v1.1
+      - uses: szenius/set-timezone@d1416e74a9a643cbf6c711905741e73e3a0c26b8 # szenius/set-timezone v1.1
         with:
           timezoneLinux: "Europe/Helsinki"
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/yki-clerk-frontend.yml
+++ b/.github/workflows/yki-clerk-frontend.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: [20.9.0]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
-      - uses: szenius/set-timezone@v1.1
+      - uses: szenius/set-timezone@d1416e74a9a643cbf6c711905741e73e3a0c26b8 # szenius/set-timezone v1.1
         with:
           timezoneLinux: "Europe/Helsinki"
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/yki-public-frontend.yml
+++ b/.github/workflows/yki-public-frontend.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: [20.9.0]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # actions/checkout v6.0.2
-      - uses: szenius/set-timezone@v1.1
+      - uses: szenius/set-timezone@d1416e74a9a643cbf6c711905741e73e3a0c26b8 # szenius/set-timezone v1.1
         with:
           timezoneLinux: "Europe/Helsinki"
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Yhteenveto

 Pinnataan GitHub Actions -workflow-actionit commit-SHA:han  tagin sijaan

## Lisätiedot

  Muutetaan seuraavat actionit käyttämään kiinteää commit-SHA:ta mutable version tagin sijaan:

| action@tag | commit hash
| - | -
| [actions/setup-java@v3](https://github.com/actions/setup-java/tree/v3) | [17f84c3641ba7b8f6deff6309fc4c864478f5d62](https://github.com/actions/setup-java/commit/17f84c3641ba7b8f6deff6309fc4c864478f5d62) |
| [szenius/set-timezone@v1.1](https://github.com/szenius/set-timezone/tree/v1.1) | [d1416e74a9a643cbf6c711905741e73e3a0c26b8](https://github.com/szenius/set-timezone/commit/d1416e74a9a643cbf6c711905741e73e3a0c26b8) |
 | [s4u/maven-settings-action@v2](https://github.com/s4u/maven-settings-action/tree/releases/v2) | [60912582505985be4cc55d2b890eb32767f8de5f](https://github.com/s4u/maven-settings-action/commit/60912582505985be4cc55d2b890eb32767f8de5f) |

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
