### PR TITLE
YKI(Frontend): Run and fix some MSW tests on public-facing YKI frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@
 **/.sts4-cache
 
 **/.idea/
+**/.obsidian/
 **/node_modules/
 dist
 **/.DS_Store

--- a/frontend/packages/yki/public/package.json
+++ b/frontend/packages/yki/public/package.json
@@ -23,7 +23,7 @@
     "yki:start:dev-server": "yarn g:webpack serve --config webpack.config.js --env proxy=http://localhost:8083",
     "yki:start:docker-compose": "yarn g:webpack serve --config webpack.config.js --env proxy=http://yki-backend:8080 --env docker",
     "yki:stylelint": "yarn g:stylelint --fix \"./src/**/*.scss\"",
-    "yki:test:cypress": "TZ=Europe/Helsinki yarn g:cypress run --spec=\"./src/tests/cypress/integration/public/*.ts\"",
+    "yki:test:cypress": "TZ=Europe/Helsinki yarn g:cypress run",
     "yki:test:cypress:open": "TZ=Europe/Helsinki yarn g:cypress open",
     "yki:test:jest": "yarn g:jest",
     "yki:tslint": "yarn g:tsc --pretty --noEmit"

--- a/frontend/packages/yki/public/src/tests/cypress/integration/public/exam_details_page.spec.ts
+++ b/frontend/packages/yki/public/src/tests/cypress/integration/public/exam_details_page.spec.ts
@@ -5,24 +5,16 @@ import { RegistrationKind } from 'enums/app';
 import { onExamDetailsPage } from 'tests/cypress/support/page-objects/examDetailsPage';
 import { worker } from 'tests/msw/browser';
 import { examSessions } from 'tests/msw/fixtures/examSession';
+import { teuvoRegistrationDetails } from 'tests/msw/fixtures/registrationDetails';
 
 const examSessionResponse = examSessions.exam_sessions.find(
   (es) => es.id === 888,
 );
 
-const expectedSuomiFiRegistrationDetails = {
-  first_name: 'Teuvo',
-  last_name: 'Testitapaus',
-  ssn: '030594W903B',
-  post_office: 'Helsinki',
-  zip: '00100',
-  street_address: 'Unioninkatu 1',
-};
-
 const getInitRegistrationResponse = (is_strongly_identified: boolean) => {
   if (is_strongly_identified) {
     const { first_name, last_name, ssn, post_office, zip, street_address } =
-      expectedSuomiFiRegistrationDetails;
+      teuvoRegistrationDetails;
 
     return {
       is_strongly_identified,
@@ -99,10 +91,19 @@ describe('ExamDetailsPage', () => {
       );
       onExamDetailsPage.isVisible();
 
-      const { first_name, last_name, street_address, zip, post_office, ssn } =
-        expectedSuomiFiRegistrationDetails;
+      const {
+        first_name,
+        preferred_name,
+        last_name,
+        street_address,
+        zip,
+        post_office,
+        ssn,
+        native_language,
+      } = teuvoRegistrationDetails;
 
       onExamDetailsPage.fillFieldByLabel('Etunimet *', first_name);
+      onExamDetailsPage.fillFieldByLabel('Kutsumanimi *', preferred_name);
       onExamDetailsPage.fillFieldByLabel('Sukunimi *', last_name);
 
       onExamDetailsPage.fillFieldByLabel('Katuosoite *', street_address);
@@ -111,6 +112,7 @@ describe('ExamDetailsPage', () => {
 
       onExamDetailsPage.selectGender('Mies');
       onExamDetailsPage.selectNationality('Serbia');
+      onExamDetailsPage.selectNativeLanguage(native_language);
 
       onExamDetailsPage.fillFieldByLabel('Puhelinnumero *', '+358501234567');
 

--- a/frontend/packages/yki/public/src/tests/cypress/integration/public/exam_details_page.spec.ts
+++ b/frontend/packages/yki/public/src/tests/cypress/integration/public/exam_details_page.spec.ts
@@ -1,6 +1,9 @@
+import { http, HttpResponse } from 'msw';
+
 import { APIEndpoints } from 'enums/api';
 import { RegistrationKind } from 'enums/app';
 import { onExamDetailsPage } from 'tests/cypress/support/page-objects/examDetailsPage';
+import { worker } from 'tests/msw/browser';
 import { examSessions } from 'tests/msw/fixtures/examSession';
 
 const examSessionResponse = examSessions.exam_sessions.find(
@@ -48,36 +51,22 @@ const getInitRegistrationResponse = (is_strongly_identified: boolean) => {
   }
 };
 
-const handleRedirect = () => {
-  // When browser attempts to logout, send browser instead directly to
-  // successful submission page.
-  // Note that mocking the response with msw doesn't currently work,
-  // as the request to logout is sent to an absolute URL (including hostname).
-  cy.intercept(
-    { url: /^.*\/yki\/auth\/logout\?redirect=/, method: 'GET' },
-    (req) => {
-      const { redirect } = req.query;
-      req.continue((res) => {
-        res.send(301, {}, { location: redirect as string });
-      });
-    },
-  );
-};
-
-describe.skip('ExamDetailsPage', () => {
+describe('ExamDetailsPage', () => {
   describe('allows filling registration form', () => {
+    if (!examSessionResponse) {
+      throw 'examSessionResponse does not have a value';
+    }
+
     it('with credentials from Suomi.fi authentication', () => {
+      worker.use(
+        http.post(APIEndpoints.IdentifyRegistration, () =>
+          HttpResponse.json(getInitRegistrationResponse(true)),
+        ),
+      );
       cy.openExamSessionRegistrationForm(
         examSessionResponse.id,
         getInitRegistrationResponse(true).registration_id,
-      ),
-        cy
-          .intercept('POST', APIEndpoints.InitRegistration, {
-            statusCode: 200,
-            body: getInitRegistrationResponse(true),
-          })
-          .as('initRegistration');
-      cy.wait('@initRegistration');
+      );
       onExamDetailsPage.isVisible();
       onExamDetailsPage.fillFieldByLabel(
         'Sähköpostiosoite *',
@@ -94,22 +83,20 @@ describe.skip('ExamDetailsPage', () => {
       onExamDetailsPage.acceptTermsOfRegistration();
       onExamDetailsPage.acceptPrivacyPolicy();
 
-      handleRedirect();
-
       onExamDetailsPage.submitForm();
       onExamDetailsPage.isFormSubmitted();
     });
 
     it('by authenticating via a login link', () => {
+      worker.use(
+        http.post(APIEndpoints.IdentifyRegistration, () =>
+          HttpResponse.json(getInitRegistrationResponse(false)),
+        ),
+      );
       cy.openExamSessionRegistrationForm(
         examSessionResponse.id,
         getInitRegistrationResponse(true).registration_id,
       );
-      cy.intercept('POST', APIEndpoints.InitRegistration, {
-        statusCode: 200,
-        body: getInitRegistrationResponse(false),
-      }).as('initRegistration');
-      cy.wait('@initRegistration');
       onExamDetailsPage.isVisible();
 
       const { first_name, last_name, street_address, zip, post_office, ssn } =
@@ -134,22 +121,20 @@ describe.skip('ExamDetailsPage', () => {
       onExamDetailsPage.acceptTermsOfRegistration();
       onExamDetailsPage.acceptPrivacyPolicy();
 
-      handleRedirect();
-
       onExamDetailsPage.submitForm();
       onExamDetailsPage.isFormSubmitted();
     });
 
     it('text fields filled by user are trimmed of whitespace before sending to backend', () => {
+      worker.use(
+        http.post(APIEndpoints.IdentifyRegistration, () =>
+          HttpResponse.json(getInitRegistrationResponse(true)),
+        ),
+      );
       cy.openExamSessionRegistrationForm(
         examSessionResponse.id,
         getInitRegistrationResponse(true).registration_id,
       );
-      cy.intercept('POST', APIEndpoints.InitRegistration, {
-        statusCode: 200,
-        body: getInitRegistrationResponse(true),
-      }).as('initRegistration');
-      cy.wait('@initRegistration');
       onExamDetailsPage.isVisible();
       const email = 'teuvotesti@test.invalid';
       onExamDetailsPage.fillFieldByLabel('Sähköpostiosoite *', '   ' + email);
@@ -171,8 +156,6 @@ describe.skip('ExamDetailsPage', () => {
 
       onExamDetailsPage.acceptTermsOfRegistration();
       onExamDetailsPage.acceptPrivacyPolicy();
-
-      handleRedirect();
 
       onExamDetailsPage.submitForm();
       onExamDetailsPage.isFormSubmitted();

--- a/frontend/packages/yki/public/src/tests/cypress/integration/public/exam_details_page.spec.ts
+++ b/frontend/packages/yki/public/src/tests/cypress/integration/public/exam_details_page.spec.ts
@@ -7,7 +7,7 @@ import { worker } from 'tests/msw/browser';
 import { examSessions } from 'tests/msw/fixtures/examSession';
 
 const examSessionResponse = examSessions.exam_sessions.find(
-  (es) => es.id === 999,
+  (es) => es.id === 888,
 );
 
 const expectedSuomiFiRegistrationDetails = {

--- a/frontend/packages/yki/public/src/tests/cypress/support/index.ts
+++ b/frontend/packages/yki/public/src/tests/cypress/support/index.ts
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import 'tests/cypress/support/commands';
 import { useFixedDate } from 'tests/cypress/support/utils/date';
 import { worker } from 'tests/msw/browser';
+import { resetData } from 'tests/msw/handlers';
 
 // MSW configs
 Cypress.on('test:before:run:async', async () => {
@@ -22,4 +23,5 @@ beforeEach(() => {
 
 afterEach(() => {
   worker.resetHandlers();
+  resetData();
 });

--- a/frontend/packages/yki/public/src/tests/cypress/support/page-objects/examDetailsPage.ts
+++ b/frontend/packages/yki/public/src/tests/cypress/support/page-objects/examDetailsPage.ts
@@ -20,6 +20,8 @@ class ExamDetailsPage {
     genderSelect: () => cy.findByRole('combobox', { name: 'Sukupuoli *' }),
     nationalitySelect: () =>
       cy.findByRole('combobox', { name: 'Kansalaisuus *' }),
+    nativeLanguageSelect: () =>
+      cy.findByRole('combobox', { name: 'Äidinkieli *' }),
   };
 
   isVisible() {
@@ -54,6 +56,12 @@ class ExamDetailsPage {
 
   selectNationality(name: string) {
     this.elements.nationalitySelect().click();
+    cy.findByRole('option', { name }).scrollIntoView();
+    cy.findByRole('option', { name }).should('be.visible').click();
+  }
+
+  selectNativeLanguage(name: string) {
+    this.elements.nativeLanguageSelect().click();
     cy.findByRole('option', { name }).scrollIntoView();
     cy.findByRole('option', { name }).should('be.visible').click();
   }

--- a/frontend/packages/yki/public/src/tests/cypress/support/page-objects/examDetailsPage.ts
+++ b/frontend/packages/yki/public/src/tests/cypress/support/page-objects/examDetailsPage.ts
@@ -39,7 +39,9 @@ class ExamDetailsPage {
   }
 
   selectCertificateLanguage(language: string) {
-    cy.findByRole('group', { name: 'Millä kielellä haluat todistuksesi? *' })
+    cy.findByRole('group', {
+      name: 'Jos todistus postitetaan, millä kielellä haluat todistuksesi? *',
+    })
       .findByRole('radio', { name: language })
       .click();
   }

--- a/frontend/packages/yki/public/src/tests/msw/fixtures/registrationDetails.ts
+++ b/frontend/packages/yki/public/src/tests/msw/fixtures/registrationDetails.ts
@@ -1,0 +1,13 @@
+export const teuvoRegistrationDetails = {
+  first_name: 'Teuvo',
+  last_name: 'Testitapaus',
+  ssn: '030594W903B',
+  post_office: 'Helsinki',
+  zip: '00100',
+  street_address: 'Unioninkatu 1',
+  // Suomi.fi supplies neither of the following, so weakly authenticated users
+  // must fill them in themselves. Both are mandatory only on the weak path.
+  preferred_name: 'Teuvo',
+  // Koodisto display name (kieli_fi), not the 'FI' code: the form selects by label.
+  native_language: 'suomi',
+};

--- a/frontend/packages/yki/public/src/tests/msw/handlers.ts
+++ b/frontend/packages/yki/public/src/tests/msw/handlers.ts
@@ -16,9 +16,11 @@ import { personDetails } from 'tests/msw/fixtures/personDetails';
 import { registrationInitResponse } from 'tests/msw/fixtures/registrationInit/registrationInit';
 
 const data = {
-  evaluationPeriods,
-  examSessions,
   personDetails,
+};
+
+export const resetData = () => {
+  data.personDetails = personDetails;
 };
 
 const notFound = () => new HttpResponse(null, { status: 404 });

--- a/scripts/run-cypress-public.sh
+++ b/scripts/run-cypress-public.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cd "$KIOS/frontend/packages/yki/public" || {
+    echo "could not find frontend/packages/yki/public" >&2
+    exit 1
+}
+
+set -x
+yarn yki:test:cypress:open


### PR DESCRIPTION
## Yhteenveto

Aiemmin CI:ssa on ajettu testejä `-spec=\"./src/tests/cypress/integration/public/*.ts\""`  - vivulla. Tämä on skipannut `public_user_details_page` - testin. Se on saattanut olla tarkoituksenmukainen, kun paikallisesti toi testi meni mulla läpi, mutta CI:n vivuilla se ei mennyt läpi. 

Varsinainen vika, miksi se ei mennyt CI:llä läpi, johtuu siitä, että cypress UI osaa resetoida `handlers.ts`:n tilan itse testien välissä. CI:llä data.personDetails ei resetoidu testien välissä, joten se pitää resetoida itse. 

## Lisätiedot

* Oon tässä lisännyt skriptin, joka käynnistää cypressin public - testeille. Lokaalisti flow on 
```sh
# Ajaa YKI ilmoittautumis-frontin
$KIOS/scripts/run-frontend-public.sh

# Käynnistää cypressin ja lataa ilmo frontin testit cypressin UI:ssa
$KIOS/scripts/run-cypress-public.sh
```

* Oon simuloinut CI:tä:
```sh
# Ajaa frontin CI:n vivuilla
cd $KIOS/frontend
yarn yki:start:ci

# Ajaa cypress testit kuten CI
cd $KIOS/frontend/packages/yki/public
yarn yki:test:cypress
```

## Huomautukset

public-puolella on vielä testejä, joita skipataan, koska niihin on laitettu `.skip`. Voisin selvittää niitä vielä erikseen, että miksi ne skipataan, ja olisiko iso työ saada niitä korjattua.

Skipatut testit:
```
 EvaluationOrderPage
    - allows submitting a reassessment order


  ExamDetailsPage
    allows filling registration form
      - with credentials from Suomi.fi authentication
      - by authenticating via a login link
      - text fields filled by user are trimmed of whitespace before sending to backend
```

## Check-lista

- [ ] yarn.lock päivitetty
- [ ] Käännösten Excel-tiedosto päivitetty
- [ ] UI-muutoksia testattu eri selaimilla ja mobiilinäkymässä
