### PR TITLE
OPHKIOS-357: YKI(Frontend): Align extra text on second row if the text is too large.

### DIFF
--- a/frontend/packages/yki/public/src/components/layouts/Footer.tsx
+++ b/frontend/packages/yki/public/src/components/layouts/Footer.tsx
@@ -56,7 +56,13 @@ export const Footer = () => {
                 {translateCommon('contactEmail.jyu')}
               </Text>
             </a>
-            <div className="columns gapped-xxs">
+            <div
+              className="columns gapped-xxs"
+              style={{
+                flexWrap: 'wrap',
+                alignItems: 'flex-start',
+              }}
+            >
               <a
                 href={`tel:${translateCommon('contactPhone.jyu')}`}
                 target="_blank"

--- a/frontend/packages/yki/public/src/components/layouts/NewYkiFooter.tsx
+++ b/frontend/packages/yki/public/src/components/layouts/NewYkiFooter.tsx
@@ -56,7 +56,13 @@ export const NewYkiFooter = () => {
                 {translateCommon('contactEmail.jyu')}
               </Text>
             </a>
-            <div className="columns gapped-xxs">
+            <div
+              className="columns gapped-xxs"
+              style={{
+                flexWrap: 'wrap',
+                alignItems: 'flex-start',
+              }}
+            >
               <a
                 href={`tel:${translateCommon('contactPhone.jyu')}`}
                 target="_blank"


### PR DESCRIPTION
## Yhteenveto

Laittaa tekstin uudelle riville jos se menee liian pitkäksi
<img width="482" height="506" alt="image" src="https://github.com/user-attachments/assets/792352ad-12e5-476d-96d5-54cbb8083892" />

Note: 480px kohdalla vasta rivittyy selosteet eri riville
<img width="414" height="539" alt="image" src="https://github.com/user-attachments/assets/6ff2018e-a931-4d9f-8e40-5b7d14f83aaa" />



Vertailun vuoksi nykyinen versio (untuvalta), siellä selosteet menee (mulla) 514px kohdalla jo eri riveille.
<img width="482" height="639" alt="image" src="https://github.com/user-attachments/assets/de2194ec-8d0f-435f-8ca8-0e5ad1579937" />


## Lisätiedot

_Tehdyt muutokset..._

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
