### PR TITLE
OPHKIOS-357 YKI(Frontend): Align footer with same rule than the main's child div

### DIFF
--- a/frontend/packages/yki/public/src/styles/base/_base.scss
+++ b/frontend/packages/yki/public/src/styles/base/_base.scss
@@ -60,6 +60,10 @@ body,
 
   .footer {
     grid-area: footer;
+
+    > div {
+      padding: 3rem;
+    }
   }
 
   .title-page {


### PR DESCRIPTION
## Yhteenveto

Kapea näyttö
<img width="438" height="804" alt="image" src="https://github.com/user-attachments/assets/83e80a38-5216-4554-a8ed-93233ef116b4" />

leveä näyttö
<img width="1093" height="804" alt="image" src="https://github.com/user-attachments/assets/cfa8b4e1-ae4d-4744-9ab4-44ebb8cd99a6" />

vielä leveämpi näyttö
<img width="1286" height="640" alt="image" src="https://github.com/user-attachments/assets/41e55fe4-332e-4279-9f29-85eea9f3706b" />


## Lisätiedot

_Tehdyt muutokset..._

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
