### PR TITLE
feat: claude improvements

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+settings.local.json

--- a/.claude/rules/behavior.md
+++ b/.claude/rules/behavior.md
@@ -1,0 +1,9 @@
+# Default Behavior for Ambiguous Requests
+
+If the intent is unclear — the user is asking a question, requesting an explanation,
+or the request could mean "explain" or "implement" — default to discussion mode.
+Summarize your understanding and ask: "Should I make changes, or just explain?"
+
+Only proceed with edits when:
+- The request is a clear imperative ("fix", "add", "refactor", "update")
+- The user says "go ahead", "do it", "make the changes"

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(ls:*)"
-    ]
-  }
-}

--- a/.claude/skills/discussion/SKILL.md
+++ b/.claude/skills/discussion/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: discussion
+description: Use when you want to explore, understand, or discuss code without making any changes yet.
+---
+
+# Discussion Mode
+
+Announce: "Discussion mode — I'll explore and explain without making any changes."
+
+You may freely read files, search code, run read-only commands, and answer questions.
+
+You must NOT edit, create, or delete any files until the user explicitly says to proceed (e.g. "ok go ahead", "make the changes", "do it").
+
+## What's allowed
+- Reading files
+- Searching code (Grep, Glob)
+- Running read-only shell commands
+- Explaining, analyzing, reviewing
+
+## What's not allowed
+- Edit / Write / NotebookEdit
+- Any shell command that modifies files or state
+
+## Exiting discussion mode
+User says something like "ok go ahead", "make the changes", or "do it" → proceed normally.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: implement
+description: Use when you are ready to implement a task. Activates implementation mode with automatic pausing at unexpected decision points.
+---
+
+# Implementation Mode
+
+Announce: "Implementation mode — I'll implement the task and pause if I hit something unexpected."
+
+Read and understand the task fully before touching any files. Once you have a clear picture, proceed with implementation confidently.
+
+## While implementing
+
+Make decisions that are clearly implied by the task without asking. Trust your understanding.
+
+**Stop immediately if you hit something unexpected** — a design fork, an ambiguity, or a conflict that the task description does not cover. Do not resolve it silently. Do not pick the "most likely" option.
+
+When you stop:
+1. Describe what you found and why it is a decision point.
+2. Enter discussion mode: no further file changes until the user decides.
+3. Wait. The issue may be cosmetic, or it may require a design change — the user decides which.
+
+This mirrors how a developer flags a blocker before proceeding, rather than making assumptions that may need to be undone.
+
+## Exiting the pause
+User gives direction → apply it and continue implementing.


### PR DESCRIPTION
## Yhteenveto

* laitettu `./claude/settings.local.json` - tiedosto `./.claude` - kansion gitignoreen. gitignore on `.claude/` - kansiossa siltä varalta, että jos joskus halutaan migroida pois claudesta, niin ei tarvitsisi muistaa tehdä muutoksia muihin tiedostoihin

* Lisätty uusi skill claudelle `/discussion`. Eli jos luulet, että claude saattaa yrittää koodata jotain, mutta haluatkin vain kysyä, voit varmistaa ettei se muuta mitään, esim:
```
There seems to be a bug in the line @frontend/some/path/to/file/MyComponent.tsx line 56.

Explain the bug /discussion
```
* Lisäsin myöskin claudeeen käyttäytymistä, että jos käyttäjän viesti on epäselvä, niin se aktivoi tuon `/discussion` - skillsin. Se enforcettaa jo tuolla ihan hyvin pois claude innokkuudesta koodata. Pikatestailuissa se nappasi ehkä 80% mun kysymyksistä discussion - moodiin, eli se ei ole kovin täydellinen vielä.


## Lisätiedot

_Tehdyt muutokset..._

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
