### PR TITLE
OPHKIOS-179: Maksuraportit - raportin lataus aikaväliltä

### DIFF
--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkPaymentReportController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkPaymentReportController.java
@@ -1,0 +1,34 @@
+package fi.oph.yki.api.clerk;
+
+import fi.oph.yki.api.dto.clerk.ClerkPaymentReportRowDTO;
+import fi.oph.yki.config.ClerkEnabledCondition;
+import fi.oph.yki.service.ClerkPaymentReportService;
+import fi.oph.yki.view.PaymentReportXlsxView;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.annotation.Resource;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.document.AbstractXlsxView;
+
+@RestController
+@RequestMapping(value = "/v2/api/clerk/paymentReport")
+@Conditional(ClerkEnabledCondition.class)
+public class ClerkPaymentReportController {
+
+  private static final String TAG = "Payment report API";
+
+  @Resource
+  private ClerkPaymentReportService clerkPaymentReportService;
+
+  @GetMapping("/excel")
+  @Operation(tags = TAG, summary = "Download payment report as Excel")
+  public AbstractXlsxView getPaymentReportExcel(@RequestParam final LocalDate from, @RequestParam final LocalDate to) {
+    final List<ClerkPaymentReportRowDTO> rows = clerkPaymentReportService.getPaymentReport(from, to);
+    return new PaymentReportXlsxView(rows, from, to);
+  }
+}

--- a/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkPaymentReportRowDTO.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkPaymentReportRowDTO.java
@@ -1,0 +1,26 @@
+package fi.oph.yki.api.dto.clerk;
+
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record ClerkPaymentReportRowDTO(
+  String organizer,
+  String lastName,
+  String firstName,
+  String email,
+  String paidAt,
+  LocalDate examDate,
+  LocalDate originalExamDate,
+  String examLanguage,
+  String examLevel,
+  String amount,
+  String reference,
+  String frSource,
+  Boolean frIsForeign,
+  Boolean frMatriculationExam,
+  Boolean frEb,
+  Boolean frDia,
+  Boolean frHigherEducationConcluded,
+  Boolean frHigherEducationEnrolled
+) {}

--- a/backend/yki/src/main/java/fi/oph/yki/config/AppConfig.java
+++ b/backend/yki/src/main/java/fi/oph/yki/config/AppConfig.java
@@ -53,6 +53,14 @@ public class AppConfig {
   }
 
   @Bean
+  public WebClient organizationClient(final Environment environment) {
+    return webClientBuilderWithCallerId("organization-connection-provider")
+      .baseUrl(environment.getRequiredProperty("app.organization-service.url"))
+      .defaultHeaders(headers -> headers.setContentType(MediaType.APPLICATION_JSON))
+      .build();
+  }
+
+  @Bean
   @ConditionalOnProperty(name = "app.email.sending-enabled", havingValue = "false")
   public EmailSender emailSenderNoOp() {
     LOG.warn("EmailSenderNoOp in use");

--- a/backend/yki/src/main/java/fi/oph/yki/model/ExamPayment.java
+++ b/backend/yki/src/main/java/fi/oph/yki/model/ExamPayment.java
@@ -12,9 +12,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcType;
+import org.hibernate.dialect.PostgreSQLEnumJdbcType;
 
 @Getter
 @Setter
@@ -29,7 +32,20 @@ public class ExamPayment {
 
   @Enumerated(EnumType.STRING)
   @Column(name = "state")
+  @JdbcType(PostgreSQLEnumJdbcType.class)
   private PaymentState state;
+
+  @Column(name = "amount")
+  private BigDecimal amount;
+
+  @Column(name = "reference")
+  private String reference;
+
+  @Column(name = "transaction_id")
+  private String transactionId;
+
+  @Column(name = "href")
+  private String href;
 
   @Column(name = "paid_at")
   private LocalDateTime paidAt;

--- a/backend/yki/src/main/java/fi/oph/yki/model/Registration.java
+++ b/backend/yki/src/main/java/fi/oph/yki/model/Registration.java
@@ -60,6 +60,10 @@ public class Registration {
   @JoinColumn(name = "exam_session_id", referencedColumnName = "id")
   private ExamSession examSession;
 
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "original_exam_session_id", referencedColumnName = "id")
+  private ExamSession originalExamSession;
+
   // DO NOT REMOVE THE fetch=FetchType.LAZY ANNOTATION unless extremely confident that things will not break!
   // IDEA will falsely claim that it will not affect loading - this is not so.
   @OneToOne(fetch = FetchType.LAZY, mappedBy = "registration", optional = false)

--- a/backend/yki/src/main/java/fi/oph/yki/repository/ExamPaymentRepository.java
+++ b/backend/yki/src/main/java/fi/oph/yki/repository/ExamPaymentRepository.java
@@ -1,0 +1,83 @@
+package fi.oph.yki.repository;
+
+import fi.oph.yki.model.ExamPayment;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExamPaymentRepository extends BaseRepository<ExamPayment> {
+  @Query(
+    nativeQuery = true,
+    value = """
+      SELECT
+        p.last_name AS lastName,
+        p.first_name AS firstName,
+        p.email AS email,
+        (epn.paid_at AT TIME ZONE 'UTC') AS paidAt,
+        ed.exam_date AS examDate,
+        oed.exam_date AS originalExamDate,
+        es.language_code AS languageCode,
+        es.level_code AS levelCode,
+        epn.amount AS amount,
+        epn.reference AS reference,
+        o.oid AS organizerOid,
+        NULL AS frSource,
+        NULL AS frIsForeign,
+        NULL AS frMatriculationExam,
+        NULL AS frEb,
+        NULL AS frDia,
+        NULL AS frHigherEducationConcluded,
+        NULL AS frHigherEducationEnrolled
+      FROM exam_payment_new epn
+      INNER JOIN registration r ON epn.registration_id = r.id
+      INNER JOIN person p ON r.person_oid = p.oid
+      INNER JOIN exam_session es ON r.exam_session_id = es.id
+      INNER JOIN exam_date ed ON es.exam_date_id = ed.id
+      INNER JOIN organizer o ON es.organizer_id = o.id
+      LEFT JOIN exam_session oes ON r.original_exam_session_id = oes.id
+      LEFT JOIN exam_date oed ON oes.exam_date_id = oed.id
+      WHERE epn.paid_at >= (:fromInclusive AT TIME ZONE 'Europe/Helsinki')
+        AND epn.paid_at < (:toExclusive AT TIME ZONE 'Europe/Helsinki')
+      """
+  )
+  List<PaymentReportProjection> findCompletedPaymentsForTimeRange(LocalDate fromInclusive, LocalDate toExclusive);
+
+  @Query(
+    nativeQuery = true,
+    value = """
+      SELECT
+        p.last_name AS lastName,
+        p.first_name AS firstName,
+        p.email AS email,
+        (fr.created_at AT TIME ZONE 'UTC') AS paidAt,
+        ed.exam_date AS examDate,
+        oed.exam_date AS originalExamDate,
+        es.language_code AS languageCode,
+        es.level_code AS levelCode,
+        0 AS amount,
+        NULL AS reference,
+        o.oid AS organizerOid,
+        fr.source AS frSource,
+        fr.is_foreign AS frIsForeign,
+        fr.matriculation_exam AS frMatriculationExam,
+        fr.eb AS frEb,
+        fr.dia AS frDia,
+        fr.higher_education_concluded AS frHigherEducationConcluded,
+        fr.higher_education_enrolled AS frHigherEducationEnrolled
+      FROM registration r
+      INNER JOIN free_registration fr ON r.id = fr.registration_id
+      INNER JOIN person p ON r.person_oid = p.oid
+      INNER JOIN exam_session es ON r.exam_session_id = es.id
+      INNER JOIN exam_date ed ON es.exam_date_id = ed.id
+      INNER JOIN organizer o ON es.organizer_id = o.id
+      LEFT JOIN exam_session oes ON r.original_exam_session_id = oes.id
+      LEFT JOIN exam_date oed ON oes.exam_date_id = oed.id
+      WHERE r.state = 'COMPLETED'
+        AND fr.created_at >= (:fromInclusive AT TIME ZONE 'Europe/Helsinki')
+        AND fr.created_at < (:toExclusive AT TIME ZONE 'Europe/Helsinki')
+      """
+  )
+  List<PaymentReportProjection> findFreeRegistrationsForTimeRange(LocalDate fromInclusive, LocalDate toExclusive);
+}

--- a/backend/yki/src/main/java/fi/oph/yki/repository/PaymentReportProjection.java
+++ b/backend/yki/src/main/java/fi/oph/yki/repository/PaymentReportProjection.java
@@ -1,0 +1,27 @@
+package fi.oph.yki.repository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public interface PaymentReportProjection {
+  String getLastName();
+  String getFirstName();
+  String getEmail();
+  LocalDateTime getPaidAt();
+  LocalDate getExamDate();
+  LocalDate getOriginalExamDate();
+  String getLanguageCode();
+  String getLevelCode();
+  BigDecimal getAmount();
+  String getReference();
+  String getOrganizerOid();
+  // Free registration fields
+  String getFrSource();
+  Boolean getFrIsForeign();
+  Boolean getFrMatriculationExam();
+  Boolean getFrEb();
+  Boolean getFrDia();
+  Boolean getFrHigherEducationConcluded();
+  Boolean getFrHigherEducationEnrolled();
+}

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkPaymentReportService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkPaymentReportService.java
@@ -1,0 +1,143 @@
+package fi.oph.yki.service;
+
+import fi.oph.yki.api.dto.clerk.ClerkPaymentReportRowDTO;
+import fi.oph.yki.repository.ExamPaymentRepository;
+import fi.oph.yki.repository.PaymentReportProjection;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ClerkPaymentReportService {
+
+  private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+  private static final Map<String, String> LANGUAGE_NAMES_FI = Map.of(
+    "fin",
+    "suomi",
+    "swe",
+    "ruotsi",
+    "eng",
+    "englanti",
+    "spa",
+    "espanja",
+    "ita",
+    "italia",
+    "fra",
+    "ranska",
+    "sme",
+    "saame",
+    "deu",
+    "saksa",
+    "rus",
+    "venäjä"
+  );
+
+  private static final Map<String, String> LEVEL_NAMES_FI = Map.of(
+    "PERUS",
+    "Perustaso",
+    "KESKI",
+    "Keskitaso",
+    "YLIN",
+    "Ylin taso"
+  );
+
+  private final ExamPaymentRepository examPaymentRepository;
+  private final OrganizationService organizationService;
+
+  @Transactional(readOnly = true)
+  public List<ClerkPaymentReportRowDTO> getPaymentReport(final LocalDate from, final LocalDate to) {
+    final LocalDate toExclusive = to.plusDays(1);
+
+    final List<PaymentReportProjection> paidPayments = examPaymentRepository.findCompletedPaymentsForTimeRange(
+      from,
+      toExclusive
+    );
+    final List<PaymentReportProjection> freeRegistrations = examPaymentRepository.findFreeRegistrationsForTimeRange(
+      from,
+      toExclusive
+    );
+
+    final List<PaymentReportProjection> allRows = Stream
+      .concat(paidPayments.stream(), freeRegistrations.stream())
+      .toList();
+
+    final Map<String, String> organizerNames = organizationService.getOrganizationNames(
+      allRows.stream().map(PaymentReportProjection::getOrganizerOid).distinct().toList()
+    );
+
+    return allRows
+      .stream()
+      .map(row -> toDTO(row, organizerNames))
+      .sorted(
+        Comparator
+          .comparing(ClerkPaymentReportRowDTO::organizer, Comparator.nullsLast(String::compareToIgnoreCase))
+          .thenComparing(ClerkPaymentReportRowDTO::lastName, Comparator.nullsLast(String::compareToIgnoreCase))
+          .thenComparing(ClerkPaymentReportRowDTO::firstName, Comparator.nullsLast(String::compareToIgnoreCase))
+      )
+      .toList();
+  }
+
+  private static ClerkPaymentReportRowDTO toDTO(
+    final PaymentReportProjection row,
+    final Map<String, String> organizerNames
+  ) {
+    return ClerkPaymentReportRowDTO
+      .builder()
+      .organizer(organizerNames.getOrDefault(row.getOrganizerOid(), row.getOrganizerOid()))
+      .lastName(row.getLastName())
+      .firstName(row.getFirstName())
+      .email(row.getEmail())
+      .paidAt(formatPaidAt(row.getPaidAt()))
+      .examDate(row.getExamDate())
+      .originalExamDate(row.getOriginalExamDate())
+      .examLanguage(LANGUAGE_NAMES_FI.getOrDefault(row.getLanguageCode(), row.getLanguageCode()))
+      .examLevel(LEVEL_NAMES_FI.getOrDefault(row.getLevelCode(), row.getLevelCode()))
+      .amount(formatAmount(row.getAmount()))
+      .reference(row.getReference())
+      .frSource(formatFrSource(row.getFrSource()))
+      .frIsForeign(row.getFrIsForeign())
+      .frMatriculationExam(row.getFrMatriculationExam())
+      .frEb(row.getFrEb())
+      .frDia(row.getFrDia())
+      .frHigherEducationConcluded(row.getFrHigherEducationConcluded())
+      .frHigherEducationEnrolled(row.getFrHigherEducationEnrolled())
+      .build();
+  }
+
+  private static String formatPaidAt(final LocalDateTime paidAt) {
+    if (paidAt == null) {
+      return null;
+    }
+    return paidAt.format(DATETIME_FORMATTER);
+  }
+
+  private static String formatAmount(final BigDecimal amount) {
+    if (amount == null) {
+      return "0,00";
+    }
+    final BigDecimal amountInEur = amount.divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+    return String.format("%.2f", amountInEur.doubleValue()).replace('.', ',');
+  }
+
+  private static String formatFrSource(final String source) {
+    if (source == null) {
+      return null;
+    }
+    return switch (source) {
+      case "KOSKI" -> "KOSKI";
+      case "USER" -> "Asiakas";
+      default -> source;
+    };
+  }
+}

--- a/backend/yki/src/main/java/fi/oph/yki/service/OrganizationService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/OrganizationService.java
@@ -1,0 +1,60 @@
+package fi.oph.yki.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class OrganizationService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OrganizationService.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final WebClient organizationClient;
+
+  @SuppressWarnings("unchecked")
+  public Map<String, String> getOrganizationNames(final Collection<String> oids) {
+    if (oids == null || oids.isEmpty()) {
+      return Map.of();
+    }
+
+    try {
+      final String responseBody = organizationClient
+        .post()
+        .uri("/api/findbyoids")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(oids)
+        .retrieve()
+        .bodyToMono(String.class)
+        .block();
+
+      final List<Map<String, Object>> organizations = OBJECT_MAPPER.readValue(responseBody, new TypeReference<>() {});
+
+      return organizations
+        .stream()
+        .collect(
+          Collectors.toMap(
+            org -> (String) org.get("oid"),
+            org -> {
+              final Map<String, String> nimi = (Map<String, String>) org.get("nimi");
+              return nimi != null ? nimi.getOrDefault("fi", "") : "";
+            },
+            (existing, replacement) -> existing
+          )
+        );
+    } catch (final Exception e) {
+      LOG.error("Failed to fetch organization names for OIDs: {}", oids, e);
+      throw new RuntimeException("Failed to fetch organization names", e);
+    }
+  }
+}

--- a/backend/yki/src/main/java/fi/oph/yki/service/OrganizationService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/OrganizationService.java
@@ -18,8 +18,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class OrganizationService {
 
   private static final Logger LOG = LoggerFactory.getLogger(OrganizationService.class);
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+  private final ObjectMapper objectMapper;
   private final WebClient organizationClient;
 
   @SuppressWarnings("unchecked")
@@ -38,7 +38,7 @@ public class OrganizationService {
         .bodyToMono(String.class)
         .block();
 
-      final List<Map<String, Object>> organizations = OBJECT_MAPPER.readValue(responseBody, new TypeReference<>() {});
+      final List<Map<String, Object>> organizations = objectMapper.readValue(responseBody, new TypeReference<>() {});
 
       return organizations
         .stream()

--- a/backend/yki/src/main/java/fi/oph/yki/view/PaymentReportXlsxView.java
+++ b/backend/yki/src/main/java/fi/oph/yki/view/PaymentReportXlsxView.java
@@ -1,0 +1,108 @@
+package fi.oph.yki.view;
+
+import static fi.oph.yki.view.ExamSessionXlsxView.autoresizeExcelColumns;
+import static fi.oph.yki.view.ExamSessionXlsxView.createExcelHeader;
+import static fi.oph.yki.view.ExamSessionXlsxView.setFilenameHeader;
+import static fi.oph.yki.view.ExamSessionXlsxView.setNullableValue;
+
+import fi.oph.yki.api.dto.clerk.ClerkPaymentReportRowDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import lombok.NonNull;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.web.servlet.view.document.AbstractXlsxView;
+
+public class PaymentReportXlsxView extends AbstractXlsxView {
+
+  private static final List<String> HEADERS = List.of(
+    "Järjestäjä",
+    "Sukunimi",
+    "Etunimet",
+    "Sähköpostiosoite",
+    "Maksun aikaleima",
+    "Koepäivä",
+    "Alkuperäinen koepäivä",
+    "Kieli",
+    "Taso",
+    "Summa (€)",
+    "Maksun yksilöintitunnus",
+    "Maksuttomuuden lähde",
+    "Ulkomainen tutkinto",
+    "Ylioppilastutkinto",
+    "EB-tutkinto",
+    "DIA-tutkinto",
+    "Korkeakoulututkinto",
+    "Korkeakouluopinnot"
+  );
+
+  private final List<ClerkPaymentReportRowDTO> rows;
+  private final LocalDate from;
+  private final LocalDate to;
+
+  public PaymentReportXlsxView(final List<ClerkPaymentReportRowDTO> rows, final LocalDate from, final LocalDate to) {
+    this.rows = rows;
+    this.from = from;
+    this.to = to;
+  }
+
+  @Override
+  protected void buildExcelDocument(
+    final @NonNull Map<String, Object> model,
+    final @NonNull Workbook workbook,
+    final @NonNull HttpServletRequest request,
+    final @NonNull HttpServletResponse response
+  ) {
+    setFilenameHeader(response, String.format("YKI_tutkintomaksut_%s_%s.xlsx", from, to));
+    response.setHeader("Cache-Control", "no-cache, no-store, private, max-age=0, must-revalidate");
+    writeExcel(workbook);
+  }
+
+  private void writeExcel(final Workbook workbook) {
+    final Sheet sheet = workbook.createSheet("Tutkintomaksut");
+
+    createExcelHeader((XSSFWorkbook) workbook, sheet, HEADERS);
+
+    for (int i = 0; i < rows.size(); i++) {
+      final Row row = sheet.createRow(i + 1);
+      final ClerkPaymentReportRowDTO data = rows.get(i);
+
+      int ci = 0;
+      setNullableValue(row.createCell(ci), data.organizer());
+      setNullableValue(row.createCell(++ci), data.lastName());
+      setNullableValue(row.createCell(++ci), data.firstName());
+      setNullableValue(row.createCell(++ci), data.email());
+      setNullableValue(row.createCell(++ci), data.paidAt());
+      setNullableValue(row.createCell(++ci), data.examDate() != null ? data.examDate().toString() : null);
+      setNullableValue(
+        row.createCell(++ci),
+        data.originalExamDate() != null ? data.originalExamDate().toString() : null
+      );
+      setNullableValue(row.createCell(++ci), data.examLanguage());
+      setNullableValue(row.createCell(++ci), data.examLevel());
+      setNullableValue(row.createCell(++ci), data.amount());
+      setNullableValue(row.createCell(++ci), data.reference());
+      setNullableValue(row.createCell(++ci), data.frSource());
+      setNullableValue(row.createCell(++ci), formatBoolean(data.frIsForeign()));
+      setNullableValue(row.createCell(++ci), formatBoolean(data.frMatriculationExam()));
+      setNullableValue(row.createCell(++ci), formatBoolean(data.frEb()));
+      setNullableValue(row.createCell(++ci), formatBoolean(data.frDia()));
+      setNullableValue(row.createCell(++ci), formatBoolean(data.frHigherEducationConcluded()));
+      setNullableValue(row.createCell(++ci), formatBoolean(data.frHigherEducationEnrolled()));
+    }
+
+    autoresizeExcelColumns(sheet, HEADERS);
+  }
+
+  private static String formatBoolean(final Boolean value) {
+    if (value == null) {
+      return "-";
+    }
+    return value ? "Kyllä" : "Ei";
+  }
+}

--- a/backend/yki/src/main/resources/application.yaml
+++ b/backend/yki/src/main/resources/application.yaml
@@ -53,6 +53,8 @@ app:
     user: ${cas.username:null}
     password: ${cas.password:null}
   clerk-enabled: ${clerk.enabled:false}
+  organization-service:
+    url: ${organization-service.url:https://virkailija.untuvaopintopolku.fi/organisaatio-service}
   email:
     sending-enabled: ${email.sending-enabled:false}
     service-url: ${email.service-url:null}

--- a/backend/yki/src/test/java/fi/oph/yki/service/ClerkPaymentReportServiceTest.java
+++ b/backend/yki/src/test/java/fi/oph/yki/service/ClerkPaymentReportServiceTest.java
@@ -135,6 +135,14 @@ public class ClerkPaymentReportServiceTest {
     testEntityManager.persist(freeRegistration);
 
     testEntityManager.flush();
+
+    testEntityManager
+      .getEntityManager()
+      .createNativeQuery("UPDATE free_registration SET created_at = :createdAt WHERE free_registration_id = :id")
+      .setParameter("createdAt", LocalDateTime.of(2026, 3, 15, 10, 0, 0))
+      .setParameter("id", freeRegistration.getId())
+      .executeUpdate();
+
     testEntityManager.clear();
 
     final List<ClerkPaymentReportRowDTO> result = clerkPaymentReportService.getPaymentReport(

--- a/backend/yki/src/test/java/fi/oph/yki/service/ClerkPaymentReportServiceTest.java
+++ b/backend/yki/src/test/java/fi/oph/yki/service/ClerkPaymentReportServiceTest.java
@@ -1,0 +1,289 @@
+package fi.oph.yki.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.when;
+
+import fi.oph.yki.Factory;
+import fi.oph.yki.PostgresTestcontainerConfig;
+import fi.oph.yki.api.dto.clerk.ClerkPaymentReportRowDTO;
+import fi.oph.yki.model.ExamDate;
+import fi.oph.yki.model.ExamPayment;
+import fi.oph.yki.model.ExamSession;
+import fi.oph.yki.model.FreeRegistration;
+import fi.oph.yki.model.Person;
+import fi.oph.yki.model.Registration;
+import fi.oph.yki.model.type.PaymentState;
+import fi.oph.yki.model.type.RegistrationState;
+import fi.oph.yki.repository.ExamPaymentRepository;
+import jakarta.annotation.Resource;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WithMockUser
+@DataJpaTest
+@ActiveProfiles("test-postgres")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(PostgresTestcontainerConfig.class)
+public class ClerkPaymentReportServiceTest {
+
+  private static final String ORGANIZER_OID = "1.2.246.562.10.99999999999";
+  private static final String ORGANIZER_NAME = "Testiorganisaatio";
+
+  @Resource
+  private ExamPaymentRepository examPaymentRepository;
+
+  @Resource
+  private TestEntityManager testEntityManager;
+
+  @MockitoBean
+  private OrganizationService organizationService;
+
+  private ClerkPaymentReportService clerkPaymentReportService;
+
+  @BeforeEach
+  public void setup() {
+    clerkPaymentReportService = new ClerkPaymentReportService(examPaymentRepository, organizationService);
+    when(organizationService.getOrganizationNames(anyCollection())).thenReturn(Map.of(ORGANIZER_OID, ORGANIZER_NAME));
+  }
+
+  @Test
+  public void testPaidPaymentIncludedInReport() {
+    final long organizerId = createOrganizer(ORGANIZER_OID);
+    final ExamDate examDate = Factory.examDate();
+    testEntityManager.persist(examDate);
+
+    final ExamSession examSession = Factory.examSession(examDate);
+    testEntityManager.persist(examSession);
+    setOrganizerOnExamSession(examSession.getId(), organizerId);
+
+    final Person person = Factory.person();
+    person.setEmail("test@example.com");
+    testEntityManager.persist(person);
+
+    final Registration registration = Factory.registration(person);
+    registration.setExamSession(examSession);
+    registration.setState(RegistrationState.COMPLETED);
+    testEntityManager.persist(registration);
+
+    final ExamPayment payment = createExamPayment(
+      registration,
+      new BigDecimal("15300"),
+      "YKI-EXAM-1-1-test-uuid",
+      LocalDateTime.of(2026, 3, 15, 10, 30, 0)
+    );
+    testEntityManager.persist(payment);
+
+    testEntityManager.flush();
+    testEntityManager.clear();
+
+    final List<ClerkPaymentReportRowDTO> result = clerkPaymentReportService.getPaymentReport(
+      LocalDate.of(2026, 3, 1),
+      LocalDate.of(2026, 3, 31)
+    );
+
+    assertEquals(1, result.size());
+    final ClerkPaymentReportRowDTO row = result.get(0);
+    assertEquals(ORGANIZER_NAME, row.organizer());
+    assertEquals("Henkilö", row.lastName());
+    assertEquals("Testi", row.firstName());
+    assertEquals("test@example.com", row.email());
+    assertEquals(LocalDate.of(2026, 6, 15), row.examDate());
+    assertNull(row.originalExamDate());
+    assertEquals("suomi", row.examLanguage());
+    assertEquals("Perustaso", row.examLevel());
+    assertEquals("153,00", row.amount());
+    assertEquals("YKI-EXAM-1-1-test-uuid", row.reference());
+    assertNull(row.frSource());
+  }
+
+  @Test
+  public void testFreeRegistrationIncludedInReport() {
+    final long organizerId = createOrganizer(ORGANIZER_OID);
+    final ExamDate examDate = Factory.examDate();
+    testEntityManager.persist(examDate);
+
+    final ExamSession examSession = Factory.examSession(examDate);
+    testEntityManager.persist(examSession);
+    setOrganizerOnExamSession(examSession.getId(), organizerId);
+
+    final Person person = Factory.person();
+    person.setEmail("free@example.com");
+    testEntityManager.persist(person);
+
+    final Registration registration = Factory.registration(person);
+    registration.setExamSession(examSession);
+    registration.setState(RegistrationState.COMPLETED);
+    testEntityManager.persist(registration);
+
+    final FreeRegistration freeRegistration = Factory.freeRegistration(registration);
+    testEntityManager.persist(freeRegistration);
+
+    testEntityManager.flush();
+    testEntityManager.clear();
+
+    final List<ClerkPaymentReportRowDTO> result = clerkPaymentReportService.getPaymentReport(
+      LocalDate.of(2026, 3, 1),
+      LocalDate.of(2026, 3, 31)
+    );
+
+    assertEquals(1, result.size());
+    final ClerkPaymentReportRowDTO row = result.get(0);
+    assertEquals(ORGANIZER_NAME, row.organizer());
+    assertEquals("0,00", row.amount());
+    assertEquals("KOSKI", row.frSource());
+    assertEquals(true, row.frMatriculationExam());
+    assertEquals(false, row.frIsForeign());
+  }
+
+  @Test
+  public void testPaymentOutsideDateRangeExcluded() {
+    final long organizerId = createOrganizer(ORGANIZER_OID);
+    final ExamDate examDate = Factory.examDate();
+    testEntityManager.persist(examDate);
+
+    final ExamSession examSession = Factory.examSession(examDate);
+    testEntityManager.persist(examSession);
+    setOrganizerOnExamSession(examSession.getId(), organizerId);
+
+    final Person person = Factory.person();
+    testEntityManager.persist(person);
+
+    final Registration registration = Factory.registration(person);
+    registration.setExamSession(examSession);
+    registration.setState(RegistrationState.COMPLETED);
+    testEntityManager.persist(registration);
+
+    testEntityManager.persist(
+      createExamPayment(
+        registration,
+        new BigDecimal("15300"),
+        "YKI-EXAM-outside-range",
+        LocalDateTime.of(2026, 2, 15, 10, 0, 0)
+      )
+    );
+
+    testEntityManager.flush();
+    testEntityManager.clear();
+
+    final List<ClerkPaymentReportRowDTO> result = clerkPaymentReportService.getPaymentReport(
+      LocalDate.of(2026, 3, 1),
+      LocalDate.of(2026, 3, 31)
+    );
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testSortingByOrganizerThenLastNameThenFirstName() {
+    final long organizerId = createOrganizer(ORGANIZER_OID);
+    final ExamDate examDate = Factory.examDate();
+    testEntityManager.persist(examDate);
+
+    final ExamSession examSession = Factory.examSession(examDate);
+    testEntityManager.persist(examSession);
+    setOrganizerOnExamSession(examSession.getId(), organizerId);
+
+    final Person personB = new Person();
+    personB.setOid("1.2.3.4.6");
+    personB.setFirstName("Bertta");
+    personB.setLastName("Virtanen");
+    testEntityManager.persist(personB);
+
+    final Person personA = new Person();
+    personA.setOid("1.2.3.4.7");
+    personA.setFirstName("Anna");
+    personA.setLastName("Korhonen");
+    testEntityManager.persist(personA);
+
+    final Registration regB = Factory.registration(personB);
+    regB.setExamSession(examSession);
+    regB.setState(RegistrationState.COMPLETED);
+    testEntityManager.persist(regB);
+
+    final Registration regA = Factory.registration(personA);
+    regA.setExamSession(examSession);
+    regA.setState(RegistrationState.COMPLETED);
+    testEntityManager.persist(regA);
+
+    testEntityManager.persist(
+      createExamPayment(regB, new BigDecimal("15300"), "YKI-EXAM-B", LocalDateTime.of(2026, 3, 10, 10, 0, 0))
+    );
+    testEntityManager.persist(
+      createExamPayment(regA, new BigDecimal("15300"), "YKI-EXAM-A", LocalDateTime.of(2026, 3, 10, 11, 0, 0))
+    );
+
+    testEntityManager.flush();
+    testEntityManager.clear();
+
+    final List<ClerkPaymentReportRowDTO> result = clerkPaymentReportService.getPaymentReport(
+      LocalDate.of(2026, 3, 1),
+      LocalDate.of(2026, 3, 31)
+    );
+
+    assertEquals(2, result.size());
+    assertEquals("Korhonen", result.get(0).lastName());
+    assertEquals("Virtanen", result.get(1).lastName());
+  }
+
+  private static int paymentCounter = 0;
+
+  private static ExamPayment createExamPayment(
+    final Registration registration,
+    final BigDecimal amount,
+    final String reference,
+    final LocalDateTime paidAt
+  ) {
+    paymentCounter++;
+    final ExamPayment payment = new ExamPayment();
+    payment.setState(PaymentState.PAID);
+    payment.setRegistration(registration);
+    payment.setAmount(amount);
+    payment.setReference(reference);
+    payment.setTransactionId("txn-" + paymentCounter);
+    payment.setHref("https://pay.example.com/" + paymentCounter);
+    payment.setPaidAt(paidAt);
+    return payment;
+  }
+
+  private long createOrganizer(final String oid) {
+    final EntityManager em = testEntityManager.getEntityManager();
+    em
+      .createNativeQuery(
+        "INSERT INTO organizer (oid, agreement_start_date, agreement_end_date) VALUES (:oid, :startDate, :endDate)"
+      )
+      .setParameter("oid", oid)
+      .setParameter("startDate", LocalDate.of(2020, 1, 1))
+      .setParameter("endDate", LocalDate.of(2030, 12, 31))
+      .executeUpdate();
+    final Number id = (Number) em
+      .createNativeQuery("SELECT id FROM organizer WHERE oid = :oid")
+      .setParameter("oid", oid)
+      .getSingleResult();
+    return id.longValue();
+  }
+
+  private void setOrganizerOnExamSession(final long examSessionId, final long organizerId) {
+    testEntityManager
+      .getEntityManager()
+      .createNativeQuery("UPDATE exam_session SET organizer_id = :organizerId WHERE id = :examSessionId")
+      .setParameter("organizerId", organizerId)
+      .setParameter("examSessionId", examSessionId)
+      .executeUpdate();
+  }
+}

--- a/frontend/packages/yki/clerk/public/i18n/en-GB/common.json
+++ b/frontend/packages/yki/clerk/public/i18n/en-GB/common.json
@@ -83,6 +83,7 @@
       "examSession": "Test",
       "extraInfo": "Lisätiedot",
       "freeRegistration": "Maksuttomuus",
+      "paymentReport": "Maksuraportti",
       "quarantine": "Osallistumiskiellot",
       "full": "Full",
       "gender": {
@@ -171,6 +172,7 @@
         "logoutSuccess": "Log out complete",
         "modifyContactDetails": "Edit contact information",
         "notFound": "Page not found",
+        "paymentReport": "Payment report",
         "reassessment": "Reassessment",
         "registration": "Registration",
         "registrationPaymentStatus": "Registration",

--- a/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
@@ -6,7 +6,10 @@
         "description": "Select the date range for which you want to view completed exam payments. By default, the entire previous month is selected. Please note that any subsequently refunded exam payments will still appear in the report as paid.",
         "from": "From",
         "to": "To",
-        "download": "Generate report (.xlsx)"
+        "download": "Generate report (.xlsx)",
+        "toasts": {
+          "downloadError": "Failed to generate the report"
+        }
       },
       "clerkCustomer": {
         "details": {

--- a/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
@@ -1,6 +1,13 @@
 {
   "yki": {
     "component": {
+      "clerkPaymentReport": {
+        "title": "Exam payment reporting",
+        "description": "Select the date range for which you want to view completed exam payments. By default, the entire previous month is selected. Please note that any subsequently refunded exam payments will still appear in the report as paid.",
+        "from": "From",
+        "to": "To",
+        "download": "Generate report (.xlsx)"
+      },
       "clerkCustomer": {
         "details": {
           "buttons": {
@@ -507,6 +514,9 @@
       },
       "clerkFreeRegistrationPage": {
         "heading": "Maksuttomuuden tarkastukset"
+      },
+      "clerkPaymentReportPage": {
+        "heading": "Reports and statistics"
       },
       "clerkQuarantinePage": {
         "heading": "Osallistumiskiellot"

--- a/frontend/packages/yki/clerk/public/i18n/fi-FI/common.json
+++ b/frontend/packages/yki/clerk/public/i18n/fi-FI/common.json
@@ -83,6 +83,7 @@
       "examSession": "Tutkinto",
       "extraInfo": "Lisätiedot",
       "freeRegistration": "Maksuttomuus",
+      "paymentReport": "Maksuraportti",
       "quarantine": "Osallistumiskiellot",
       "full": "Täynnä",
       "gender": {
@@ -171,6 +172,7 @@
         "logoutSuccess": "Uloskirjautuminen onnnistui",
         "modifyContactDetails": "Muokkaa yhteystietoja",
         "notFound": "Etsimääsi sivua ei löytynyt",
+        "paymentReport": "Maksuraportti",
         "reassessment": "Tarkistusarviointi",
         "registration": "Ilmoittautuminen",
         "registrationPaymentStatus": "Ilmoittautuminen",

--- a/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
@@ -6,7 +6,10 @@
         "description": "Valitse alta päivämäärät joiden ajalta haluat tarkastella toteutuneita tutkintomaksuja. Oletusarvoisesti valittuna on koko edellinen kuukausi. Huomaathan, että mahdollisesti jälkikäteen palautetut tutkintomaksut näkyvät edelleen raportissa maksettuina.",
         "from": "Mistä",
         "to": "Mihin",
-        "download": "Muodosta raportti (.xlsx)"
+        "download": "Muodosta raportti (.xlsx)",
+        "toasts": {
+          "downloadError": "Raportin luominen epäonnistui"
+        }
       },
       "clerkCustomer": {
         "details": {

--- a/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
@@ -3,7 +3,7 @@
     "component": {
       "clerkPaymentReport": {
         "title": "Tutkintomaksujen raportointi",
-        "description": "Valitse alta päivämäärät joiden ajalta haluat tarkastella toteutuneita tutkintomaksuja. Oletusarvoisesti valittuna on koko edellinen kuukausi. Huomaathan, että mahdollisesti jälkikäteen palautetut tutkintomaksut näkyvät edelleen raportissa maksutuina.",
+        "description": "Valitse alta päivämäärät joiden ajalta haluat tarkastella toteutuneita tutkintomaksuja. Oletusarvoisesti valittuna on koko edellinen kuukausi. Huomaathan, että mahdollisesti jälkikäteen palautetut tutkintomaksut näkyvät edelleen raportissa maksettuina.",
         "from": "Mistä",
         "to": "Mihin",
         "download": "Muodosta raportti (.xlsx)"

--- a/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
@@ -1,6 +1,13 @@
 {
   "yki": {
     "component": {
+      "clerkPaymentReport": {
+        "title": "Tutkintomaksujen raportointi",
+        "description": "Valitse alta päivämäärät joiden ajalta haluat tarkastella toteutuneita tutkintomaksuja. Oletusarvoisesti valittuna on koko edellinen kuukausi. Huomaathan, että mahdollisesti jälkikäteen palautetut tutkintomaksut näkyvät edelleen raportissa maksutuina.",
+        "from": "Mistä",
+        "to": "Mihin",
+        "download": "Muodosta raportti (.xlsx)"
+      },
       "clerkCustomer": {
         "details": {
           "buttons": {
@@ -507,6 +514,9 @@
       },
       "clerkFreeRegistrationPage": {
         "heading": "Maksuttomuuden tarkastukset"
+      },
+      "clerkPaymentReportPage": {
+        "heading": "Raportit ja tilastot"
       },
       "clerkQuarantinePage": {
         "heading": "Osallistumiskiellot"

--- a/frontend/packages/yki/clerk/public/i18n/sv-SE/common.json
+++ b/frontend/packages/yki/clerk/public/i18n/sv-SE/common.json
@@ -83,6 +83,7 @@
       "examSession": "Examen",
       "extraInfo": "Lisätiedot",
       "freeRegistration": "Maksuttomuus",
+      "paymentReport": "Maksuraportti",
       "quarantine": "Osallistumiskiellot",
       "full": "Fullbokat",
       "gender": {
@@ -171,6 +172,7 @@
         "logoutSuccess": "Utloggning lyckades",
         "modifyContactDetails": "Redigera kontaktuppgifterna",
         "notFound": "Sidan hittades inte",
+        "paymentReport": "Betalningsrapport",
         "reassessment": "Kontrollbedömning",
         "registration": "Anmälning",
         "registrationPaymentStatus": "Anmälning",

--- a/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
@@ -6,7 +6,10 @@
         "description": "Välj datumintervallet för vilka du vill granska genomförda examensavgifter. Som standard är hela föregående månad vald. Observera att eventuellt i efterhand återbetalade examensavgifter fortfarande visas i rapporten som betalda.",
         "from": "Från",
         "to": "Till",
-        "download": "Skapa rapport (.xlsx)"
+        "download": "Skapa rapport (.xlsx)",
+        "toasts": {
+          "downloadError": "Det gick inte att skapa rapporten"
+        }
       },
       "clerkCustomer": {
         "details": {

--- a/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
@@ -1,6 +1,13 @@
 {
   "yki": {
     "component": {
+      "clerkPaymentReport": {
+        "title": "Rapportering av examensavgifter",
+        "description": "Välj datumintervallet för vilka du vill granska genomförda examensavgifter. Som standard är hela föregående månad vald. Observera att eventuellt i efterhand återbetalade examensavgifter fortfarande visas i rapporten som betalda.",
+        "from": "Från",
+        "to": "Till",
+        "download": "Skapa rapport (.xlsx)"
+      },
       "clerkCustomer": {
         "details": {
           "buttons": {
@@ -507,6 +514,9 @@
       },
       "clerkFreeRegistrationPage": {
         "heading": "Maksuttomuuden tarkastukset"
+      },
+      "clerkPaymentReportPage": {
+        "heading": "Rapporter och statistik"
       },
       "clerkQuarantinePage": {
         "heading": "Osallistumiskiellot"

--- a/frontend/packages/yki/clerk/src/components/clerkPaymentReport/ClerkPaymentReport.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkPaymentReport/ClerkPaymentReport.tsx
@@ -32,7 +32,10 @@ export const ClerkPaymentReport = () => {
       const url = `${APIEndpoints.ClerkPaymentReportExcel}?from=${from.format(
         'YYYY-MM-DD',
       )}&to=${to.format('YYYY-MM-DD')}`;
-      const response = await fetch(url, { credentials: 'include' });
+      const response = await fetch(url, {
+        credentials: 'include',
+        redirect: 'manual',
+      });
       if (!response.ok) {
         showToast({
           severity: Severity.Error,

--- a/frontend/packages/yki/clerk/src/components/clerkPaymentReport/ClerkPaymentReport.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkPaymentReport/ClerkPaymentReport.tsx
@@ -3,7 +3,8 @@ import { OphButton } from '@opetushallitus/oph-design-system';
 import dayjs, { Dayjs } from 'dayjs';
 import { useState } from 'react';
 import { CustomDatePicker } from 'shared/components';
-import { Variant } from 'shared/enums';
+import { Severity, Variant } from 'shared/enums';
+import { useToast } from 'shared/hooks';
 
 import { usePublicTranslation } from 'configs/i18n';
 import { APIEndpoints } from 'enums/api';
@@ -12,6 +13,7 @@ export const ClerkPaymentReport = () => {
   const { t } = usePublicTranslation({
     keyPrefix: 'yki.component.clerkPaymentReport',
   });
+  const { showToast } = useToast();
 
   const [from, setFrom] = useState<Dayjs | null>(
     dayjs().subtract(1, 'month').startOf('month'),
@@ -31,6 +33,14 @@ export const ClerkPaymentReport = () => {
         'YYYY-MM-DD',
       )}&to=${to.format('YYYY-MM-DD')}`;
       const response = await fetch(url, { credentials: 'include' });
+      if (!response.ok) {
+        showToast({
+          severity: Severity.Error,
+          description: t('toasts.downloadError'),
+        });
+
+        return;
+      }
       const blob = await response.blob();
       const downloadUrl = window.URL.createObjectURL(blob);
       const a = document.createElement('a');

--- a/frontend/packages/yki/clerk/src/components/clerkPaymentReport/ClerkPaymentReport.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkPaymentReport/ClerkPaymentReport.tsx
@@ -1,0 +1,84 @@
+import { CircularProgress, Typography } from '@mui/material';
+import { OphButton } from '@opetushallitus/oph-design-system';
+import dayjs, { Dayjs } from 'dayjs';
+import { useState } from 'react';
+import { CustomDatePicker } from 'shared/components';
+import { Variant } from 'shared/enums';
+
+import { usePublicTranslation } from 'configs/i18n';
+import { APIEndpoints } from 'enums/api';
+
+export const ClerkPaymentReport = () => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.clerkPaymentReport',
+  });
+
+  const [from, setFrom] = useState<Dayjs | null>(
+    dayjs().subtract(1, 'month').startOf('month'),
+  );
+  const [to, setTo] = useState<Dayjs | null>(
+    dayjs().subtract(1, 'month').endOf('month'),
+  );
+  const [loading, setLoading] = useState(false);
+
+  const isValid = from && to && !to.isBefore(from, 'day');
+
+  const handleDownload = async () => {
+    if (!isValid) return;
+    setLoading(true);
+    try {
+      const url = `${APIEndpoints.ClerkPaymentReportExcel}?from=${from.format(
+        'YYYY-MM-DD',
+      )}&to=${to.format('YYYY-MM-DD')}`;
+      const response = await fetch(url, { credentials: 'include' });
+      const blob = await response.blob();
+      const downloadUrl = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = downloadUrl;
+      a.download = `YKI_tutkintomaksut_${from.format('YYYY-MM-DD')}_${to.format(
+        'YYYY-MM-DD',
+      )}.xlsx`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(downloadUrl);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="rows gapped">
+      <Typography variant="h3">{t('title')}</Typography>
+      <Typography>{t('description')}</Typography>
+      <div className="columns gapped" style={{ alignItems: 'flex-end' }}>
+        <div className="rows gapped-xxs">
+          <label>{t('from')}</label>
+          <div style={{ maxWidth: '180px' }}>
+            <CustomDatePicker value={from} setValue={setFrom} />
+          </div>
+        </div>
+        <Typography style={{ paddingBottom: '8px' }}>—</Typography>
+        <div className="rows gapped-xxs">
+          <label>{t('to')}</label>
+          <div style={{ maxWidth: '180px' }}>
+            <CustomDatePicker value={to} setValue={setTo} />
+          </div>
+        </div>
+      </div>
+      <div>
+        <OphButton
+          color="primary"
+          variant={Variant.Contained}
+          disabled={!isValid || loading}
+          onClick={handleDownload}
+        >
+          {loading && (
+            <CircularProgress size={20} color="inherit" sx={{ mr: 1 }} />
+          )}
+          {t('download')}
+        </OphButton>
+      </div>
+    </div>
+  );
+};

--- a/frontend/packages/yki/clerk/src/components/layouts/clerkHeader/ClerkNavigationLinks.tsx
+++ b/frontend/packages/yki/clerk/src/components/layouts/clerkHeader/ClerkNavigationLinks.tsx
@@ -18,6 +18,8 @@ const getTabForPath = (path: string) => {
     path.includes(AppRoutes.ClerkExamDates)
   ) {
     return 'clerkExamSessions';
+  } else if (path.includes(AppRoutes.ClerkPaymentReport)) {
+    return 'paymentReport';
   } else {
     return false;
   }
@@ -52,6 +54,11 @@ export const ClerkNavigationLinks = () => {
           active: getTabForPath(pathname) === 'customerSearch',
           href: AppRoutes.CustomerSearch,
           label: translateCommon('customerSearch'),
+        },
+        {
+          active: getTabForPath(pathname) === 'paymentReport',
+          href: AppRoutes.ClerkPaymentReport,
+          label: translateCommon('paymentReport'),
         },
         {
           active: getTabForPath(pathname) === 'quarantine',

--- a/frontend/packages/yki/clerk/src/components/layouts/clerkHeader/ClerkNavigationLinks.tsx
+++ b/frontend/packages/yki/clerk/src/components/layouts/clerkHeader/ClerkNavigationLinks.tsx
@@ -56,14 +56,14 @@ export const ClerkNavigationLinks = () => {
           label: translateCommon('customerSearch'),
         },
         {
-          active: getTabForPath(pathname) === 'paymentReport',
-          href: AppRoutes.ClerkPaymentReport,
-          label: translateCommon('paymentReport'),
-        },
-        {
           active: getTabForPath(pathname) === 'quarantine',
           href: AppRoutes.ClerkQuarantine,
           label: translateCommon('quarantine'),
+        },
+        {
+          active: getTabForPath(pathname) === 'paymentReport',
+          href: AppRoutes.ClerkPaymentReport,
+          label: translateCommon('paymentReport'),
         },
       ]}
     />

--- a/frontend/packages/yki/clerk/src/enums/api.ts
+++ b/frontend/packages/yki/clerk/src/enums/api.ts
@@ -15,6 +15,7 @@ export enum APIEndpoints {
   ClerkCustomersSearch = '/yki/v2/api/clerk/customer/search?page=:page&size=:size',
   ClerkExamDate = '/yki/v2/api/clerk/examDate',
   ClerkPersonContactUpdate = '/yki/v2/api/clerk/person/:oid/contactDetails',
+  ClerkPaymentReportExcel = '/yki/v2/api/clerk/paymentReport/excel',
   ClerkQuarantineMatches = '/yki/v2/api/clerk/quarantine/matches',
   User = '/yki/api/user/identity',
 }

--- a/frontend/packages/yki/clerk/src/enums/app.ts
+++ b/frontend/packages/yki/clerk/src/enums/app.ts
@@ -14,6 +14,7 @@ export enum AppRoutes {
   ClerkOrganizerRegisterDetails = '/yki/v2/virkailija/jarjestajarekisteri/:oid/tutkintotilaisuudet',
   ClerkFreeRegistration = '/yki/v2/virkailija/maksuttomuus',
   ClerkFreeRegistrationDetails = '/yki/v2/virkailija/maksuttomuus/:id',
+  ClerkPaymentReport = '/yki/v2/virkailija/maksuraportti',
   ClerkQuarantine = '/yki/v2/virkailija/osallistumiskiellot',
 }
 

--- a/frontend/packages/yki/clerk/src/pages/ClerkPaymentReportPage.tsx
+++ b/frontend/packages/yki/clerk/src/pages/ClerkPaymentReportPage.tsx
@@ -1,0 +1,30 @@
+import { Box, Grid, Paper, Typography } from '@mui/material';
+import { FC } from 'react';
+
+import { ClerkPaymentReport } from 'components/clerkPaymentReport/ClerkPaymentReport';
+import { usePublicTranslation } from 'configs/i18n';
+
+export const ClerkPaymentReportPage: FC = () => {
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.pages.clerkPaymentReportPage',
+  });
+
+  return (
+    <Box className="clerk-payment-report-page">
+      <Typography variant="h2">{t('heading')}</Typography>
+      <Grid
+        container
+        rowSpacing={4}
+        direction="column"
+        className="clerk-payment-report-page__grid-container"
+      >
+        <Paper
+          elevation={3}
+          className="clerk-payment-report-page__grid-container__results"
+        >
+          <ClerkPaymentReport />
+        </Paper>
+      </Grid>
+    </Box>
+  );
+};

--- a/frontend/packages/yki/clerk/src/routers/AppRouter.tsx
+++ b/frontend/packages/yki/clerk/src/routers/AppRouter.tsx
@@ -30,6 +30,7 @@ import { ClerkFreeRegistrationDetailsPage } from 'pages/ClerkFreeRegistrationDet
 import { ClerkFreeRegistrationPage } from 'pages/ClerkFreeRegistrationPage';
 import { ClerkHomePage } from 'pages/ClerkHomePage';
 import { ClerkOrganizerRegisterDetailsPage } from 'pages/ClerkOrganizerRegisterDetails';
+import { ClerkPaymentReportPage } from 'pages/ClerkPaymentReportPage';
 import { ClerkQuarantinePage } from 'pages/ClerkQuarantinePage';
 import { loadSession } from 'redux/reducers/session';
 import { sessionSelector } from 'redux/selectors/session';
@@ -159,6 +160,14 @@ export const AppRouter: FC = () => {
           element={
             <YkiTitlePage title="customerDetails">
               <ClerkCustomerDetailsPage />
+            </YkiTitlePage>
+          }
+        />
+        <Route
+          path={AppRoutes.ClerkPaymentReport}
+          element={
+            <YkiTitlePage title="paymentReport">
+              <ClerkPaymentReportPage />
             </YkiTitlePage>
           }
         />

--- a/frontend/packages/yki/clerk/src/styles/pages/_clerk-payment-report-page.scss
+++ b/frontend/packages/yki/clerk/src/styles/pages/_clerk-payment-report-page.scss
@@ -1,0 +1,13 @@
+.clerk-payment-report-page {
+  flex: 1;
+  background-color: $page-background-color;
+
+  & &__grid-container {
+    margin-top: 2rem;
+    display: grid;
+
+    &__results {
+      padding: 2rem;
+    }
+  }
+}

--- a/frontend/packages/yki/clerk/src/styles/styles.scss
+++ b/frontend/packages/yki/clerk/src/styles/styles.scss
@@ -23,3 +23,4 @@
 @import 'pages/clerk-customer-details-page';
 @import 'pages/clerk-customers-search-page';
 @import 'pages/clerk-add-organizer-page';
+@import 'pages/clerk-payment-report-page';

--- a/frontend/packages/yki/clerk/src/tests/jest/components/layouts/__snapshots__/ClerkHeader.test.tsx.snap
+++ b/frontend/packages/yki/clerk/src/tests/jest/components/layouts/__snapshots__/ClerkHeader.test.tsx.snap
@@ -68,24 +68,24 @@ exports[`ClerkHeader should render ClerkHeader correctly 1`] = `
             <li>
               <a
                 aria-current="false"
-                href="/yki/v2/virkailija/maksuraportti"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
-                >
-                  paymentReport
-                </p>
-              </a>
-            </li>
-            <li>
-              <a
-                aria-current="false"
                 href="/yki/v2/virkailija/osallistumiskiellot"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
                 >
                   quarantine
+                </p>
+              </a>
+            </li>
+            <li>
+              <a
+                aria-current="false"
+                href="/yki/v2/virkailija/maksuraportti"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
+                >
+                  paymentReport
                 </p>
               </a>
             </li>

--- a/frontend/packages/yki/clerk/src/tests/jest/components/layouts/__snapshots__/ClerkHeader.test.tsx.snap
+++ b/frontend/packages/yki/clerk/src/tests/jest/components/layouts/__snapshots__/ClerkHeader.test.tsx.snap
@@ -68,6 +68,18 @@ exports[`ClerkHeader should render ClerkHeader correctly 1`] = `
             <li>
               <a
                 aria-current="false"
+                href="/yki/v2/virkailija/maksuraportti"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
+                >
+                  paymentReport
+                </p>
+              </a>
+            </li>
+            <li>
+              <a
+                aria-current="false"
                 href="/yki/v2/virkailija/osallistumiskiellot"
               >
                 <p

--- a/frontend/packages/yki/clerk/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/clerk/src/tests/msw/handlers.ts
@@ -339,6 +339,24 @@ export const handlers = [
       return HttpResponse.json(findOrganizations);
     },
   ),
+  http.get(APIEndpoints.ClerkPaymentReportExcel, ({ request }) => {
+    const url = new URL(request.url);
+    const from = url.searchParams.get('from');
+    const to = url.searchParams.get('to');
+
+    if (!from || !to) {
+      return new HttpResponse(null, { status: 400 });
+    }
+
+    return new HttpResponse(new Blob(['mock-excel-content']), {
+      status: 200,
+      headers: {
+        'Content-Type':
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'Content-Disposition': `attachment; filename="YKI_tutkintomaksut_${from}_${to}.xlsx"`,
+      },
+    });
+  }),
   http.get(APIEndpoints.ClerkQuarantineMatches, () =>
     HttpResponse.json({ quarantineMatches }),
   ),


### PR DESCRIPTION
## Yhteenveto

Mahdollistaa maksuraporttien latauksen uudessa virkailijassa.

<img width="966" height="517" alt="Screenshot 2026-04-01 at 14 58 22" src="https://github.com/user-attachments/assets/45125adf-5625-4ec7-97dd-91bef50b9d44" />

## Lisätiedot

[Figma-linkki.](https://www.figma.com/design/ZOfE587TPiFCuk34BH3Vwz/OPH-Kios---Kielitutkinnot-YKI?node-id=1047-6694&t=3gpxpIg6KA4CpLgv-1)

Näkymä untuvalla: https://virkailija.untuvaopintopolku.fi/yki/v2/virkailija/maksuraportti

## Huomautukset

Ei vaadi kantamuutoksia tai migraatioita. Toteutus pyrkii vastaamaan samaa maksuraportin latausta, kuin vanhassa virkailijassa. Lisätty boldatut otsakkeet excel-tiedostoon, sekä Figmasta löytynyt latausindikaattori raportin latauspainikkeeseen.

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
