### PR TITLE
VKT(Backend) Ei logata virhettä jos OID puuttuu henkilöltä

### DIFF
--- a/backend/vkt/src/main/java/fi/oph/vkt/service/RegisterEnrollmentService.java
+++ b/backend/vkt/src/main/java/fi/oph/vkt/service/RegisterEnrollmentService.java
@@ -111,7 +111,7 @@ public class RegisterEnrollmentService {
       }
 
       if (enrollment.getPerson().getOid() == null || enrollment.getPerson().getOid().isEmpty()) {
-        LOG.error(String.format("Sync failed. No oid for person in enrollment (%s)", id));
+        LOG.warn(String.format("Sync failed. No oid for person in enrollment (%s)", id));
         return;
       }
 


### PR DESCRIPTION
## Yhteenveto

Ei tehdä virhettä jos OID puuttuu henkilöltä. Näitä on muutama tuotannossa koska ulkomaalaisen tunnistautumisella ei ole saatu henkilötunnusta ja siten ei ole tehty oppijaa.
