### PR TITLE
YKI(Backend): OPHKIOS-180: Backend improvements

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -3,3 +3,7 @@
   1. Current domain in the stack
   2. Current category / sub domain
   3. Stack (frontend or backend)
+
+## Java
+
+- When constructing multi-field DTOs or domain objects, prefer Lombok `@Builder` (`.builder()...build()`) over positional constructor calls. If a type is a `record` and needs to be constructed with many fields, convert it to a `@Builder` class instead.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,9 @@
+# Testing
+
+## Java — Test Data Setup
+
+In `@DataJpaTest` service tests, set up test data using `Factory.*()` methods with `TestEntityManager.persist()`.
+
+Reference: `ClerkExamSessionServiceTest` and `RegistrationServiceTest` are the canonical examples.
+
+**If the primary `Factory` + `entityManager` approach hits a blocker** (e.g. a JPA model is missing fields, or an entity doesn't exist yet), do not assume a workaround. Stop and discuss with the user to decide the right path — whether that means extending the model, adding a factory method, or accepting raw SQL for that specific case.

--- a/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkQuarantineMatchDTO.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/dto/clerk/ClerkQuarantineMatchDTO.java
@@ -3,7 +3,9 @@ package fi.oph.yki.api.dto.clerk;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.Instant;
 import java.time.LocalDate;
+import lombok.Builder;
 
+@Builder
 public record ClerkQuarantineMatchDTO(
   Long id,
   String quarantineLang,

--- a/backend/yki/src/main/java/fi/oph/yki/model/Quarantine.java
+++ b/backend/yki/src/main/java/fi/oph/yki/model/Quarantine.java
@@ -6,6 +6,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.Instant;
+import java.time.LocalDate;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,4 +21,31 @@ public class Quarantine {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id", nullable = false)
   private long id;
+
+  @Column(name = "language_code", nullable = false)
+  private String languageCode;
+
+  @Column(name = "ssn")
+  private String ssn;
+
+  @Column(name = "birthdate", nullable = false)
+  private String birthdate;
+
+  @Column(name = "first_name", nullable = false)
+  private String firstName;
+
+  @Column(name = "last_name", nullable = false)
+  private String lastName;
+
+  @Column(name = "start_date", nullable = false)
+  private LocalDate startDate;
+
+  @Column(name = "end_date", nullable = false)
+  private LocalDate endDate;
+
+  @Column(name = "updated")
+  private Instant updated;
+
+  @Column(name = "deleted_at")
+  private Instant deletedAt;
 }

--- a/backend/yki/src/main/java/fi/oph/yki/model/Registration.java
+++ b/backend/yki/src/main/java/fi/oph/yki/model/Registration.java
@@ -1,5 +1,6 @@
 package fi.oph.yki.model;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import fi.oph.yki.model.type.RegistrationKind;
 import fi.oph.yki.model.type.RegistrationState;
 import jakarta.persistence.Column;
@@ -20,7 +21,9 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.JdbcType;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.dialect.PostgreSQLEnumJdbcType;
+import org.hibernate.type.SqlTypes;
 
 @Getter
 @Setter
@@ -46,6 +49,10 @@ public class Registration {
   @Enumerated(value = EnumType.STRING)
   @JdbcType(PostgreSQLEnumJdbcType.class)
   private RegistrationState state;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "form")
+  private ObjectNode form;
 
   @Column(name = "lifted_from_queue_at")
   private LocalDateTime liftedFromQueueAt;

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkQuarantineService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkQuarantineService.java
@@ -70,7 +70,7 @@ public class ClerkQuarantineService {
         form.put("birthdate", HetuUtils.dateFromHetu(originalFormSsn).toString());
       }
 
-      form.put("ssn", oidToSsn.get(proj.getPersonOid()));
+      form.put("ssn", proj.getPersonOid() != null ? oidToSsn.get(proj.getPersonOid()) : null);
 
       matches.add(
         ClerkQuarantineMatchDTO

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkQuarantineService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkQuarantineService.java
@@ -73,22 +73,23 @@ public class ClerkQuarantineService {
       form.put("ssn", oidToSsn.get(proj.getPersonOid()));
 
       matches.add(
-        new ClerkQuarantineMatchDTO(
-          proj.getQuarantineId(),
-          proj.getQuarantineLang().trim(),
-          proj.getBirthdate(),
-          proj.getCreated(),
-          proj.getSsn(),
-          proj.getFirstName(),
-          proj.getLastName(),
-          proj.getEmail(),
-          proj.getPhoneNumber(),
-          proj.getRegistrationId(),
-          form,
-          proj.getState(),
-          proj.getExamDate(),
-          proj.getLanguageCode().trim()
-        )
+        ClerkQuarantineMatchDTO
+          .builder()
+          .id(proj.getQuarantineId())
+          .quarantineLang(proj.getQuarantineLang().trim())
+          .birthdate(proj.getBirthdate())
+          .created(proj.getCreated())
+          .ssn(proj.getSsn())
+          .firstName(proj.getFirstName())
+          .lastName(proj.getLastName())
+          .email(proj.getEmail())
+          .phoneNumber(proj.getPhoneNumber())
+          .registrationId(proj.getRegistrationId())
+          .form(form)
+          .state(proj.getState())
+          .examDate(proj.getExamDate())
+          .languageCode(proj.getLanguageCode().trim())
+          .build()
       );
     }
 

--- a/backend/yki/src/test/java/fi/oph/yki/Factory.java
+++ b/backend/yki/src/test/java/fi/oph/yki/Factory.java
@@ -5,6 +5,7 @@ import fi.oph.yki.model.ExamSession;
 import fi.oph.yki.model.ExamSessionLocation;
 import fi.oph.yki.model.FreeRegistration;
 import fi.oph.yki.model.Person;
+import fi.oph.yki.model.Quarantine;
 import fi.oph.yki.model.Registration;
 import fi.oph.yki.model.type.ExamSessionType;
 import fi.oph.yki.model.type.FreeRegistrationSource;
@@ -72,6 +73,18 @@ public class Factory {
     examSession.setContactPhoneNumber("0401234567");
 
     return examSession;
+  }
+
+  public static Quarantine quarantine() {
+    final Quarantine quarantine = new Quarantine();
+    quarantine.setLanguageCode("fin");
+    quarantine.setBirthdate("1975-01-01");
+    quarantine.setFirstName("Testi");
+    quarantine.setLastName("Henkilö");
+    quarantine.setStartDate(LocalDate.of(2026, 1, 1));
+    quarantine.setEndDate(LocalDate.of(2026, 12, 31));
+
+    return quarantine;
   }
 
   public static ExamSessionLocation examSessionLocation(final ExamSession examSession) {

--- a/backend/yki/src/test/java/fi/oph/yki/service/ClerkQuarantineServiceTest.java
+++ b/backend/yki/src/test/java/fi/oph/yki/service/ClerkQuarantineServiceTest.java
@@ -1,24 +1,35 @@
 package fi.oph.yki.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.oph.yki.Factory;
 import fi.oph.yki.PostgresTestcontainerConfig;
 import fi.oph.yki.api.dto.clerk.ClerkQuarantineMatchDTO;
 import fi.oph.yki.api.dto.clerk.ClerkQuarantineMatchesResponseDTO;
 import fi.oph.yki.audit.AuditService;
+import fi.oph.yki.model.ExamDate;
+import fi.oph.yki.model.ExamSession;
+import fi.oph.yki.model.Person;
+import fi.oph.yki.model.Quarantine;
+import fi.oph.yki.model.Registration;
+import fi.oph.yki.model.type.RegistrationState;
 import fi.oph.yki.onr.OnrService;
 import fi.oph.yki.onr.dto.PersonalDataDTO;
 import fi.oph.yki.repository.QuarantineRepository;
 import jakarta.annotation.Resource;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -36,6 +47,11 @@ public class ClerkQuarantineServiceTest {
   private QuarantineRepository quarantineRepository;
 
   @Resource
+  private TestEntityManager entityManager;
+
+  // Kept for quarantine_review inserts only — QuarantineReview has no JPA entity and we decided
+  // against adding one that would be used exclusively in tests.
+  @Resource
   private JdbcTemplate jdbcTemplate;
 
   @MockBean
@@ -44,62 +60,109 @@ public class ClerkQuarantineServiceTest {
   @MockBean
   private AuditService auditService;
 
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
   private ClerkQuarantineService clerkQuarantineService;
+
+  private ExamSession finSession;
+  private Registration regSsnMatch;
+  private Registration regBirthdateMatch;
+  private Registration regStarted;
+  private Registration regSweMismatch;
+  private Registration regReviewed;
 
   @BeforeEach
   public void setup() {
-    clerkQuarantineService =
-      new ClerkQuarantineService(quarantineRepository, onrService, auditService, new ObjectMapper());
+    clerkQuarantineService = new ClerkQuarantineService(quarantineRepository, onrService, auditService, objectMapper);
 
-    // exam_date: id=100, within ban date range
-    jdbcTemplate.update(
-      "INSERT INTO exam_date (id, exam_date, registration_start_date, registration_end_date) VALUES (100, '2026-05-09', '2025-12-01', '2025-12-31')"
-    );
-    // exam_session: id=100 (fin), id=101 (swe) — both share exam_date 100
-    jdbcTemplate.update(
-      "INSERT INTO exam_session (id, language_code, level_code, exam_date_id, max_participants) VALUES (100, 'fin', 'KESKI', 100, 30)"
-    );
-    jdbcTemplate.update(
-      "INSERT INTO exam_session (id, language_code, level_code, exam_date_id, max_participants) VALUES (101, 'swe', 'KESKI', 100, 30)"
-    );
+    final ExamDate examDate = Factory.examDate();
+    entityManager.persist(examDate);
 
-    // registration 100: COMPLETED, fin, SSN match, person_oid='person1'
-    jdbcTemplate.update(
-      "INSERT INTO registration (id, state, exam_session_id, form, person_oid) VALUES (100, 'COMPLETED', 100, '{\"ssn\":\"010675-9981\",\"birthdate\":\"1975-06-01\"}'::jsonb, 'person1')"
-    );
-    // registration 101: SUBMITTED, fin, birthdate-only match (no ssn in form), person_oid='person2'
-    jdbcTemplate.update(
-      "INSERT INTO registration (id, state, exam_session_id, form, person_oid) VALUES (101, 'SUBMITTED', 100, '{\"birthdate\":\"1980-02-15\"}'::jsonb, 'person2')"
-    );
-    // registration 102: STARTED — should be filtered out
-    jdbcTemplate.update(
-      "INSERT INTO registration (id, state, exam_session_id, form) VALUES (102, 'STARTED', 100, '{\"ssn\":\"010675-9981\"}'::jsonb)"
-    );
-    // registration 103: COMPLETED, swe — language mismatch with fin quarantine
-    jdbcTemplate.update(
-      "INSERT INTO registration (id, state, exam_session_id, form) VALUES (103, 'COMPLETED', 101, '{\"ssn\":\"010675-9981\"}'::jsonb)"
-    );
-    // registration 104: COMPLETED, fin, SSN match — will have a reviewed quarantine_review
-    jdbcTemplate.update(
-      "INSERT INTO registration (id, state, exam_session_id, form, person_oid) VALUES (104, 'COMPLETED', 100, '{\"ssn\":\"100100-960R\"}'::jsonb, 'person3')"
-    );
+    finSession = Factory.examSession(examDate);
+    entityManager.persist(finSession);
 
-    // quarantine 100: fin, SSN=010675-9981, covers exam_date 2026-05-09
-    jdbcTemplate.update(
-      "INSERT INTO quarantine (id, language_code, ssn, birthdate, first_name, last_name, start_date, end_date, updated) VALUES (100, 'fin', '010675-9981', '1975-06-01', 'Anna-Liisa', 'Sallinen', '2026-01-01', '2026-12-31', '2020-01-01 00:00:00+00')"
-    );
-    // quarantine 101: fin, birthdate-only match with registration 101
-    jdbcTemplate.update(
-      "INSERT INTO quarantine (id, language_code, ssn, birthdate, first_name, last_name, start_date, end_date) VALUES (101, 'fin', null, '1980-02-15', 'Test', 'Person', '2026-01-01', '2026-12-31')"
-    );
-    // quarantine 102: fin, SSN match with registration 104 — will be reviewed
-    jdbcTemplate.update(
-      "INSERT INTO quarantine (id, language_code, ssn, birthdate, first_name, last_name, start_date, end_date, updated) VALUES (102, 'fin', '100100-960R', '1910-01-10', 'Reviewed', 'Person', '2026-01-01', '2026-12-31', '2020-01-01 00:00:00+00')"
-    );
+    final ExamSession sweSession = Factory.examSession(examDate);
+    sweSession.setLanguage("swe");
+    entityManager.persist(sweSession);
 
-    // quarantine_review for quarantine 102 / registration 104 — updated is newer than quarantine.updated
+    final Person person1 = Factory.person();
+    person1.setOid("oid-person1");
+    entityManager.persist(person1);
+
+    final Person person2 = Factory.person();
+    person2.setOid("oid-person2");
+    entityManager.persist(person2);
+
+    final Person person3 = Factory.person();
+    person3.setOid("oid-person3");
+    entityManager.persist(person3);
+
+    // COMPLETED, fin, SSN match
+    regSsnMatch = Factory.registration(person1);
+    regSsnMatch.setExamSession(finSession);
+    regSsnMatch.setState(RegistrationState.COMPLETED);
+    regSsnMatch.setForm(objectMapper.createObjectNode().put("ssn", "010675-9981").put("birthdate", "1975-06-01"));
+    entityManager.persist(regSsnMatch);
+
+    // SUBMITTED, fin, birthdate-only match (no ssn in form)
+    regBirthdateMatch = Factory.registration(person2);
+    regBirthdateMatch.setExamSession(finSession);
+    regBirthdateMatch.setForm(objectMapper.createObjectNode().put("birthdate", "1980-02-15"));
+    entityManager.persist(regBirthdateMatch);
+
+    // STARTED — should be filtered out
+    regStarted = Factory.registration(null);
+    regStarted.setExamSession(finSession);
+    regStarted.setState(RegistrationState.STARTED);
+    regStarted.setForm(objectMapper.createObjectNode().put("ssn", "010675-9981"));
+    entityManager.persist(regStarted);
+
+    // COMPLETED, swe — language mismatch with fin quarantine
+    regSweMismatch = Factory.registration(null);
+    regSweMismatch.setExamSession(sweSession);
+    regSweMismatch.setState(RegistrationState.COMPLETED);
+    regSweMismatch.setForm(objectMapper.createObjectNode().put("ssn", "010675-9981"));
+    entityManager.persist(regSweMismatch);
+
+    // COMPLETED, fin — will have a reviewed quarantine_review
+    regReviewed = Factory.registration(person3);
+    regReviewed.setExamSession(finSession);
+    regReviewed.setState(RegistrationState.COMPLETED);
+    regReviewed.setForm(objectMapper.createObjectNode().put("ssn", "100100-960R"));
+    entityManager.persist(regReviewed);
+
+    // fin, SSN=010675-9981, covers Factory.examDate() date
+    final Quarantine quarantineSsn = Factory.quarantine();
+    quarantineSsn.setSsn("010675-9981");
+    quarantineSsn.setBirthdate("1975-06-01");
+    quarantineSsn.setFirstName("Anna-Liisa");
+    quarantineSsn.setLastName("Sallinen");
+    quarantineSsn.setUpdated(Instant.parse("2020-01-01T00:00:00Z"));
+    entityManager.persist(quarantineSsn);
+
+    // fin, birthdate-only match
+    final Quarantine quarantineBirthdate = Factory.quarantine();
+    quarantineBirthdate.setSsn(null);
+    quarantineBirthdate.setBirthdate("1980-02-15");
+    entityManager.persist(quarantineBirthdate);
+
+    // fin, SSN match with regReviewed — will be reviewed
+    final Quarantine quarantineReviewed = Factory.quarantine();
+    quarantineReviewed.setSsn("100100-960R");
+    quarantineReviewed.setBirthdate("1910-01-10");
+    quarantineReviewed.setFirstName("Reviewed");
+    quarantineReviewed.setLastName("Person");
+    quarantineReviewed.setUpdated(Instant.parse("2020-01-01T00:00:00Z"));
+    entityManager.persist(quarantineReviewed);
+
+    entityManager.flush();
+
+    // quarantine_review — raw SQL: QuarantineReview has no JPA entity and we decided against
+    // adding one that would be used exclusively in tests.
     jdbcTemplate.update(
-      "INSERT INTO quarantine_review (id, quarantine_id, registration_id, quarantined, reviewer_oid, updated) VALUES (1, 102, 104, true, 'reviewer1', CURRENT_TIMESTAMP)"
+      "INSERT INTO quarantine_review (quarantine_id, registration_id, quarantined, reviewer_oid) VALUES (?, ?, true, 'reviewer1')",
+      quarantineReviewed.getId(),
+      regReviewed.getId()
     );
   }
 
@@ -109,9 +172,7 @@ public class ClerkQuarantineServiceTest {
 
     final ClerkQuarantineMatchesResponseDTO response = clerkQuarantineService.getQuarantineMatches();
 
-    // registration 102 (STARTED) must not appear
-    final boolean hasStarted = response.quarantineMatches().stream().anyMatch(m -> m.registrationId().equals(102L));
-    assertEquals(false, hasStarted);
+    assertFalse(response.quarantineMatches().stream().anyMatch(m -> m.registrationId().equals(regStarted.getId())));
   }
 
   @Test
@@ -120,9 +181,7 @@ public class ClerkQuarantineServiceTest {
 
     final ClerkQuarantineMatchesResponseDTO response = clerkQuarantineService.getQuarantineMatches();
 
-    // registration 103 is in swe session but quarantine 100 is fin — no match
-    final boolean hasSweMismatch = response.quarantineMatches().stream().anyMatch(m -> m.registrationId().equals(103L));
-    assertEquals(false, hasSweMismatch);
+    assertFalse(response.quarantineMatches().stream().anyMatch(m -> m.registrationId().equals(regSweMismatch.getId())));
   }
 
   @Test
@@ -131,8 +190,7 @@ public class ClerkQuarantineServiceTest {
 
     final ClerkQuarantineMatchesResponseDTO response = clerkQuarantineService.getQuarantineMatches();
 
-    final boolean hasSsnMatch = response.quarantineMatches().stream().anyMatch(m -> m.registrationId().equals(100L));
-    assertEquals(true, hasSsnMatch);
+    assertTrue(response.quarantineMatches().stream().anyMatch(m -> m.registrationId().equals(regSsnMatch.getId())));
   }
 
   @Test
@@ -141,11 +199,9 @@ public class ClerkQuarantineServiceTest {
 
     final ClerkQuarantineMatchesResponseDTO response = clerkQuarantineService.getQuarantineMatches();
 
-    final boolean hasBirthdateMatch = response
-      .quarantineMatches()
-      .stream()
-      .anyMatch(m -> m.registrationId().equals(101L));
-    assertEquals(true, hasBirthdateMatch);
+    assertTrue(
+      response.quarantineMatches().stream().anyMatch(m -> m.registrationId().equals(regBirthdateMatch.getId()))
+    );
   }
 
   @Test
@@ -154,27 +210,22 @@ public class ClerkQuarantineServiceTest {
 
     final ClerkQuarantineMatchesResponseDTO response = clerkQuarantineService.getQuarantineMatches();
 
-    // quarantine 102 / registration 104 has a newer review — must be excluded
-    final boolean hasReviewedPair = response
-      .quarantineMatches()
-      .stream()
-      .anyMatch(m -> m.registrationId().equals(104L));
-    assertEquals(false, hasReviewedPair);
+    assertFalse(response.quarantineMatches().stream().anyMatch(m -> m.registrationId().equals(regReviewed.getId())));
   }
 
   @Test
   public void testFormSsnIsOverwrittenWithOnrSsn() throws Exception {
-    final PersonalDataDTO person1 = new PersonalDataDTO();
-    person1.setOidHenkilo("person1");
-    person1.setIdentityNumber("NEW-SSN-FROM-ONR");
-    when(onrService.listPersonDetails(any())).thenReturn(List.of(person1));
+    final PersonalDataDTO person1Dto = new PersonalDataDTO();
+    person1Dto.setOidHenkilo("oid-person1");
+    person1Dto.setIdentityNumber("NEW-SSN-FROM-ONR");
+    when(onrService.listPersonDetails(any())).thenReturn(List.of(person1Dto));
 
     final ClerkQuarantineMatchesResponseDTO response = clerkQuarantineService.getQuarantineMatches();
 
     final ClerkQuarantineMatchDTO match = response
       .quarantineMatches()
       .stream()
-      .filter(m -> m.registrationId().equals(100L))
+      .filter(m -> m.registrationId().equals(regSsnMatch.getId()))
       .findFirst()
       .orElseThrow();
 
@@ -183,11 +234,16 @@ public class ClerkQuarantineServiceTest {
 
   @Test
   public void testFormBirthdateIsPopulatedWhenAbsentUsingOriginalFormSsn() throws Exception {
-    // registration 101 has birthdate-only match; form has no ssn → birthdate stays absent for this case
-    // Use a separate registration with ssn but no birthdate in form
-    jdbcTemplate.update(
-      "INSERT INTO registration (id, state, exam_session_id, form, person_oid) VALUES (200, 'COMPLETED', 100, '{\"ssn\":\"010675-9981\"}'::jsonb, 'person4')"
-    );
+    final Person person4 = Factory.person();
+    person4.setOid("oid-person4");
+    entityManager.persist(person4);
+
+    // Registration with SSN in form but no birthdate — birthdate should be derived from the SSN
+    final Registration regNoBirthdate = Factory.registration(person4);
+    regNoBirthdate.setExamSession(finSession);
+    regNoBirthdate.setState(RegistrationState.COMPLETED);
+    regNoBirthdate.setForm(objectMapper.createObjectNode().put("ssn", "010675-9981"));
+    entityManager.persistAndFlush(regNoBirthdate);
 
     when(onrService.listPersonDetails(any())).thenReturn(List.of());
 
@@ -196,11 +252,11 @@ public class ClerkQuarantineServiceTest {
     final ClerkQuarantineMatchDTO match = response
       .quarantineMatches()
       .stream()
-      .filter(m -> m.registrationId().equals(200L))
+      .filter(m -> m.registrationId().equals(regNoBirthdate.getId()))
       .findFirst()
       .orElseThrow();
 
-    // birthdate should be computed from original form.ssn (010675-9981 → 1975-06-01)
+    // birthdate derived from original form.ssn (010675-9981 → 1975-06-01)
     assertEquals("1975-06-01", match.form().get("birthdate").asText());
   }
 
@@ -213,11 +269,11 @@ public class ClerkQuarantineServiceTest {
     final ClerkQuarantineMatchDTO match = response
       .quarantineMatches()
       .stream()
-      .filter(m -> m.registrationId().equals(100L))
+      .filter(m -> m.registrationId().equals(regSsnMatch.getId()))
       .findFirst()
       .orElseThrow();
 
-    // person1 not in ONR response → form.ssn should be JSON null
+    // person not in ONR response → form.ssn should be JSON null
     assertTrue(match.form().get("ssn").isNull());
   }
 }


### PR DESCRIPTION
## Yhteenveto

Korjauksia pullariin #1013

* Käytetään Factory-patternia raw-sql - sijaan
* Käytetään Builder -patternia new SomeClass - sijaan
* Lisätty claudelle sääntöjä, että käyttää noita jatkossa

## Testausohjeet

* avaa selaimessa:
```
http://localhost:4004/yki/v2/virkailija/osallistumiskiellot
```

* oon lisännyt lokaaliin kantaan testidataksi tällaista
```sql
-- Prerequisites (use high IDs to avoid collisions)
INSERT INTO organizer (id, oid, agreement_start_date, agreement_end_date)
VALUES (9000, '1.2.246.562.10.99999999999', '2020-01-01', '2030-12-31')
ON CONFLICT DO NOTHING;

INSERT INTO exam_date (id, exam_date, registration_start_date, registration_end_date)
VALUES (9000, '2026-09-15', '2026-01-01', '2026-09-14')
ON CONFLICT DO NOTHING;

INSERT INTO exam_session (id, organizer_id, language_code, level_code, exam_date_id, max_participants)
VALUES (9000, 9000, 'fin', 'KESKI', 9000, 30)
ON CONFLICT DO NOTHING;

INSERT INTO participant (id, external_user_id)
VALUES (9000, 'test-quarantine-participant')
ON CONFLICT DO NOTHING;

-- Case 1: SSN-based match
INSERT INTO registration (id, state, exam_session_id, participant_id, form, kind)
VALUES (
  300,
  'SUBMITTED',
  9000,
  9000,
  '{"ssn":"010675-9981","birthdate":"1975-06-01","first_name":"Anna-Liisa","last_name":"Testinen","email":"anna.testinen@testi.fi","phone_number":"+35840111222","zip":"00100","post_office":"Helsinki","street_address":"Testikatu 1","nationalities":["246"],"nationality_desc":"Suomi","gender":"2","exam_lang":"fi","certificate_lang":"fi"}'::jsonb,
  'ADMISSION'
);

INSERT INTO quarantine (id, language_code, ssn, birthdate, first_name, last_name, email, phone_number, diary_number, start_date, end_date)
VALUES (300, 'fin', '010675-9981', '1975-06-01', 'Anna-Liisa', 'Sallinen', 'anna@kvt.fi', '0401234567', 'DIARY-300', '2026-01-01', '2026-12-31');

-- Case 2: Birthdate-only match (no SSN in quarantine)
INSERT INTO registration (id, state, exam_session_id, participant_id, form, kind)
VALUES (
  301,
  'COMPLETED',
  9000,
  9000,
  '{"birthdate":"1980-02-15","first_name":"Mikko","last_name":"Korhonen","email":"mikko.korhonen@testi.fi","phone_number":"+35840222333","zip":"00200","post_office":"Helsinki","street_address":"Koivukuja 5","nationalities":["246"],"nationality_desc":"Suomi","gender":"1","exam_lang":"fi","certificate_lang":"fi"}'::jsonb,
  'ADMISSION'
);

INSERT INTO quarantine (id, language_code, ssn, birthdate, first_name, last_name, email, phone_number, diary_number, start_date, end_date)
VALUES (301, 'fin', NULL, '1980-02-15', 'Mikko', 'Testinen', 'mikko@kvt.fi', '0401234568', 'DIARY-301', '2026-01-01', '2026-12-31');
```  


## Huomautukset

Tuosta claude-konffien commitista: Mä oon huomannut mun claude käytössä, että koodaamisessa on 2 vaihetta:
1): Yritän ymmärtää jotain asiaa
2): Toteutan jotain asiaa

Noi vaatii claudelta hieman erilaisia asioita. Nyt vielä nykyiset muutokset on kohtuullisia, mutta jos meidän säännöt kasvaa isoiksi, niin pitäisi enemmän käyttää muita clauden ominaisuuuksia, jotta ei tuu contextin saastumista. 

Veikkaan, että meillä olis ideaalisti rekursiivinen-flow jossa:
* Pitääkö ymmärtää jotain -> triggeröi system analysis - säännöt
* Pitääkä toteuttaa jotain -> triggeröi code implemention - säännöt

Ja toi flow olis herkkä keskeytymään, jotta sais käyttäjältä palautetta, eikä tekisi oletuksia ja jatka nykyistä flow:ta
