### PR TITLE
YKI(Frontend): OPHKIOS-180 fixes to odottavat - table and exam-session tab highlight

### DIFF
--- a/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
@@ -387,6 +387,10 @@
             "ssn": "Hetu"
           },
           "description": "Järjestelmän tunnistamat ilmoittautujat, joiden tiedot vastaavat voimassa olevan osallistumiskiellon tietoja. Tarkista, onko ilmoittautuja osallistumiskellossa ja <bold>peru tai hyväksy ilmoittautuminen</bold>",
+          "personType": {
+            "quarantinedPerson": "Osallistumiskielto",
+            "registrant": "Ilmoittautuja"
+          },
           "resultCount": "{{count}} ilmoittautujaa"
         },
         "tabs": {

--- a/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
@@ -395,7 +395,7 @@
         },
         "tabs": {
           "active": "Voimassa olevat osallistumiskiellot",
-          "pending": "Odottavat tarkistukset",
+          "pending": "Odottavat tarkistukset ({{count}})",
           "previous": "Aiemmat tarkistukset"
         }
       },

--- a/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
@@ -387,6 +387,10 @@
             "ssn": "Hetu"
           },
           "description": "Järjestelmän tunnistamat ilmoittautujat, joiden tiedot vastaavat voimassa olevan osallistumiskiellon tietoja. Tarkista, onko ilmoittautuja osallistumiskellossa ja <bold>peru tai hyväksy ilmoittautuminen</bold>",
+          "personType": {
+            "quarantinedPerson": "Osallistumiskielto",
+            "registrant": "Ilmoittautuja"
+          },
           "resultCount": "{{count}} ilmoittautujaa"
         },
         "tabs": {

--- a/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
@@ -395,7 +395,7 @@
         },
         "tabs": {
           "active": "Voimassa olevat osallistumiskiellot",
-          "pending": "Odottavat tarkistukset",
+          "pending": "Odottavat tarkistukset ({{count}})",
           "previous": "Aiemmat tarkistukset"
         }
       },

--- a/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
@@ -387,6 +387,10 @@
             "ssn": "Hetu"
           },
           "description": "Järjestelmän tunnistamat ilmoittautujat, joiden tiedot vastaavat voimassa olevan osallistumiskiellon tietoja. Tarkista, onko ilmoittautuja osallistumiskellossa ja <bold>peru tai hyväksy ilmoittautuminen</bold>",
+          "personType": {
+            "quarantinedPerson": "Osallistumiskielto",
+            "registrant": "Ilmoittautuja"
+          },
           "resultCount": "{{count}} ilmoittautujaa"
         },
         "tabs": {

--- a/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
@@ -395,7 +395,7 @@
         },
         "tabs": {
           "active": "Voimassa olevat osallistumiskiellot",
-          "pending": "Odottavat tarkistukset",
+          "pending": "Odottavat tarkistukset ({{count}})",
           "previous": "Aiemmat tarkistukset"
         }
       },

--- a/frontend/packages/yki/clerk/src/components/clerkExamSession/ClerkExamSessionRegistrations.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkExamSession/ClerkExamSessionRegistrations.tsx
@@ -49,12 +49,12 @@ const ExamsListingTabs = ({
   };
 
   return (
-    <div className="clerk-exam-session-page__filter-tabs">
+    <div className="clerk-exam-session-registrations__filter-tabs">
       <div className="columns gapped">
         {TABS.map((tab) => (
           <div
             key={tab}
-            className={`clerk-exam-session-page__filter-tabs__tab ${
+            className={`clerk-exam-session-registrations__filter-tabs__tab ${
               activeTab === tab ? 'active' : ''
             }`}
             onClick={() => handleTabChange(tab)}
@@ -241,14 +241,14 @@ export const ClerkExamSessionRegistrations = ({
 
   return (
     <Stack spacing={4}>
-      <div className="clerk-exam-session-page__tabs grid-2-columns">
+      <div className="clerk-exam-session-registrations__tabs grid-2-columns">
         <ExamsListingTabs
           admissionCount={admissions.length ?? 0}
           queuedCount={queued.length ?? 0}
           activeTab={activeTab}
           setActiveTab={setActiveTab}
         />
-        <div className="clerk-exam-session-page__filter-buttons">
+        <div className="clerk-exam-session-registrations__filter-buttons">
           <OphButton
             color="primary"
             variant={Variant.Contained}

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantine.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantine.tsx
@@ -6,7 +6,10 @@ import { APIResponseStatus } from 'shared/enums';
 import { ClerkQuarantineListing } from 'components/clerkQuarantine/ClerkQuarantineListing';
 import { usePublicTranslation } from 'configs/i18n';
 import { H2 } from 'ophTheme/Text';
-import { loadClerkQuarantineMatches } from 'redux/reducers/clerkQuarantine';
+import {
+  loadClerkQuarantineMatches,
+  setQuarantineSort,
+} from 'redux/reducers/clerkQuarantine';
 import {
   clerkQuarantineSelector,
   selectSortedQuarantineMatches,
@@ -77,7 +80,7 @@ const QuarantineTabs = ({
 
 export const ClerkQuarantine = () => {
   const dispatch = useDispatch();
-  const { status } = useSelector(clerkQuarantineSelector);
+  const { status, sort } = useSelector(clerkQuarantineSelector);
   const rows = useSelector(selectSortedQuarantineMatches);
   const [activeTab, setActiveTab] = useState<Tab>('pending');
   const [page, setPage] = useState(1);
@@ -98,6 +101,8 @@ export const ClerkQuarantine = () => {
             pageSize={pageSize}
             setPageSize={setPageSize}
             activeTab={activeTab}
+            sort={sort}
+            setSort={(s) => dispatch(setQuarantineSort(s))}
           />
         );
       default:

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantine.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantine.tsx
@@ -39,12 +39,14 @@ type QuarantineTabsProps = {
   activeTab: Tab;
   setActiveTab: Dispatch<SetStateAction<Tab>>;
   setPage: Dispatch<SetStateAction<number>>;
+  tableRowsCount?: number;
 };
 
 const QuarantineTabs = ({
   activeTab,
   setActiveTab,
   setPage,
+  tableRowsCount,
 }: QuarantineTabsProps) => {
   const { t } = usePublicTranslation({
     keyPrefix: 'yki.component.clerkQuarantine.tabs',
@@ -69,7 +71,9 @@ const QuarantineTabs = ({
             tabIndex={0}
             onKeyDown={() => handleTabChange(tab)}
           >
-            {t(tab)}
+            {tab === 'pending'
+              ? t('pending', { count: tableRowsCount ?? 0 })
+              : t(tab)}
           </div>
         ))}
       </div>
@@ -116,6 +120,7 @@ export const ClerkQuarantine = () => {
         activeTab={activeTab}
         setActiveTab={setActiveTab}
         setPage={setPage}
+        tableRowsCount={rows?.length}
       />
       {renderListing()}
     </div>

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantine.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantine.tsx
@@ -78,7 +78,7 @@ const QuarantineTabs = ({
 export const ClerkQuarantine = () => {
   const dispatch = useDispatch();
   const { status } = useSelector(clerkQuarantineSelector);
-  const matches = useSelector(selectSortedQuarantineMatches);
+  const rows = useSelector(selectSortedQuarantineMatches);
   const [activeTab, setActiveTab] = useState<Tab>('pending');
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
@@ -92,7 +92,7 @@ export const ClerkQuarantine = () => {
       case APIResponseStatus.Success:
         return (
           <ClerkQuarantineListing
-            matches={matches}
+            rows={rows}
             page={page}
             setPage={setPage}
             pageSize={pageSize}

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantine.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantine.tsx
@@ -120,7 +120,7 @@ export const ClerkQuarantine = () => {
         activeTab={activeTab}
         setActiveTab={setActiveTab}
         setPage={setPage}
-        tableRowsCount={rows?.length}
+        tableRowsCount={rows.length}
       />
       {renderListing()}
     </div>

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
@@ -102,7 +102,7 @@ export const ClerkQuarantineListing = ({
     },
     {
       key: 'email',
-      style,
+      style: { ...style, width: '20%' }, // Note: the default is ~12.5% with 8 equal columns
       title: t('listing.columns.email'),
       render: (match) => (
         <div>

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
@@ -3,7 +3,10 @@ import { Trans } from 'react-i18next';
 import { ListTable } from 'components/oph-design/table/list-table';
 import { ListTableColumn, Row } from 'components/oph-design/table/table-types';
 import { usePublicTranslation } from 'configs/i18n';
-import { ClerkQuarantineMatch } from 'interfaces/clerkQuarantine';
+import {
+  ClerkQuarantineMatch,
+  ClerkQuarantineSort,
+} from 'interfaces/clerkQuarantine';
 import { Text } from 'ophTheme/Text';
 import { languageToString } from 'utils/clerk';
 
@@ -16,6 +19,8 @@ type ClerkQuarantineListingProps = {
   pageSize: number;
   setPageSize: (pageSize: number) => void;
   activeTab: 'pending' | 'previous' | 'active';
+  sort: ClerkQuarantineSort;
+  setSort: (sort: ClerkQuarantineSort) => void;
 };
 
 export const ClerkQuarantineListing = ({
@@ -23,10 +28,13 @@ export const ClerkQuarantineListing = ({
   page,
   setPage,
   pageSize,
+  sort,
+  setSort,
 }: ClerkQuarantineListingProps) => {
   const { t } = usePublicTranslation({
     keyPrefix: 'yki.component.clerkQuarantine',
   });
+
   // Cells stack two values (registrant + quarantined person). Some values such
   // as email are long tokens with no spaces, so the browser cannot wrap them
   // naturally and they overflow into adjacent cells without this.
@@ -50,6 +58,7 @@ export const ClerkQuarantineListing = ({
     },
     {
       key: 'examDate',
+      sortable: true,
       title: t('listing.columns.examDate'),
       render: ({ examDate }) => examDate.format('D.M.YYYY'),
     },
@@ -130,6 +139,8 @@ export const ClerkQuarantineListing = ({
         rowKeyProp="quarantineId"
         columns={columns}
         translateHeader={false}
+        sort={sort}
+        setSort={(s) => setSort(s as ClerkQuarantineSort)}
         pagination={{
           page,
           setPage,

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
@@ -102,7 +102,7 @@ export const ClerkQuarantineListing = ({
     },
     {
       key: 'email',
-      style: { ...style, width: '20%' }, // Note: the default is ~12.5% with 8 equal columns
+      style: { ...style, width: '20%' }, // Note: the default is, ~12.5% with 8 equal columns
       title: t('listing.columns.email'),
       render: (match) => (
         <div>

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
@@ -1,6 +1,7 @@
 import { Trans } from 'react-i18next';
 
 import { ListTable } from 'components/oph-design/table/list-table';
+import { PageSizeSelector } from 'components/oph-design/table/page-size-selector';
 import { ListTableColumn, Row } from 'components/oph-design/table/table-types';
 import { usePublicTranslation } from 'configs/i18n';
 import {
@@ -28,6 +29,7 @@ export const ClerkQuarantineListing = ({
   page,
   setPage,
   pageSize,
+  setPageSize,
   sort,
   setSort,
 }: ClerkQuarantineListingProps) => {
@@ -133,7 +135,10 @@ export const ClerkQuarantineListing = ({
           components={{ bold: <strong /> }}
         />
       </Text>
-      <Text>{t('listing.resultCount', { count: rows.length })}</Text>
+      <div className="columns space-between">
+        <Text>{t('listing.resultCount', { count: rows.length })}</Text>
+        <PageSizeSelector pageSize={pageSize} setPageSize={setPageSize} />
+      </div>
       <ListTable
         rows={rows}
         rowKeyProp="quarantineId"

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
@@ -34,6 +34,16 @@ export const ClerkQuarantineListing = ({
 
   const columns: ListTableColumn<ClerkQuarantineMatchRow>[] = [
     {
+      key: 'personType',
+      title: '',
+      render: () => (
+        <div>
+          <div>{t('listing.personType.registrant')}</div>
+          <div>{t('listing.personType.quarantinedPerson')}</div>
+        </div>
+      ),
+    },
+    {
       key: 'examLanguageCode',
       title: t('listing.columns.examLanguage'),
       render: ({ examLanguageCode }) => languageToString(examLanguageCode),

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
@@ -10,7 +10,7 @@ import { languageToString } from 'utils/clerk';
 type ClerkQuarantineMatchRow = ClerkQuarantineMatch & Row;
 
 type ClerkQuarantineListingProps = {
-  matches: ClerkQuarantineMatch[];
+  rows: ClerkQuarantineMatchRow[];
   page: number;
   setPage: (page: number) => void;
   pageSize: number;
@@ -19,7 +19,7 @@ type ClerkQuarantineListingProps = {
 };
 
 export const ClerkQuarantineListing = ({
-  matches,
+  rows,
   page,
   setPage,
   pageSize,
@@ -27,10 +27,10 @@ export const ClerkQuarantineListing = ({
   const { t } = usePublicTranslation({
     keyPrefix: 'yki.component.clerkQuarantine',
   });
-
-  const rows: ClerkQuarantineMatchRow[] = matches.map((match) => ({
-    ...match,
-  }));
+  // Cells stack two values (registrant + quarantined person). Some values such
+  // as email are long tokens with no spaces, so the browser cannot wrap them
+  // naturally and they overflow into adjacent cells without this.
+  const style = { wordBreak: 'break-word' as const };
 
   const columns: ListTableColumn<ClerkQuarantineMatchRow>[] = [
     {
@@ -45,29 +45,63 @@ export const ClerkQuarantineListing = ({
     },
     {
       key: 'name',
+      style,
       title: t('listing.columns.name'),
-      render: ({ quarantinedPerson }) =>
-        `${quarantinedPerson.firstName} ${quarantinedPerson.lastName}`,
+      render: (match) => (
+        <div>
+          <div>
+            {match.registrantForm.firstName} {match.registrantForm.lastName}
+          </div>
+          <div>
+            {match.quarantinedPerson.firstName}{' '}
+            {match.quarantinedPerson.lastName}
+          </div>
+        </div>
+      ),
     },
     {
       key: 'birthdate',
+      style,
       title: t('listing.columns.birthdate'),
-      render: ({ quarantinedPerson }) => quarantinedPerson.birthdate,
+      render: (match) => (
+        <div>
+          <div>{match.registrantForm.birthdate}</div>
+          <div>{match.quarantinedPerson.birthdate}</div>
+        </div>
+      ),
     },
     {
       key: 'ssn',
+      style,
       title: t('listing.columns.ssn'),
-      render: ({ quarantinedPerson }) => quarantinedPerson.ssn,
+      render: (match) => (
+        <div>
+          <div>{match.registrantForm.ssn}</div>
+          <div>{match.quarantinedPerson.ssn}</div>
+        </div>
+      ),
     },
     {
       key: 'email',
+      style,
       title: t('listing.columns.email'),
-      render: ({ quarantinedPerson }) => quarantinedPerson.email,
+      render: (match) => (
+        <div>
+          <div>{match.registrantForm.email}</div>
+          <div>{match.quarantinedPerson.email}</div>
+        </div>
+      ),
     },
     {
       key: 'phoneNumber',
+      style,
       title: t('listing.columns.phoneNumber'),
-      render: ({ quarantinedPerson }) => quarantinedPerson.phoneNumber,
+      render: (match) => (
+        <div>
+          <div>{match.registrantForm.phoneNumber}</div>
+          <div>{match.quarantinedPerson.phoneNumber}</div>
+        </div>
+      ),
     },
   ];
 
@@ -80,7 +114,7 @@ export const ClerkQuarantineListing = ({
           components={{ bold: <strong /> }}
         />
       </Text>
-      <Text>{t('listing.resultCount', { count: matches.length })}</Text>
+      <Text>{t('listing.resultCount', { count: rows.length })}</Text>
       <ListTable
         rows={rows}
         rowKeyProp="quarantineId"
@@ -90,7 +124,7 @@ export const ClerkQuarantineListing = ({
           page,
           setPage,
           pageSize,
-          totalCount: matches.length,
+          totalCount: rows.length,
         }}
       />
     </>

--- a/frontend/packages/yki/clerk/src/redux/reducers/clerkQuarantine.ts
+++ b/frontend/packages/yki/clerk/src/redux/reducers/clerkQuarantine.ts
@@ -45,5 +45,6 @@ export const clerkQuarantineReducer = clerkQuarantineSlice.reducer;
 export const {
   loadClerkQuarantineMatches,
   rejectClerkQuarantineMatches,
+  setQuarantineSort,
   storeClerkQuarantineMatches,
 } = clerkQuarantineSlice.actions;

--- a/frontend/packages/yki/clerk/src/styles/pages/_clerk-exam-session-page.scss
+++ b/frontend/packages/yki/clerk/src/styles/pages/_clerk-exam-session-page.scss
@@ -17,7 +17,9 @@
       padding: 2rem;
     }
   }
+}
 
+.clerk-exam-session-registrations {
   &__filter-tabs {
     justify-self: left;
 

--- a/frontend/packages/yki/clerk/src/styles/pages/_clerk-free-registration-page.scss
+++ b/frontend/packages/yki/clerk/src/styles/pages/_clerk-free-registration-page.scss
@@ -1,3 +1,20 @@
+.clerk-free-registration {
+  &__filter-tabs {
+    &__tab {
+      padding: 0.5rem 1rem;
+
+      &.active {
+        color: #0033cc;
+        border-bottom: 2px solid #0033cc;
+      }
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+}
+
 .clerk-free-registration-page {
   flex: 1;
   background-color: $page-background-color;

--- a/frontend/packages/yki/clerk/src/styles/pages/_clerk-quarantine-page.scss
+++ b/frontend/packages/yki/clerk/src/styles/pages/_clerk-quarantine-page.scss
@@ -1,3 +1,20 @@
+.clerk-quarantine {
+  &__filter-tabs {
+    &__tab {
+      padding: 0.5rem 1rem;
+
+      &.active {
+        color: #0033cc;
+        border-bottom: 2px solid #0033cc;
+      }
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+}
+
 .clerk-quarantine-page {
   flex: 1;
   background-color: $page-background-color;

--- a/frontend/packages/yki/clerk/src/tests/cypress/integration/clerk/clerk_quarantine_page.spec.ts
+++ b/frontend/packages/yki/clerk/src/tests/cypress/integration/clerk/clerk_quarantine_page.spec.ts
@@ -46,13 +46,14 @@ describe('ClerkQuarantinePage', () => {
 
   it('should display correct data in first row', () => {
     onClerkQuarantinePage.expectCorrectRowData(0, [
+      'IlmoittautujaOsallistumiskielto',
       'suomi',
       '20.9.2025',
-      'Markku Virtanen',
-      '1980-05-15',
-      '150580-900T',
-      'markku.virtanen@ban.fi',
-      '+358401234567',
+      'Marko VirtanenMarkku Virtanen',
+      '1980-05-151980-05-15',
+      '150580-900T150580-900T',
+      'marko.virtanen@gmail.commarkku.virtanen@ban.fi',
+      '+358401234567+358401234567',
     ]);
   });
 });

--- a/frontend/packages/yki/clerk/src/tests/cypress/integration/clerk/clerk_quarantine_page.spec.ts
+++ b/frontend/packages/yki/clerk/src/tests/cypress/integration/clerk/clerk_quarantine_page.spec.ts
@@ -14,7 +14,7 @@ describe('ClerkQuarantinePage', () => {
     onClerkQuarantinePage.elements
       .tabs()
       .eq(0)
-      .should('have.text', 'Odottavat tarkistukset');
+      .should('have.text', 'Odottavat tarkistukset (4)');
     onClerkQuarantinePage.elements
       .tabs()
       .eq(1)
@@ -26,7 +26,7 @@ describe('ClerkQuarantinePage', () => {
   });
 
   it('should have pending tab active by default', () => {
-    onClerkQuarantinePage.expectActiveTab('Odottavat tarkistukset');
+    onClerkQuarantinePage.expectActiveTab('Odottavat tarkistukset (4)');
   });
 
   it('should switch active tab on click', () => {

--- a/frontend/packages/yki/clerk/src/tests/cypress/support/page-objects/clerkQuarantinePage.ts
+++ b/frontend/packages/yki/clerk/src/tests/cypress/support/page-objects/clerkQuarantinePage.ts
@@ -27,13 +27,9 @@ class ClerkQuarantinePage {
       .tableRows()
       .eq(index)
       .within(() => {
-        cy.get('td').eq(0).should('have.text', data[0]);
-        cy.get('td').eq(1).should('have.text', data[1]);
-        cy.get('td').eq(2).should('have.text', data[2]);
-        cy.get('td').eq(3).should('have.text', data[3]);
-        cy.get('td').eq(4).should('have.text', data[4]);
-        cy.get('td').eq(5).should('have.text', data[5]);
-        cy.get('td').eq(6).should('have.text', data[6]);
+        data.forEach((value, i) => {
+          cy.get('td').eq(i).should('have.text', value);
+        });
       });
   }
 }


### PR DESCRIPTION
## Yhteenveto

<img width="1784" height="619" alt="image" src="https://github.com/user-attachments/assets/1b91d03a-9d41-4678-baa0-814039f60de0" />

## Lisätiedot

* Lisätty exam-sesion ja clerkQuarantine sivulle tab highlight (se oli osallistumiskieltojen lisäksi ainoa, josta toi puuttui)
* Lisätty ilmoittautuja / osallistumiskielto - kolumni
* näytetään ilmoittautujan tiedot
* Sorttaus tutkintopäivän mukaan
* Levennetty email-kentän tilaa. Tästä ei tullut kommentteja, mutta sen tila oli ahdas mun testailuissa
* Lisätty pending - tabiin myös se taulukon koko-count.
* Käyttäjä voi vaihtaa sivutuksen kokoa. Oletus näyttäis olevan tässä 10.

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
