### PR TITLE
OPHKIOS-369: osakoetiedon korjaukset ilmoflowhin

### DIFF
--- a/frontend/packages/yki/public/src/components/registration/PublicRegistrationExamSessionDetails.tsx
+++ b/frontend/packages/yki/public/src/components/registration/PublicRegistrationExamSessionDetails.tsx
@@ -10,17 +10,21 @@ import {
 import { useAppSelector } from 'configs/redux';
 import { PublicRegistrationFormStep } from 'enums/publicRegistration';
 import { ExamSession } from 'interfaces/examSessions';
+import { PartialExamType } from 'interfaces/publicRegistration';
 import { publicFreeRegistrationSelector } from 'redux/selectors/publicFreeRegistration';
 import { registrationSelector } from 'redux/selectors/registration';
 import { sessionSelector } from 'redux/selectors/session';
 import { ExamSessionUtils } from 'utils/examSession';
 
+// PartialExamTypeProp is only used when ConfirmRegistrationPage renders ExamSessionDetails
 export const PublicRegistrationExamSessionDetails = ({
   examSession,
   showOpenings,
+  partialExamType: partialExamTypeProp,
 }: {
   examSession?: ExamSession;
   showOpenings: boolean;
+  partialExamType?: PartialExamType;
 }) => {
   const { t } = usePublicTranslation({
     keyPrefix: 'yki.component.registration.examSessionDetails',
@@ -146,7 +150,7 @@ export const PublicRegistrationExamSessionDetails = ({
             <b>
               {ExamSessionUtils.getPartialExamTypeText(
                 examSession.type,
-                initRegistration.partialExamType,
+                partialExamTypeProp ?? initRegistration.partialExamType,
               )}
             </b>
           </Text>

--- a/frontend/packages/yki/public/src/components/registration/PublicRegistrationExamSessionDetails.tsx
+++ b/frontend/packages/yki/public/src/components/registration/PublicRegistrationExamSessionDetails.tsx
@@ -140,15 +140,17 @@ export const PublicRegistrationExamSessionDetails = ({
         <H2 style={{ marginBottom: '1rem' }}>
           <b>{header}</b>
         </H2>
-        <Text>
-          {`${translateCommon('partialExams')}: `}
-          <b>
-            {ExamSessionUtils.getPartialExamTypeText(
-              examSession.type,
-              initRegistration.partialExamType,
-            )}
-          </b>
-        </Text>
+        {activeStep !== PublicRegistrationFormStep.Done && (
+          <Text>
+            {`${translateCommon('partialExams')}: `}
+            <b>
+              {ExamSessionUtils.getPartialExamTypeText(
+                examSession.type,
+                initRegistration.partialExamType,
+              )}
+            </b>
+          </Text>
+        )}
         <Text>
           {`${translateCommon('examDate')}: `}
           <b>{DateUtils.formatOptionalDate(examSession.session_date)}</b>
@@ -179,10 +181,12 @@ export const PublicRegistrationExamSessionDetails = ({
             start,
           )} - ${DateUtils.formatOptionalDate(end)}`}</b>
         </Text>
-        <Text>
-          {`${t('examFee')}: `}
-          <b>{examFeeText}</b>
-        </Text>
+        {activeStep !== PublicRegistrationFormStep.Done && (
+          <Text>
+            {`${t('examFee')}: `}
+            <b>{examFeeText}</b>
+          </Text>
+        )}
         {showOpenings && (
           <Text>
             {`${t('openings')}: `}

--- a/frontend/packages/yki/public/src/components/registration/PublicRegistrationExamSessionDetails.tsx
+++ b/frontend/packages/yki/public/src/components/registration/PublicRegistrationExamSessionDetails.tsx
@@ -163,20 +163,20 @@ export const PublicRegistrationExamSessionDetails = ({
           {`${translateCommon('examDate')}: `}
           <b>{DateUtils.formatOptionalDate(examSession.session_date)}</b>
         </Text>
-
-        <Text>
-          {`${translateCommon('partialExamTimeLabel')}: `}
-          <b>
-            {translateCommon('partialExamTime', {
-              startTime:
-                ExamSessionUtils.getStartTime(
-                  examSession,
-                  initRegistration.partialExamType,
-                ) || '',
-            })}
-          </b>
-        </Text>
-
+        {examSession.type !== 'FULL' && (
+          <Text>
+            {`${translateCommon('partialExamTimeLabel')}: `}
+            <b>
+              {translateCommon('partialExamTime', {
+                startTime:
+                  ExamSessionUtils.getStartTime(
+                    examSession,
+                    initRegistration.partialExamType,
+                  ) || '',
+              })}
+            </b>
+          </Text>
+        )}
         <Text>
           {`${translateCommon('institution')}: `}
           <b>{`${location.name}, ${

--- a/frontend/packages/yki/public/src/components/registration/PublicRegistrationExamSessionDetails.tsx
+++ b/frontend/packages/yki/public/src/components/registration/PublicRegistrationExamSessionDetails.tsx
@@ -138,13 +138,17 @@ export const PublicRegistrationExamSessionDetails = ({
 
   const attemptsLeft = 3 - (attemptsUsed || 0);
 
+  const isPartialExamRegistrationEndStep =
+    activeStep === PublicRegistrationFormStep.Done &&
+    examSession.type !== 'FULL';
+
   return (
     <div className="rows">
       <div className="rows-gapped-xxs">
         <H2 style={{ marginBottom: '1rem' }}>
           <b>{header}</b>
         </H2>
-        {activeStep !== PublicRegistrationFormStep.Done && (
+        {!isPartialExamRegistrationEndStep && (
           <Text>
             {`${translateCommon('partialExams')}: `}
             <b>
@@ -185,7 +189,7 @@ export const PublicRegistrationExamSessionDetails = ({
             start,
           )} - ${DateUtils.formatOptionalDate(end)}`}</b>
         </Text>
-        {activeStep !== PublicRegistrationFormStep.Done && (
+        {!isPartialExamRegistrationEndStep && (
           <Text>
             {`${t('examFee')}: `}
             <b>{examFeeText}</b>

--- a/frontend/packages/yki/public/src/enums/app.ts
+++ b/frontend/packages/yki/public/src/enums/app.ts
@@ -7,7 +7,7 @@ export enum AppRoutes {
   AccessibilityStatementPage = '/yki/saavutettavuus',
   Registration = '/yki/ilmoittautuminen',
   RegistrationPaymentStatus = '/yki/ilmoittautuminen/maksu/tila',
-  FreeRegistrationSuccess = '/yki/ilmoittautuminen/maksuton/:examSessionId/valmis',
+  FreeRegistrationSuccess = '/yki/ilmoittautuminen/maksuton/:examSessionId/:registrationId/valmis',
   ExamSessionRegistration = '/yki/ilmoittautuminen/tutkintotilaisuus/:examSessionId/:registrationId',
   ExamSessionQueue = '/yki/ilmoittautuminen/tutkintotilaisuus/:examSessionId/:registrationId/jono',
   Reassessment = '/yki/tarkistusarviointi',

--- a/frontend/packages/yki/public/src/interfaces/publicRegistration.ts
+++ b/frontend/packages/yki/public/src/interfaces/publicRegistration.ts
@@ -153,3 +153,10 @@ export interface UserOpenRegistration {
 export interface UserOpenRegistrationsResponse {
   open_registrations: Array<UserOpenRegistration>;
 }
+
+export interface RegistrationDetailsResponse {
+  id: number;
+  kind: RegistrationKind;
+  partial_exam_type: PartialExamType;
+  exam_session_id: number;
+}

--- a/frontend/packages/yki/public/src/pages/ConfirmRegistrationPage.tsx
+++ b/frontend/packages/yki/public/src/pages/ConfirmRegistrationPage.tsx
@@ -16,9 +16,8 @@ import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { APIEndpoints } from 'enums/api';
 import { ExamSession } from 'interfaces/examSessions';
 import { loadRegistrationToConfirmDetails } from 'redux/reducers/confirmRegistration';
-import { fetchRegistrationDetails } from 'redux/reducers/registration';
 import { confirmRegistrationSelector } from 'redux/selectors/confirmRegistration';
-import { registrationSelector } from 'redux/selectors/registration';
+import { userDetailsSelector } from 'redux/selectors/userDetails';
 import { SerializationUtils } from 'utils/serialization';
 
 const Header = () => {
@@ -36,10 +35,14 @@ const Header = () => {
 
 const Contents = () => {
   const { registrationDetails } = useAppSelector(confirmRegistrationSelector);
+  const { personDetails } = useAppSelector(userDetailsSelector);
   if (!registrationDetails) {
     return null;
   }
   const lang = getCurrentLang();
+  const partialExamType = personDetails?.registrations.find(
+    (r) => r.id === registrationDetails.id,
+  )?.partialExamType;
 
   return (
     <Grid>
@@ -50,6 +53,7 @@ const Contents = () => {
         <PublicRegistrationExamSessionDetails
           examSession={registrationDetails as unknown as ExamSession}
           showOpenings={false}
+          partialExamType={partialExamType}
         />
         <ConfirmRegistration
           paymentDetails={{
@@ -68,23 +72,9 @@ const Contents = () => {
 export const ConfirmRegistrationPage = () => {
   const dispatch = useAppDispatch();
   const { loadDetailsStatus } = useAppSelector(confirmRegistrationSelector);
-  const { fetchRegistrationStatus } = useAppSelector(registrationSelector);
 
   // React Router
   const params = useParams();
-
-  const registrationId = params.registrationId
-    ? Number(params.registrationId)
-    : undefined;
-
-  useEffect(() => {
-    if (
-      fetchRegistrationStatus === APIResponseStatus.NotStarted &&
-      registrationId
-    ) {
-      dispatch(fetchRegistrationDetails(registrationId));
-    }
-  }, [dispatch, registrationId, fetchRegistrationStatus]);
 
   useEffect(() => {
     if (
@@ -95,9 +85,7 @@ export const ConfirmRegistrationPage = () => {
     }
   }, [dispatch, params.registrationId, loadDetailsStatus]);
 
-  const loading =
-    loadDetailsStatus === APIResponseStatus.InProgress ||
-    fetchRegistrationStatus === APIResponseStatus.InProgress;
+  const loading = loadDetailsStatus === APIResponseStatus.InProgress;
 
   return (
     <Box className="confirm-registration-page">

--- a/frontend/packages/yki/public/src/pages/ConfirmRegistrationPage.tsx
+++ b/frontend/packages/yki/public/src/pages/ConfirmRegistrationPage.tsx
@@ -16,7 +16,9 @@ import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { APIEndpoints } from 'enums/api';
 import { ExamSession } from 'interfaces/examSessions';
 import { loadRegistrationToConfirmDetails } from 'redux/reducers/confirmRegistration';
+import { fetchRegistrationDetails } from 'redux/reducers/registration';
 import { confirmRegistrationSelector } from 'redux/selectors/confirmRegistration';
+import { registrationSelector } from 'redux/selectors/registration';
 import { SerializationUtils } from 'utils/serialization';
 
 const Header = () => {
@@ -66,9 +68,23 @@ const Contents = () => {
 export const ConfirmRegistrationPage = () => {
   const dispatch = useAppDispatch();
   const { loadDetailsStatus } = useAppSelector(confirmRegistrationSelector);
+  const { fetchRegistrationStatus } = useAppSelector(registrationSelector);
 
   // React Router
   const params = useParams();
+
+  const registrationId = params.registrationId
+    ? Number(params.registrationId)
+    : undefined;
+
+  useEffect(() => {
+    if (
+      fetchRegistrationStatus === APIResponseStatus.NotStarted &&
+      registrationId
+    ) {
+      dispatch(fetchRegistrationDetails(registrationId));
+    }
+  }, [dispatch, registrationId, fetchRegistrationStatus]);
 
   useEffect(() => {
     if (
@@ -79,7 +95,9 @@ export const ConfirmRegistrationPage = () => {
     }
   }, [dispatch, params.registrationId, loadDetailsStatus]);
 
-  const loading = loadDetailsStatus === APIResponseStatus.InProgress;
+  const loading =
+    loadDetailsStatus === APIResponseStatus.InProgress ||
+    fetchRegistrationStatus === APIResponseStatus.InProgress;
 
   return (
     <Box className="confirm-registration-page">

--- a/frontend/packages/yki/public/src/pages/ExamDetailsPage.tsx
+++ b/frontend/packages/yki/public/src/pages/ExamDetailsPage.tsx
@@ -13,6 +13,7 @@ import { PublicRegistrationFormStep } from 'enums/publicRegistration';
 import { loadExamSession } from 'redux/reducers/examSession';
 import {
   acceptPublicRegistrationSubmission,
+  fetchRegistrationDetails,
   identifyRegistration,
   setActiveStep,
 } from 'redux/reducers/registration';
@@ -34,14 +35,26 @@ export const ExamDetailsPage = ({
   // Redux
   const dispatch = useAppDispatch();
   const { status, examSession } = useAppSelector(examSessionSelector);
-  const { initRegistration } = useAppSelector(registrationSelector);
+  const { initRegistration, fetchRegistrationStatus } =
+    useAppSelector(registrationSelector);
   // React Router
   const params = useParams();
   const [searchParams] = useSearchParams();
 
   const isLoading =
     status === APIResponseStatus.InProgress ||
+    fetchRegistrationStatus === APIResponseStatus.InProgress ||
     initRegistration.status === APIResponseStatus.InProgress;
+
+  const registrationId = params.registrationId
+    ? Number(params.registrationId)
+    : undefined;
+
+  useEffect(() => {
+    if (registrationId && !initRegistration.partialExamType) {
+      dispatch(fetchRegistrationDetails(registrationId));
+    }
+  }, [dispatch, registrationId, initRegistration.partialExamType]);
 
   useEffect(() => {
     dispatch(setActiveStep(PublicRegistrationFormStep.Register));

--- a/frontend/packages/yki/public/src/pages/FreeRegistrationSuccessPage.tsx
+++ b/frontend/packages/yki/public/src/pages/FreeRegistrationSuccessPage.tsx
@@ -11,7 +11,10 @@ import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { PublicRegistrationFormStep } from 'enums/publicRegistration';
 import { loadExamSession } from 'redux/reducers/examSession';
 import { setPublicFreeRegistration } from 'redux/reducers/publicFreeRegistration';
-import { setActiveStep } from 'redux/reducers/registration';
+import {
+  fetchRegistrationDetails,
+  setActiveStep,
+} from 'redux/reducers/registration';
 import { examSessionSelector } from 'redux/selectors/examSession';
 
 export const FreeRegistrationSuccessPage = () => {
@@ -29,12 +32,18 @@ export const FreeRegistrationSuccessPage = () => {
   const examSessionId = params.examSessionId
     ? Number(params.examSessionId)
     : undefined;
+  const registrationId = params.registrationId
+    ? Number(params.registrationId)
+    : undefined;
 
   const isLoading = status === APIResponseStatus.InProgress;
 
   useEffect(() => {
     dispatch(setActiveStep(PublicRegistrationFormStep.Done));
     dispatch(setPublicFreeRegistration({ isFree: 'YES' }));
+    if (registrationId) {
+      dispatch(fetchRegistrationDetails(registrationId));
+    }
   }, [dispatch]);
 
   useEffect(() => {

--- a/frontend/packages/yki/public/src/pages/FreeRegistrationSuccessPage.tsx
+++ b/frontend/packages/yki/public/src/pages/FreeRegistrationSuccessPage.tsx
@@ -44,7 +44,7 @@ export const FreeRegistrationSuccessPage = () => {
     if (registrationId) {
       dispatch(fetchRegistrationDetails(registrationId));
     }
-  }, [dispatch]);
+  }, [dispatch, registrationId]);
 
   useEffect(() => {
     if (status === APIResponseStatus.NotStarted && examSessionId) {

--- a/frontend/packages/yki/public/src/redux/reducers/registration.ts
+++ b/frontend/packages/yki/public/src/redux/reducers/registration.ts
@@ -48,6 +48,7 @@ export interface RegistrationState {
   activeStep: PublicRegistrationFormStep;
   showErrors: boolean;
   hasTimerExpired: boolean;
+  fetchRegistrationStatus: APIResponseStatus;
 }
 
 export const initialState: RegistrationState = {
@@ -67,6 +68,7 @@ export const initialState: RegistrationState = {
   },
   showErrors: false,
   hasTimerExpired: false,
+  fetchRegistrationStatus: APIResponseStatus.NotStarted,
 };
 
 const registrationSlice = createSlice({
@@ -245,11 +247,17 @@ const registrationSlice = createSlice({
       state.initRegistration.registrationKind = action.payload.registrationKind;
       state.initRegistration.registrationId = action.payload.registrationId;
     },
-    fetchRegistrationDetails(_state, _action: PayloadAction<number>) {},
+    fetchRegistrationDetails(state, _action: PayloadAction<number>) {
+      state.fetchRegistrationStatus = APIResponseStatus.InProgress;
+    },
+    rejectRegistrationDetails(state) {
+      state.fetchRegistrationStatus = APIResponseStatus.Error;
+    },
     acceptFetchRegistrationDetails(
       state,
       action: PayloadAction<RegistrationDetailsResponse>,
     ) {
+      state.fetchRegistrationStatus = APIResponseStatus.Success;
       state.initRegistration.partialExamType = action.payload.partial_exam_type;
       state.initRegistration.registrationKind = action.payload.kind;
       state.initRegistration.examSessionId = action.payload.exam_session_id;
@@ -275,6 +283,7 @@ export const {
   rejectCancelRegistration,
   identifyRegistration,
   fetchRegistrationDetails,
+  rejectRegistrationDetails,
   acceptFetchRegistrationDetails,
   setHasTimerExpired,
 } = registrationSlice.actions;

--- a/frontend/packages/yki/public/src/redux/reducers/registration.ts
+++ b/frontend/packages/yki/public/src/redux/reducers/registration.ts
@@ -19,6 +19,7 @@ import {
   PublicRegistrationInitPayload,
   PublicRegistrationInitResponse,
   PublicSuomiFiRegistration,
+  RegistrationDetailsResponse,
 } from 'interfaces/publicRegistration';
 
 export interface RegistrationState {
@@ -244,6 +245,15 @@ const registrationSlice = createSlice({
       state.initRegistration.registrationKind = action.payload.registrationKind;
       state.initRegistration.registrationId = action.payload.registrationId;
     },
+    fetchRegistrationDetails(_state, _action: PayloadAction<number>) {},
+    acceptFetchRegistrationDetails(
+      state,
+      action: PayloadAction<RegistrationDetailsResponse>,
+    ) {
+      state.initRegistration.partialExamType = action.payload.partial_exam_type;
+      state.initRegistration.registrationKind = action.payload.kind;
+      state.initRegistration.examSessionId = action.payload.exam_session_id;
+    },
   },
 });
 
@@ -264,5 +274,7 @@ export const {
   acceptCancelRegistration,
   rejectCancelRegistration,
   identifyRegistration,
+  fetchRegistrationDetails,
+  acceptFetchRegistrationDetails,
   setHasTimerExpired,
 } = registrationSlice.actions;

--- a/frontend/packages/yki/public/src/redux/sagas/registration.ts
+++ b/frontend/packages/yki/public/src/redux/sagas/registration.ts
@@ -31,6 +31,7 @@ import {
   rejectCancelRegistration,
   rejectPublicRegistrationInit,
   rejectPublicRegistrationSubmission,
+  rejectRegistrationDetails,
   resetPublicRegistration,
   setActiveStep,
   submitPublicRegistration,
@@ -218,7 +219,7 @@ function* fetchRegistrationDetailsSaga(action: PayloadAction<number>) {
     );
     yield put(acceptFetchRegistrationDetails(response.data));
   } catch {
-    // Silently fail - partialExamType will be set when identify saga completes
+    yield put(rejectRegistrationDetails());
   }
 }
 

--- a/frontend/packages/yki/public/src/redux/sagas/registration.ts
+++ b/frontend/packages/yki/public/src/redux/sagas/registration.ts
@@ -162,7 +162,7 @@ function* submitRegistrationFormSaga() {
         window.location.href = AppRoutes.FreeRegistrationSuccess.replace(
           /:examSessionId/,
           `${registrationState.initRegistration.examSessionId}`,
-        );
+        ).replace(/:registrationId/, `${registrationState.registration.id}`);
       }
       yield put(resetUserOpenRegistrations());
     } else {

--- a/frontend/packages/yki/public/src/redux/sagas/registration.ts
+++ b/frontend/packages/yki/public/src/redux/sagas/registration.ts
@@ -15,13 +15,16 @@ import {
   PublicRegistrationInitErrorResponse,
   PublicRegistrationInitPayload,
   PublicRegistrationInitResponse,
+  RegistrationDetailsResponse,
 } from 'interfaces/publicRegistration';
 import { resetExamSession, storeExamSession } from 'redux/reducers/examSession';
 import {
   acceptCancelRegistration,
+  acceptFetchRegistrationDetails,
   acceptPublicRegistrationInit,
   acceptPublicRegistrationSubmission,
   cancelRegistration,
+  fetchRegistrationDetails,
   identifyRegistration,
   initRegistration,
   RegistrationState,
@@ -207,6 +210,18 @@ function* submitRegistrationFormSaga() {
   }
 }
 
+function* fetchRegistrationDetailsSaga(action: PayloadAction<number>) {
+  try {
+    const response: AxiosResponse<RegistrationDetailsResponse> = yield call(
+      axiosInstance.get,
+      APIEndpoints.Registration.replace(/:registrationId/, `${action.payload}`),
+    );
+    yield put(acceptFetchRegistrationDetails(response.data));
+  } catch {
+    // Silently fail - partialExamType will be set when identify saga completes
+  }
+}
+
 function* cancelRegistrationSaga() {
   try {
     const { registration }: RegistrationState =
@@ -233,6 +248,7 @@ function* cancelRegistrationSaga() {
 export function* watchRegistration() {
   yield takeLatest(initRegistration.type, initRegistrationSaga);
   yield takeLatest(identifyRegistration.type, identifyRegistrationSaga);
+  yield takeLatest(fetchRegistrationDetails.type, fetchRegistrationDetailsSaga);
   yield takeLatest(submitPublicRegistration.type, submitRegistrationFormSaga);
   yield takeLatest(cancelRegistration.type, cancelRegistrationSaga);
 }

--- a/frontend/packages/yki/public/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/public/src/tests/msw/handlers.ts
@@ -203,4 +203,21 @@ export const handlers = [
   http.post(APIEndpoints.PublicFreeRegistrationEducation, () => {
     return HttpResponse.json({ id: 1337 }, { status: 201 });
   }),
+  http.get(APIEndpoints.LoginLinkInfo, () => {
+    return HttpResponse.json({
+      expires_at: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+    });
+  }),
+  http.get(APIEndpoints.Registration, ({ params }) => {
+    const { registrationId } = params;
+    const id = Number(registrationId);
+    const queued = id % 2 === 1;
+
+    return HttpResponse.json({
+      id,
+      kind: queued ? RegistrationKind.Queue : RegistrationKind.Admission,
+      partial_exam_type: 'ALL_PARTS',
+      exam_session_id: id,
+    });
+  }),
 ];

--- a/frontend/packages/yki/public/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/public/src/tests/msw/handlers.ts
@@ -220,4 +220,17 @@ export const handlers = [
       exam_session_id: id,
     });
   }),
+  http.get(APIEndpoints.ConfirmRegistration, ({ params }) => {
+    const { registrationId } = params;
+
+    const registration = data.personDetails.registrations.find(
+      (r) => `${r.id}` === registrationId,
+    );
+
+    if (registration) {
+      return HttpResponse.json(registration);
+    } else {
+      return notFound();
+    }
+  }),
 ];

--- a/frontend/packages/yki/public/src/utils/examSession.ts
+++ b/frontend/packages/yki/public/src/utils/examSession.ts
@@ -1,4 +1,4 @@
-import { AppLanguage } from 'shared/enums';
+import { AppLanguage, I18nNamespace } from 'shared/enums';
 import { StringUtils } from 'shared/utils';
 
 import { translateOutsideComponent } from 'configs/i18n';
@@ -226,31 +226,49 @@ export class ExamSessionUtils {
 
     const t = translateOutsideComponent();
 
+    const ns = I18nNamespace.Public;
+
     if (examSessionType === 'FULL') {
-      return t('yki.component.examSessionCard.examType.full');
+      return t('yki.component.registration.examSessionCard.examType.full', {
+        ns,
+      });
     }
 
     if (examSessionType === 'LISTEN_WRITE') {
       if (partialExamType === 'ALL_PARTS') {
-        return t('yki.component.examSessionCard.examType.listenWrite');
+        return t(
+          'yki.component.registration.examSessionCard.examType.listenWrite',
+          { ns },
+        );
       }
       if (partialExamType === 'LISTEN') {
-        return t('yki.component.examSessionCard.examType.listen');
+        return t('yki.component.registration.examSessionCard.examType.listen', {
+          ns,
+        });
       }
       if (partialExamType === 'WRITE') {
-        return t('yki.component.examSessionCard.examType.write');
+        return t('yki.component.registration.examSessionCard.examType.write', {
+          ns,
+        });
       }
     }
 
     if (examSessionType === 'READ_SPEAK') {
       if (partialExamType === 'ALL_PARTS') {
-        return t('yki.component.examSessionCard.examType.readSpeak');
+        return t(
+          'yki.component.registration.examSessionCard.examType.readSpeak',
+          { ns },
+        );
       }
       if (partialExamType === 'READ') {
-        return t('yki.component.examSessionCard.examType.read');
+        return t('yki.component.registration.examSessionCard.examType.read', {
+          ns,
+        });
       }
       if (partialExamType === 'SPEAK') {
-        return t('yki.component.examSessionCard.examType.speak');
+        return t('yki.component.registration.examSessionCard.examType.speak', {
+          ns,
+        });
       }
     }
   }

--- a/frontend/webpack.yki.js
+++ b/frontend/webpack.yki.js
@@ -62,6 +62,7 @@ module.exports = (appName, env, dirName, port, entryPage = "etusivu", isClerk = 
       ...getESLintPlugin(env),
       ...getStylelintPlugin(env),
       ...getHtmlWebpackPlugin(env, CONTEXT_PATH, dirName, isClerk),
+      new CSPNoncePlaceholderInjectorPlugin({ isCypress: !!env.cypress }),
       new CSPNoncePlaceholderInjectorPlugin(),
       new Dotenv()
     ],
@@ -273,6 +274,10 @@ const addThymeleafNoncePlaceholder = (e) => {
 };
 
 class CSPNoncePlaceholderInjectorPlugin {
+  constructor({ isCypress = false } = {}) {
+    this.isCypress = isCypress;
+  }
+
   apply(compiler) {
     compiler.hooks.compilation.tap(
       "CSPNoncePlaceholderInjectorPlugin",
@@ -306,6 +311,19 @@ class CSPNoncePlaceholderInjectorPlugin {
                 "window.__CLERK_ENABLED__ = /*[[${clerkEnabled}]]*/ false;"
               )
             );
+            if (!this.isCypress) {
+              data.headTags.push(
+                HtmlWebpackPlugin.createHtmlTagObject(
+                  "script",
+                  {
+                    "th:if": "${clerkEnabled}",
+                    "th:attr": "nonce=${cspNonce}",
+                    src: "/virkailija-raamit/apply-raamit.js",
+                    defer: true,
+                  }
+                )
+              );
+            }
             cb(null, data);
           }
         );

--- a/frontend/webpack.yki.js
+++ b/frontend/webpack.yki.js
@@ -63,7 +63,6 @@ module.exports = (appName, env, dirName, port, entryPage = "etusivu", isClerk = 
       ...getStylelintPlugin(env),
       ...getHtmlWebpackPlugin(env, CONTEXT_PATH, dirName, isClerk),
       new CSPNoncePlaceholderInjectorPlugin({ isCypress: !!env.cypress }),
-      new CSPNoncePlaceholderInjectorPlugin(),
       new Dotenv()
     ],
   });


### PR DESCRIPTION
## Yhteenveto

Lisätty rekisteröinnin osakoetieto ilmoittautumisen vahvistus näkymiin (ilmoittautuminen ja omat ilmoittautumiset)

Poistettu rekisteröinnistä riippuvaiset osakoetiedot Maksun vahvistus näkymästä toistaiseksi (osakoetieto ja osakokeen hinta)


