### PR TITLE
feat: Add plugins to claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "jdtls-lsp@claude-plugins-official": true
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "enabledPlugins": {
-    "jdtls-lsp@claude-plugins-official": true
+    "jdtls-lsp@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Yhteenveto

## Java LSP 
 [Java](https://github.com/eclipse-jdtls/eclipse.jdt.ls) plugin, jotta claude ymmärtää javaa paremmin. Huom, clauden marketplacessa ei oo virallisempaa java LSP:tä 


## Typescript LSP
[typescript](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/typescript-lsp) plugin, jotta claude ymmärtää täsää/reactia paremmin. Anthropicin virallinen plugari

~## Superpowers~
~[Superpowers](https://github.com/obra/superpowers) - plugin.  Halutaanko tämä? Vai asentaako devaajat tällaisia itselleen jos haluaavat? Tykkään, kun siinä on paljon hyviä omainuuksia, esim `/brainstormin`, jolla saa clauden pallottelemaan sun kanssa, eikä se oo siinä moodissa niin innokas koodari~
