### PR TITLE
YKI(Frontend/Backend): OPHKIOS-180 osallistumiskiellot hyväksy/peruuta - toiminnot

### DIFF
--- a/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkQuarantineController.java
+++ b/backend/yki/src/main/java/fi/oph/yki/api/clerk/ClerkQuarantineController.java
@@ -10,6 +10,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.annotation.Resource;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,5 +30,15 @@ public class ClerkQuarantineController {
   @Operation(tags = TAG_QUARANTINE, summary = "Get unreviewed quarantine matches")
   public ClerkQuarantineMatchesResponseDTO getQuarantineMatches() throws JsonProcessingException {
     return clerkQuarantineService.getQuarantineMatches();
+  }
+
+  @PutMapping(path = "/{id:\\d+}/registration/{regId:\\d+}/set", consumes = APPLICATION_JSON_VALUE)
+  @Operation(tags = TAG_QUARANTINE, summary = "Set quarantine review decision for a registration")
+  public void setQuarantineReview(
+    @PathVariable final long id,
+    @PathVariable final long regId,
+    @RequestBody final boolean isQuarantined
+  ) {
+    clerkQuarantineService.setQuarantineReview(id, regId, isQuarantined);
   }
 }

--- a/backend/yki/src/main/java/fi/oph/yki/audit/YkiOperation.java
+++ b/backend/yki/src/main/java/fi/oph/yki/audit/YkiOperation.java
@@ -20,4 +20,5 @@ public enum YkiOperation implements Operation {
   CREATE_EVALUATION,
   DELETE_EXAM_DATE,
   GET_QUARANTINE_MATCHES,
+  SET_QUARANTINE_REVIEW,
 }

--- a/backend/yki/src/main/java/fi/oph/yki/repository/QuarantineRepository.java
+++ b/backend/yki/src/main/java/fi/oph/yki/repository/QuarantineRepository.java
@@ -3,8 +3,11 @@ package fi.oph.yki.repository;
 import fi.oph.yki.model.Quarantine;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface QuarantineRepository extends JpaRepository<Quarantine, Long> {
@@ -48,4 +51,51 @@ ORDER BY q.id DESC, r.id
     nativeQuery = true
   )
   List<QuarantineMatchProjection> findPendingMatches();
+
+  @Transactional
+  @Query(
+    value = """
+INSERT INTO quarantine_review (
+  quarantine_id,
+  registration_id,
+  quarantined,
+  reviewer_oid
+) VALUES (
+  :quarantineId,
+  :registrationId,
+  :quarantined,
+  :reviewerOid
+)
+ON CONFLICT ON CONSTRAINT quarantine_review_unique_quarantine_registration_combination
+DO UPDATE SET quarantined = :quarantined, reviewer_oid = :reviewerOid, updated = current_timestamp
+RETURNING ID
+""",
+    nativeQuery = true
+  )
+  long upsertReview(
+    @Param("quarantineId") Long quarantineId,
+    @Param("registrationId") Long registrationId,
+    @Param("quarantined") Boolean quarantined,
+    @Param("reviewerOid") String reviewerOid
+  );
+
+  @Modifying
+  @Transactional
+  @Query(
+    value = """
+UPDATE registration r SET
+    state =
+        CASE WHEN state = 'COMPLETED'::registration_state THEN 'PAID_AND_CANCELLED'::registration_state
+             ELSE 'CANCELLED'::registration_state
+        END
+WHERE r.id = :registrationId
+  AND r.state NOT IN ('CANCELLED', 'PAID_AND_CANCELLED')
+  AND now() < (
+      SELECT ed.exam_date FROM exam_date ed
+      INNER JOIN exam_session es ON ed.id = es.exam_date_id
+      WHERE es.id = r.exam_session_id)
+""",
+    nativeQuery = true
+  )
+  void cancelForQuarantine(@Param("registrationId") Long registrationId);
 }

--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkQuarantineService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkQuarantineService.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -96,5 +97,23 @@ public class ClerkQuarantineService {
     auditService.logOperation(YkiOperation.GET_QUARANTINE_MATCHES);
 
     return new ClerkQuarantineMatchesResponseDTO(matches);
+  }
+
+  @Transactional
+  public void setQuarantineReview(final long quarantineId, final long registrationId, final boolean isQuarantined) {
+    final String reviewerOid = SecurityContextHolder.getContext().getAuthentication().getName();
+
+    if (isQuarantined) {
+      quarantineRepository.cancelForQuarantine(registrationId);
+    }
+
+    long quarantineReviewId = quarantineRepository.upsertReview(
+      quarantineId,
+      registrationId,
+      isQuarantined,
+      reviewerOid
+    );
+
+    auditService.logClerkById(YkiOperation.SET_QUARANTINE_REVIEW, String.valueOf(quarantineReviewId));
   }
 }

--- a/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/en-GB/public.json
@@ -387,7 +387,12 @@
             "IN_PROGRESS": "Ladataan tietoja",
             "NOT_STARTED": "Tietojen lataaminen epäonnistui"
           },
+          "actions": {
+            "accept": "Hyväksy ilmoittautuminen",
+            "cancel": "Peru ilmoittautuminen"
+          },
           "columns": {
+            "actions": "Toiminnot",
             "birthdate": "Syntymäaika",
             "email": "Sähköposti",
             "examDate": "Tutkinnon pvm",
@@ -407,6 +412,12 @@
           "active": "Voimassa olevat osallistumiskiellot",
           "pending": "Odottavat tarkistukset ({{count}})",
           "previous": "Aiemmat tarkistukset"
+        },
+        "toasts": {
+          "acceptError": "Hyväksyminen epäonnistui",
+          "acceptSuccess": "Hyväksyminen onnistui",
+          "cancelError": "Hylkääminen epäonnistui",
+          "cancelSuccess": "Hylkääminen onnistui"
         }
       },
       "clerkRegister": {

--- a/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/fi-FI/public.json
@@ -387,7 +387,12 @@
             "IN_PROGRESS": "Ladataan tietoja",
             "NOT_STARTED": "Tietojen lataaminen epäonnistui"
           },
+          "actions": {
+            "accept": "Hyväksy ilmoittautuminen",
+            "cancel": "Peru ilmoittautuminen"
+          },
           "columns": {
+            "actions": "Toiminnot",
             "birthdate": "Syntymäaika",
             "email": "Sähköposti",
             "examDate": "Tutkinnon pvm",
@@ -407,6 +412,12 @@
           "active": "Voimassa olevat osallistumiskiellot",
           "pending": "Odottavat tarkistukset ({{count}})",
           "previous": "Aiemmat tarkistukset"
+        },
+        "toasts": {
+          "acceptError": "Hyväksyminen epäonnistui",
+          "acceptSuccess": "Hyväksyminen onnistui",
+          "cancelError": "Hylkääminen epäonnistui",
+          "cancelSuccess": "Hylkääminen onnistui"
         }
       },
       "clerkRegister": {

--- a/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
+++ b/frontend/packages/yki/clerk/public/i18n/sv-SE/public.json
@@ -387,7 +387,12 @@
             "IN_PROGRESS": "Ladataan tietoja",
             "NOT_STARTED": "Tietojen lataaminen epäonnistui"
           },
+          "actions": {
+            "accept": "Hyväksy ilmoittautuminen",
+            "cancel": "Peru ilmoittautuminen"
+          },
           "columns": {
+            "actions": "Toiminnot",
             "birthdate": "Syntymäaika",
             "email": "Sähköposti",
             "examDate": "Tutkinnon pvm",
@@ -407,6 +412,12 @@
           "active": "Voimassa olevat osallistumiskiellot",
           "pending": "Odottavat tarkistukset ({{count}})",
           "previous": "Aiemmat tarkistukset"
+        },
+        "toasts": {
+          "acceptError": "Hyväksyminen epäonnistui",
+          "acceptSuccess": "Hyväksyminen onnistui",
+          "cancelError": "Hylkääminen epäonnistui",
+          "cancelSuccess": "Hylkääminen onnistui"
         }
       },
       "clerkRegister": {

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantine.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantine.tsx
@@ -1,13 +1,16 @@
 import { Box, Divider } from '@mui/material';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { APIResponseStatus } from 'shared/enums';
+import { APIResponseStatus, Severity } from 'shared/enums';
+import { useToast } from 'shared/hooks';
 
 import { ClerkQuarantineListing } from 'components/clerkQuarantine/ClerkQuarantineListing';
 import { usePublicTranslation } from 'configs/i18n';
 import { H2 } from 'ophTheme/Text';
 import {
   loadClerkQuarantineMatches,
+  resetQuarantineReviewStatus,
+  setQuarantineReview,
   setQuarantineSort,
 } from 'redux/reducers/clerkQuarantine';
 import {
@@ -84,15 +87,38 @@ const QuarantineTabs = ({
 
 export const ClerkQuarantine = () => {
   const dispatch = useDispatch();
-  const { status, sort } = useSelector(clerkQuarantineSelector);
+  const { status, sort, reviewStatus, lastReviewAction } = useSelector(
+    clerkQuarantineSelector,
+  );
   const rows = useSelector(selectSortedQuarantineMatches);
   const [activeTab, setActiveTab] = useState<Tab>('pending');
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
+  const { showToast } = useToast();
+  const { t } = usePublicTranslation({
+    keyPrefix: 'yki.component.clerkQuarantine',
+  });
 
   useEffect(() => {
     dispatch(loadClerkQuarantineMatches());
   }, [dispatch]);
+
+  useEffect(() => {
+    if (!lastReviewAction) return;
+    if (reviewStatus === APIResponseStatus.Success) {
+      showToast({
+        severity: Severity.Success,
+        description: t(`toasts.${lastReviewAction}Success`),
+      });
+      dispatch(resetQuarantineReviewStatus());
+    } else if (reviewStatus === APIResponseStatus.Error) {
+      showToast({
+        severity: Severity.Error,
+        description: t(`toasts.${lastReviewAction}Error`),
+      });
+      dispatch(resetQuarantineReviewStatus());
+    }
+  }, [dispatch, showToast, t, reviewStatus, lastReviewAction]);
 
   const renderListing = () => {
     switch (status) {
@@ -107,6 +133,15 @@ export const ClerkQuarantine = () => {
             activeTab={activeTab}
             sort={sort}
             setSort={(s) => dispatch(setQuarantineSort(s))}
+            onSetReview={(quarantineId, registrationId, isQuarantined) =>
+              dispatch(
+                setQuarantineReview({
+                  quarantineId,
+                  registrationId,
+                  isQuarantined,
+                }),
+              )
+            }
           />
         );
       default:

--- a/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
+++ b/frontend/packages/yki/clerk/src/components/clerkQuarantine/ClerkQuarantineListing.tsx
@@ -1,4 +1,6 @@
+import { OphButton } from '@opetushallitus/oph-design-system';
 import { Trans } from 'react-i18next';
+import { Variant } from 'shared/enums';
 
 import { ListTable } from 'components/oph-design/table/list-table';
 import { PageSizeSelector } from 'components/oph-design/table/page-size-selector';
@@ -22,6 +24,11 @@ type ClerkQuarantineListingProps = {
   activeTab: 'pending' | 'previous' | 'active';
   sort: ClerkQuarantineSort;
   setSort: (sort: ClerkQuarantineSort) => void;
+  onSetReview: (
+    quarantineId: number,
+    registrationId: number,
+    isQuarantined: boolean,
+  ) => void;
 };
 
 export const ClerkQuarantineListing = ({
@@ -32,6 +39,7 @@ export const ClerkQuarantineListing = ({
   setPageSize,
   sort,
   setSort,
+  onSetReview,
 }: ClerkQuarantineListingProps) => {
   const { t } = usePublicTranslation({
     keyPrefix: 'yki.component.clerkQuarantine',
@@ -40,7 +48,8 @@ export const ClerkQuarantineListing = ({
   // Cells stack two values (registrant + quarantined person). Some values such
   // as email are long tokens with no spaces, so the browser cannot wrap them
   // naturally and they overflow into adjacent cells without this.
-  const style = { wordBreak: 'break-word' as const };
+  const wideStyle = { wordBreak: 'break-word' as const };
+  const narrowStyle = { whiteSpace: 'nowrap' as const, width: '1%' };
 
   const columns: ListTableColumn<ClerkQuarantineMatchRow>[] = [
     {
@@ -55,18 +64,20 @@ export const ClerkQuarantineListing = ({
     },
     {
       key: 'examLanguageCode',
+      style: narrowStyle,
       title: t('listing.columns.examLanguage'),
       render: ({ examLanguageCode }) => languageToString(examLanguageCode),
     },
     {
       key: 'examDate',
       sortable: true,
+      style: narrowStyle,
       title: t('listing.columns.examDate'),
       render: ({ examDate }) => examDate.format('D.M.YYYY'),
     },
     {
       key: 'name',
-      style,
+      style: wideStyle,
       title: t('listing.columns.name'),
       render: (match) => (
         <div>
@@ -82,7 +93,7 @@ export const ClerkQuarantineListing = ({
     },
     {
       key: 'birthdate',
-      style,
+      style: narrowStyle,
       title: t('listing.columns.birthdate'),
       render: (match) => (
         <div>
@@ -93,7 +104,7 @@ export const ClerkQuarantineListing = ({
     },
     {
       key: 'ssn',
-      style,
+      style: narrowStyle,
       title: t('listing.columns.ssn'),
       render: (match) => (
         <div>
@@ -104,7 +115,7 @@ export const ClerkQuarantineListing = ({
     },
     {
       key: 'email',
-      style: { ...style, width: '20%' }, // Note: the default is, ~12.5% with 8 equal columns
+      style: wideStyle,
       title: t('listing.columns.email'),
       render: (match) => (
         <div>
@@ -115,12 +126,39 @@ export const ClerkQuarantineListing = ({
     },
     {
       key: 'phoneNumber',
-      style,
+      style: narrowStyle,
       title: t('listing.columns.phoneNumber'),
       render: (match) => (
         <div>
           <div>{match.registrantForm.phoneNumber}</div>
           <div>{match.quarantinedPerson.phoneNumber}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'actions',
+      title: t('listing.columns.actions'),
+      style: narrowStyle,
+      render: (match) => (
+        <div className="columns gapped-xxs">
+          <OphButton
+            variant={Variant.Text}
+            sx={{ padding: 0, minWidth: 0 }}
+            onClick={() =>
+              onSetReview(match.quarantineId, match.registrationId, true)
+            }
+          >
+            {t('listing.actions.accept')}
+          </OphButton>
+          <OphButton
+            variant={Variant.Text}
+            sx={{ padding: 0, minWidth: 0 }}
+            onClick={() =>
+              onSetReview(match.quarantineId, match.registrationId, false)
+            }
+          >
+            {t('listing.actions.cancel')}
+          </OphButton>
         </div>
       ),
     },

--- a/frontend/packages/yki/clerk/src/components/oph-design/table/list-table.tsx
+++ b/frontend/packages/yki/clerk/src/components/oph-design/table/list-table.tsx
@@ -42,7 +42,7 @@ const EMPTY_ARRAY = Object.freeze([]) as Array<never>;
 
 const StyledTable = styled(Table)({
   width: '100%',
-  tableLayout: 'fixed',
+  tableLayout: 'auto',
 
   '& .MuiTableCell-root': {
     padding: '8px 8px 8px 16px',

--- a/frontend/packages/yki/clerk/src/enums/api.ts
+++ b/frontend/packages/yki/clerk/src/enums/api.ts
@@ -17,6 +17,7 @@ export enum APIEndpoints {
   ClerkPersonContactUpdate = '/yki/v2/api/clerk/person/:oid/contactDetails',
   ClerkPaymentReportExcel = '/yki/v2/api/clerk/paymentReport/excel',
   ClerkQuarantineMatches = '/yki/v2/api/clerk/quarantine/matches',
+  ClerkQuarantineSetReview = '/yki/v2/api/clerk/quarantine/:id/registration/:regId/set',
   User = '/yki/api/user/identity',
 }
 

--- a/frontend/packages/yki/clerk/src/redux/reducers/clerkQuarantine.ts
+++ b/frontend/packages/yki/clerk/src/redux/reducers/clerkQuarantine.ts
@@ -10,12 +10,16 @@ interface ClerkQuarantineState {
   matches: ClerkQuarantineMatch[];
   sort: ClerkQuarantineSort;
   status: APIResponseStatus;
+  reviewStatus: APIResponseStatus;
+  lastReviewAction: 'accept' | 'cancel' | null;
 }
 
 const initialState: ClerkQuarantineState = {
   matches: [],
   sort: 'examDate:asc',
   status: APIResponseStatus.NotStarted,
+  reviewStatus: APIResponseStatus.NotStarted,
+  lastReviewAction: null,
 };
 
 const clerkQuarantineSlice = createSlice({
@@ -38,6 +42,29 @@ const clerkQuarantineSlice = createSlice({
     setQuarantineSort(state, action: PayloadAction<ClerkQuarantineSort>) {
       state.sort = action.payload;
     },
+    setQuarantineReview(
+      state,
+      action: PayloadAction<{
+        quarantineId: number;
+        registrationId: number;
+        isQuarantined: boolean;
+      }>,
+    ) {
+      state.reviewStatus = APIResponseStatus.InProgress;
+      state.lastReviewAction = action.payload.isQuarantined
+        ? 'accept'
+        : 'cancel';
+    },
+    resolveQuarantineReview(state) {
+      state.reviewStatus = APIResponseStatus.Success;
+    },
+    rejectQuarantineReview(state) {
+      state.reviewStatus = APIResponseStatus.Error;
+    },
+    resetQuarantineReviewStatus(state) {
+      state.reviewStatus = APIResponseStatus.NotStarted;
+      state.lastReviewAction = null;
+    },
   },
 });
 
@@ -45,6 +72,10 @@ export const clerkQuarantineReducer = clerkQuarantineSlice.reducer;
 export const {
   loadClerkQuarantineMatches,
   rejectClerkQuarantineMatches,
+  rejectQuarantineReview,
+  resetQuarantineReviewStatus,
+  resolveQuarantineReview,
+  setQuarantineReview,
   setQuarantineSort,
   storeClerkQuarantineMatches,
 } = clerkQuarantineSlice.actions;

--- a/frontend/packages/yki/clerk/src/redux/sagas/clerkQuarantine.ts
+++ b/frontend/packages/yki/clerk/src/redux/sagas/clerkQuarantine.ts
@@ -1,3 +1,4 @@
+import { PayloadAction } from '@reduxjs/toolkit';
 import { AxiosResponse } from 'axios';
 import { call, put, takeLatest } from 'redux-saga/effects';
 
@@ -7,6 +8,9 @@ import { ClerkQuarantineMatchesResponse } from 'interfaces/clerkQuarantine';
 import {
   loadClerkQuarantineMatches,
   rejectClerkQuarantineMatches,
+  rejectQuarantineReview,
+  resolveQuarantineReview,
+  setQuarantineReview,
   storeClerkQuarantineMatches,
 } from 'redux/reducers/clerkQuarantine';
 import { SerializationUtils } from 'utils/serialization';
@@ -26,9 +30,35 @@ function* loadClerkQuarantineMatchesSaga() {
   }
 }
 
+function* setQuarantineReviewSaga(
+  action: PayloadAction<{
+    quarantineId: number;
+    registrationId: number;
+    isQuarantined: boolean;
+  }>,
+) {
+  const { quarantineId, registrationId, isQuarantined } = action.payload;
+
+  try {
+    yield call(
+      axiosInstance.put,
+      APIEndpoints.ClerkQuarantineSetReview.replace(
+        ':id',
+        String(quarantineId),
+      ).replace(':regId', String(registrationId)),
+      isQuarantined,
+    );
+    yield put(resolveQuarantineReview());
+    yield put(loadClerkQuarantineMatches());
+  } catch (error) {
+    yield put(rejectQuarantineReview());
+  }
+}
+
 export function* watchClerkQuarantine() {
   yield takeLatest(
     loadClerkQuarantineMatches.type,
     loadClerkQuarantineMatchesSaga,
   );
+  yield takeLatest(setQuarantineReview.type, setQuarantineReviewSaga);
 }

--- a/frontend/packages/yki/clerk/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/clerk/src/tests/msw/handlers.ts
@@ -360,6 +360,16 @@ export const handlers = [
   http.get(APIEndpoints.ClerkQuarantineMatches, () =>
     HttpResponse.json({ quarantineMatches }),
   ),
+  http.put(APIEndpoints.ClerkQuarantineSetReview, ({ params }) => {
+    const id = Number(params.id);
+    const regId = Number(params.regId);
+    const idx = quarantineMatches.findIndex(
+      (m) => m.id === id && m.registrationId === regId,
+    );
+    if (idx !== -1) quarantineMatches.splice(idx, 1);
+
+    return new HttpResponse(null, { status: 200 });
+  }),
   http.post(APIEndpoints.AddClerkOrganizer, async ({ request }) => {
     const requestBody = (await request.json()) as Omit<
       ClerkOrganizerResponse,


### PR DESCRIPTION
## Yhteenveto

<img width="1766" height="756" alt="image" src="https://github.com/user-attachments/assets/30266163-9d00-4bc2-85d4-ca66bc9fe405" />

## Lisätiedot

* Lisätty näppäimet loppuun: hyväksy/hylkää
* Taulukko sisältää aika paljon informaatiota, joten laitoin kieli ja pvm - kentät mahd suppeiksi, jotta muillekin on tilaa
* Bäkkärin toteutus on melko uskollinen alkuperäiselle toteutukselle, mutta 
  * alkuperäinen ottaa vastaan JSON `{ isQuarantined: true/false }`. Nyt supistin sen vaan booleaniksi, ettei tuolle tarvitse tehdä uutta tyyppiä
  * alkuperäisessä toteutuksessa upsert-kysely ei tarvitse `RETURNING ID`, koska clojure osaa keksiä sen itse. java ei osaa, joten se pitää itse palauttaa kyselyssä.

### Osallistumiskiellon hyväksyminen
PUT `/{id}/registration/{regId}/set` --data "true" => ajaa cancel-registration - skriptin ja sen jäkeen upsert-quarantine-review (quarantined=true)

### Osallistumiskiellon hylkääminen
PUT `/{id}/registration/{regId}/set` --data "false" => ajaa pelkän upsert-quarantine-review (quarantined=false)



## Alkuperäinen toteutus

1. handler: https://github.com/Opetushallitus/yki/blob/dev/src/yki/handler/quarantine.clj#L98
2. boundary: https://github.com/Opetushallitus/yki/blob/dev/src/yki/boundary/quarantine_db.clj#L76
3. sql-kyselyt: https://github.com/Opetushallitus/yki/blob/dev/resources/yki/queries.sql#L225

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
