### PR TITLE
OPHKIOS-350: ajastettujen taskien monitorointi

### DIFF
--- a/backend/yki/src/main/java/fi/oph/yki/config/Constants.java
+++ b/backend/yki/src/main/java/fi/oph/yki/config/Constants.java
@@ -7,4 +7,6 @@ public class Constants {
   public static final String APP_ADMIN_ROLE = "APP_YKI_YLLAPITAJA";
   public static final String APP_EVALUATION_UPDATER_ROLE = "APP_YKI_SUORITUKSEN_TILAN_KIRJOITUS";
   public static final String EMAIL_SENDER_NAME = "Yleiset kielitutkinnot | Opetushallitus";
+
+  public static final String SCHEDULED_TASK_MONITOR_CRON = "0 */5 * * * *";
 }

--- a/backend/yki/src/main/java/fi/oph/yki/config/SchedulingConfig.java
+++ b/backend/yki/src/main/java/fi/oph/yki/config/SchedulingConfig.java
@@ -2,12 +2,12 @@ package fi.oph.yki.config;
 
 import javax.sql.DataSource;
 import net.javacrumbs.shedlock.core.LockProvider;
-import org.springframework.lang.NonNull;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.lang.NonNull;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration

--- a/backend/yki/src/main/java/fi/oph/yki/config/SchedulingConfig.java
+++ b/backend/yki/src/main/java/fi/oph/yki/config/SchedulingConfig.java
@@ -1,0 +1,28 @@
+package fi.oph.yki.config;
+
+import javax.sql.DataSource;
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.springframework.lang.NonNull;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
+public class SchedulingConfig {
+
+  @Bean
+  public LockProvider lockProvider(@NonNull final DataSource dataSource) {
+    return new JdbcTemplateLockProvider(
+      JdbcTemplateLockProvider.Configuration
+        .builder()
+        .withJdbcTemplate(new JdbcTemplate(dataSource))
+        .usingDbTime()
+        .build()
+    );
+  }
+}

--- a/backend/yki/src/main/java/fi/oph/yki/model/TaskLock.java
+++ b/backend/yki/src/main/java/fi/oph/yki/model/TaskLock.java
@@ -1,0 +1,26 @@
+package fi.oph.yki.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "task_lock")
+public class TaskLock {
+
+  @Id
+  @Column(name = "task")
+  private String task;
+
+  @Column(name = "last_executed")
+  private LocalDateTime lastExecuted;
+
+  @Column(name = "worker_id")
+  private String workerId;
+}

--- a/backend/yki/src/main/java/fi/oph/yki/repository/TaskLockRepository.java
+++ b/backend/yki/src/main/java/fi/oph/yki/repository/TaskLockRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TaskLockRepository extends JpaRepository<TaskLock, String> {
-}
+public interface TaskLockRepository extends JpaRepository<TaskLock, String> {}

--- a/backend/yki/src/main/java/fi/oph/yki/repository/TaskLockRepository.java
+++ b/backend/yki/src/main/java/fi/oph/yki/repository/TaskLockRepository.java
@@ -1,0 +1,9 @@
+package fi.oph.yki.repository;
+
+import fi.oph.yki.model.TaskLock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TaskLockRepository extends JpaRepository<TaskLock, String> {
+}

--- a/backend/yki/src/main/java/fi/oph/yki/scheduled/ScheduledTaskMonitor.java
+++ b/backend/yki/src/main/java/fi/oph/yki/scheduled/ScheduledTaskMonitor.java
@@ -1,0 +1,51 @@
+package fi.oph.yki.scheduled;
+
+import fi.oph.yki.config.Constants;
+import fi.oph.yki.repository.TaskLockRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.springframework.lang.NonNull;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduledTaskMonitor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ScheduledTaskMonitor.class);
+
+  private static final String LOCK_AT_LEAST = "PT1S";
+  private static final String LOCK_AT_MOST = "PT4M";
+
+  private static final Map<String, Duration> MONITORED_TASKS = Map.of(
+    "REGISTRATION_QUEUE_HANDLER", Duration.ofMinutes(10), // interval: 29s
+    "REGISTRATION_STATE_HANDLER", Duration.ofMinutes(10), // interval: 59s
+    "PERSONS_SYNC_HANDLER", Duration.ofMinutes(20), // interval: 179s
+    "PARTICIPANTS_SYNC_HANDLER", Duration.ofHours(3), // interval: 59min
+    "SYNC_ONR_PARTICIPANT_DATA_HANDLER", Duration.ofHours(3), // interval: 59min
+    "EXAM_SESSION_STATISTICS_HANDLER", Duration.ofHours(3) // interval: 57min
+  );
+
+  private final TaskLockRepository taskLockRepository;
+
+  @Scheduled(cron = Constants.SCHEDULED_TASK_MONITOR_CRON)
+  @SchedulerLock(name = "scheduledTaskMonitor", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
+  public void monitorScheduledTasks() {
+    MONITORED_TASKS.forEach((@NonNull final String task, final Duration maxAge) -> {
+      taskLockRepository.findById(task).ifPresentOrElse(
+        taskLock -> {
+          final LocalDateTime threshold = LocalDateTime.now().minus(maxAge);
+          if (taskLock.getLastExecuted().isBefore(threshold)) {
+            LOG.error("Scheduled task {} has not run since {} [ERROR_SCHEDULED_TASK]", task, taskLock.getLastExecuted());
+          }
+        },
+        () -> LOG.error("Scheduled task {} not found in task_lock [ERROR_SCHEDULED_TASK]", task)
+      );
+    });
+  }
+}

--- a/backend/yki/src/main/java/fi/oph/yki/scheduled/ScheduledTaskMonitor.java
+++ b/backend/yki/src/main/java/fi/oph/yki/scheduled/ScheduledTaskMonitor.java
@@ -43,6 +43,7 @@ public class ScheduledTaskMonitor {
   @Scheduled(cron = Constants.SCHEDULED_TASK_MONITOR_CRON)
   @SchedulerLock(name = "scheduledTaskMonitor", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
   public void monitorScheduledTasks() {
+    LOG.info("Monitoring scheduled tasks");
     MONITORED_TASKS.forEach((@NonNull final String task, final Duration maxAge) -> {
       taskLockRepository
         .findById(task)

--- a/backend/yki/src/main/java/fi/oph/yki/scheduled/ScheduledTaskMonitor.java
+++ b/backend/yki/src/main/java/fi/oph/yki/scheduled/ScheduledTaskMonitor.java
@@ -5,11 +5,11 @@ import fi.oph.yki.repository.TaskLockRepository;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
-import org.springframework.lang.NonNull;
 import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -23,12 +23,18 @@ public class ScheduledTaskMonitor {
   private static final String LOCK_AT_MOST = "PT4M";
 
   private static final Map<String, Duration> MONITORED_TASKS = Map.of(
-    "REGISTRATION_QUEUE_HANDLER", Duration.ofMinutes(10), // interval: 29s
-    "REGISTRATION_STATE_HANDLER", Duration.ofMinutes(10), // interval: 59s
-    "PERSONS_SYNC_HANDLER", Duration.ofMinutes(20), // interval: 179s
-    "PARTICIPANTS_SYNC_HANDLER", Duration.ofHours(3), // interval: 59min
-    "SYNC_ONR_PARTICIPANT_DATA_HANDLER", Duration.ofHours(3), // interval: 59min
-    "EXAM_SESSION_STATISTICS_HANDLER", Duration.ofHours(3) // interval: 57min
+    "REGISTRATION_QUEUE_HANDLER",
+    Duration.ofMinutes(10), // interval: 29s
+    "REGISTRATION_STATE_HANDLER",
+    Duration.ofMinutes(10), // interval: 59s
+    "PERSONS_SYNC_HANDLER",
+    Duration.ofMinutes(20), // interval: 179s
+    "PARTICIPANTS_SYNC_HANDLER",
+    Duration.ofHours(3), // interval: 59min
+    "SYNC_ONR_PARTICIPANT_DATA_HANDLER",
+    Duration.ofHours(3), // interval: 59min
+    "EXAM_SESSION_STATISTICS_HANDLER",
+    Duration.ofHours(3) // interval: 57min
   );
 
   private final TaskLockRepository taskLockRepository;
@@ -37,15 +43,21 @@ public class ScheduledTaskMonitor {
   @SchedulerLock(name = "scheduledTaskMonitor", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
   public void monitorScheduledTasks() {
     MONITORED_TASKS.forEach((@NonNull final String task, final Duration maxAge) -> {
-      taskLockRepository.findById(task).ifPresentOrElse(
-        taskLock -> {
-          final LocalDateTime threshold = LocalDateTime.now().minus(maxAge);
-          if (taskLock.getLastExecuted().isBefore(threshold)) {
-            LOG.error("Scheduled task {} has not run since {} [ERROR_SCHEDULED_TASK]", task, taskLock.getLastExecuted());
-          }
-        },
-        () -> LOG.error("Scheduled task {} not found in task_lock [ERROR_SCHEDULED_TASK]", task)
-      );
+      taskLockRepository
+        .findById(task)
+        .ifPresentOrElse(
+          taskLock -> {
+            final LocalDateTime threshold = LocalDateTime.now().minus(maxAge);
+            if (taskLock.getLastExecuted().isBefore(threshold)) {
+              LOG.error(
+                "Scheduled task {} has not run since {} [ERROR_SCHEDULED_TASK]",
+                task,
+                taskLock.getLastExecuted()
+              );
+            }
+          },
+          () -> LOG.error("Scheduled task {} not found in task_lock [ERROR_SCHEDULED_TASK]", task)
+        );
     });
   }
 }

--- a/backend/yki/src/main/java/fi/oph/yki/scheduled/ScheduledTaskMonitor.java
+++ b/backend/yki/src/main/java/fi/oph/yki/scheduled/ScheduledTaskMonitor.java
@@ -22,6 +22,7 @@ public class ScheduledTaskMonitor {
   private static final String LOCK_AT_LEAST = "PT1S";
   private static final String LOCK_AT_MOST = "PT4M";
 
+  // task interval values from yki-repo
   private static final Map<String, Duration> MONITORED_TASKS = Map.of(
     "REGISTRATION_QUEUE_HANDLER",
     Duration.ofMinutes(10), // interval: 29s

--- a/backend/yki/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/backend/yki/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -225,4 +225,21 @@
         <renameColumn tableName="exam_date" oldColumnName="type" newColumnName="exam_type" />
         <sql>ALTER TABLE exam_date ALTER COLUMN exam_type TYPE VARCHAR(50) USING exam_type::text</sql>
     </changeSet>
+
+    <changeSet id="2026-04-10-create-shedlock-table" author="miikavonbell">
+        <createTable tableName="shedlock">
+            <column name="name" type="VARCHAR(64)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="lock_until" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="locked_at" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="locked_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Yhteenveto

Lisätään ajastettu taski Java puolelle, joka valvoo Clojure puolen ajastettuja taskeja, sekä mahdollisia jumeja niissä.

## Lisätiedot

Tällä varmistetaan, että saadaan lokeillta tieto, jos joku taski on jumittunut.

## Huomautukset

Ensimmäinen ajastettu taski uudella Java puolella.

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
