### PR TITLE
YKI(Backend): avoid sending empty oid list to onr service

### DIFF
--- a/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
+++ b/backend/yki/src/main/java/fi/oph/yki/service/ClerkCustomerService.java
@@ -167,6 +167,9 @@ public class ClerkCustomerService {
   }
 
   private Map<String, String> getOidToHetuMap(List<String> oids) {
+    if (oids.isEmpty()) {
+      return Map.of();
+    }
     try {
       return onrService
         .listPersonDetails(oids)


### PR DESCRIPTION
## Yhteenveto

Huomattu pallerolla sattumalta, että asiakashaku-sivulla tehty satunnainen haku kaatoi koko kontin OutOfMemory -virheeseen. Mahdollinen juurisyy saattoi olla, että ONR rajapinnasta kysyttiin henkilöiden tietoja tutkintotilaisuuksista, joissa ei ole yhtään osallistujaa. Tällöin ONR rajapintaan lähetettiin tyhjälista OID:ta, jolloin ONR tulkitsee kutsun niin, että se palauttaa KAIKKIEN henkilöiden tiedot. Tämän vastauksen koko on useita gigatavuja ja kun backend yrittää parsia vastauksen, loppuu muisti kesken ja sovellus kaatuu.

## Lisätiedot

Ei lähetetä tyhjiä OID listoja ONR:ään.

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
