### PR TITLE
YKI(Frontend): OPHKIOS-357 align new yki footer

### DIFF
--- a/frontend/packages/yki/public/src/styles/base/_base.scss
+++ b/frontend/packages/yki/public/src/styles/base/_base.scss
@@ -60,10 +60,6 @@ body,
 
   .footer {
     grid-area: footer;
-
-    > div {
-      padding: 3rem;
-    }
   }
 
   .title-page {

--- a/frontend/packages/yki/public/src/styles/components/layouts/_new-yki-footer.scss
+++ b/frontend/packages/yki/public/src/styles/components/layouts/_new-yki-footer.scss
@@ -6,7 +6,9 @@
   &__info-row {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(25rem, auto));
-    justify-content: space-evenly;
+    justify-content: center;
+    margin: 0 auto;
+    padding: 3rem;
     padding-top: 4rem;
 
     @include phone {


### PR DESCRIPTION
## Yhteenveto

Kapea:
<img width="498" height="706" alt="image" src="https://github.com/user-attachments/assets/5aeab1fe-d862-46c6-9801-67b81bb494e4" />

semi kapea
<img width="735" height="706" alt="image" src="https://github.com/user-attachments/assets/230ddf0f-9e73-437f-b065-24ce7fab0c68" />

just sen verran leveä että kaikki mahtuu samalle riville
<img width="971" height="706" alt="image" src="https://github.com/user-attachments/assets/56aecf08-89d4-464e-a672-7cc68616c347" />

leveä
<img width="1675" height="706" alt="image" src="https://github.com/user-attachments/assets/63e12efb-722c-4bdc-985e-150eab6551ac" />



## Lisätiedot

_Tehdyt muutokset..._

## Huomautukset

_Muut mahdolliset huomautukset..._

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
